### PR TITLE
Quick wins: excalidraw conventions (#16) + multi-people awareness (#8) + feature freshness (#13)

### DIFF
--- a/.codex/agents/prompts/sleep-state.md
+++ b/.codex/agents/prompts/sleep-state.md
@@ -88,6 +88,7 @@ dreamcontext core changelog add \
   --summary "<≤200 char one-liner: what shipped, scannable in snapshot>" \
   --description "<one paragraph: what changed and why; mention key file/symbol where helpful>" \
   --references "commit:<sha>,file:<path>,knowledge:<slug>,feature:<slug>,task:<slug>,url:<href>" \
+  [--authors "<person-a,person-b>"] \
   [--supersedes "<date>|<scope>"] \
   $([ "$BREAKING" = "true" ] && echo "--breaking")
 ```
@@ -99,6 +100,8 @@ dreamcontext core changelog add \
 **References field**: optional, flat string array with prefix convention. Use freely — they help future recall queries follow the trail. Common shapes: `commit:abc1234`, `file:src/lib/recall.ts`, `knowledge:decision-mem0-vs-bm25-recall`, `feature:memory-recall-bm25`, `task:rice-prioritization`, `url:https://...`. **No `note:` prefix** — free-form goes in `description`. Auto-populate commit refs from `git log --oneline --since=<sleep-epoch>` when you can identify the commit(s) the change shipped in.
 
 **Supersedes field**: optional, only when a later entry reverses or replaces an earlier one (e.g., a "default-on" flip of a previously "opt-in" flag, or a v0.4 file path being deprecated). Use coarse keys like `"2026-05-23|memory"` (date + scope) — disambiguators only matter when multiple entries share the same date+scope, in which case fall back to the position-from-top index. Most entries do NOT supersede anything; leave the field absent.
+
+**Authors field (multi-person projects only)**: optional, attributes the change to the person(s) who drove it. Set it ONLY when the project is multi-person (`.config.json` `people` roster has >1 entry — see Pass B.5). Pass comma-separated kebab-case slugs matching the roster (`--authors "mehmet,ada"`). Determine attribution from the same signals Pass B.5 uses (git `%an` on the commits the entry clusters, self-identification in the session transcript). When a single change was driven by distinct people across clusters, attribute each `dreamcontext core changelog add` invocation to its own author(s). Single-person projects: OMIT `--authors` entirely — output stays byte-identical to today. Authors are excluded from the changelog dedup fingerprint, so adding them never re-opens an already-released entry.
 
 #### A3. Releases — surface readiness, never auto-release
 
@@ -179,6 +182,39 @@ dreamcontext trigger add "<when>" "<remind>"   # context-dependent reminders
 
 Cross-domain catches from your own changelog pass land here naturally — if you wrote a `feat` entry whose description revealed a preference enforced twice, write it into `1.user.md` in the same cycle (no flagging needed; you own both files).
 
+### Pass B.5 — People detection (multi-person awareness)
+
+dreamcontext defaults to single-person. When you have **corroborated evidence** that more than one human works in this project, record the roster so changelogs/tasks/memory can attribute work per person. This is **AI-driven detection** — there is no manual toggle and no persisted `multiPerson` flag (multi-person status is DERIVED from `people.length > 1`).
+
+**Detection gate — require ≥2 corroborated signals** before flipping a project to multi-person (this gate prevents false positives; one weak signal is never enough):
+
+- **Self-identification in user turns** — a person names themselves or another teammate ("this is Ada", "Mehmet asked me to…", "I'm covering for Lina").
+- **Distinct git authors since the epoch** — `git log --since="$CUTOFF" --format='%an <%ae>' | sort -u` returns more than one real human author (ignore bots/CI like `github-actions`, `dependabot`).
+- **Distinct voice / handoff** — the transcript shows a clear authorship handoff or a different working style/voice than the established user.
+
+```bash
+# Signal 2: distinct human git authors since the sleep epoch
+git log --since="$CUTOFF" --format='%an' | sort -u
+# Read the existing roster FIRST — you append, you never overwrite.
+jq -r '.people // [] | join(", ")' _dream_context/state/.config.json 2>/dev/null
+```
+
+When the gate is met:
+
+1. **Additive union to the roster — never overwrite.** Read the current `people` array first, then write the union (existing ∪ newly observed) back. Use kebab-case display-name slugs (`mehmet`, `ada`). A previously recorded person is NEVER dropped because they were quiet this cycle.
+
+   ```bash
+   dreamcontext config  # confirm current roster, then edit state/.config.json people[] = union
+   ```
+
+   (There is no CLI writer for `people` yet — edit `_dream_context/state/.config.json` directly with Edit, preserving every existing key. Do NOT add a `multiPerson` key; it is derived.)
+
+2. **Refresh `## People` in `1.user.md`** to enumerate the full roster. Use the `ensurePeopleSection(userMd, people)` helper semantics (idempotent insert/replace of a `## People` block; one bullet per person). This is a no-op for single-person projects.
+
+3. **Attribute this cycle's changelog entries** — re-run Pass A's `dreamcontext core changelog add` with `--authors "<slugs>"` for each entry, attributing it to the person(s) who drove that cluster (Pass A and this pass share the git-author analysis).
+
+**Single-person projects (gate NOT met): this entire pass is a NO-OP.** Do not create a roster, do not add a `## People` section, do not pass `--authors`. A solo project's `.config.json`, `1.user.md`, and changelog output must stay byte-identical to today. The cost of a false positive (spuriously attributing a solo user's work to a phantom teammate) is high — stay conservative.
+
 ### Pass C — Anti-bloat sweep + knowledge staleness flags
 
 #### C1. Anti-bloat sweep — ~150 line ceiling per core file
@@ -225,6 +261,10 @@ You do **not** edit knowledge files. Produce flags for `sleep-product` to act on
 - 1.user.md: untouched (no recurring preference observed)
 - 4.tech_stack.md: untouched
 - Triggers added: 0
+
+### People (multi-person detection)
+- Roster: single-person (no multi-person signals this cycle) — no changes
+  | OR: detected 2 humans (signals: 2 distinct git authors + self-id in transcript) → roster updated mehmet, ada (additive union; ada appended, mehmet preserved); `## People` refreshed in 1.user.md; 3 changelog entries attributed via --authors
 
 ### Anti-bloat & staleness
 - 2.memory.md at 287 lines — under ceiling, no extraction needed

--- a/.codex/agents/prompts/sleep-tasks.md
+++ b/.codex/agents/prompts/sleep-tasks.md
@@ -98,6 +98,22 @@ dreamcontext tasks create "<descriptive-slug>" --status in_progress --priority m
 
 Untracked, genuinely-separate work is invisible to future sessions — always link it. But a smaller slice of existing work belongs *inside* that task, never in a duplicate.
 
+### 2.5. Person attribution (multi-person projects only)
+
+When the project's `.config.json` `people` array has **>1 entry**, the person responsible for a task's progress this cycle must be recorded as a `person:<slug>` tag in the task's frontmatter `tags` array. Slug is kebab-case matching the roster (e.g., `person:mehmet`, `person:ada`). Determine attribution from the same signals sleep-state uses for Pass B.5 (git `%an` on the commits, self-identification in the session transcript).
+
+```bash
+# Read the current roster
+jq -r '.people // [] | join(", ")' _dream_context/state/.config.json 2>/dev/null
+```
+
+- **New task**: pass `--person <name>` to `dreamcontext tasks create` (the CLI injects a `person:<slug>` tag automatically).
+- **Existing task**: add the tag directly via Edit on the task frontmatter `tags:` array, or via `dreamcontext tasks insert`.
+
+When the person is already tagged on the task, no action is needed — the tag is additive. Do not remove a previously-set `person:` tag for a person who was quiet this cycle; they remain attributed for prior work.
+
+**Single-person projects (`.config.json` `people` has 0 or 1 entry): this step is a NO-OP.** Never inject a `person:` tag on a solo project. The output must stay byte-identical to today.
+
 ### 3. Log progress AND reconcile the body — both required
 
 **(a) Append a changelog entry** — what happened this session:
@@ -154,6 +170,7 @@ If every task linked to the active version is `completed` (or only `in_review` r
 - Folded in (no new task): <existing-slug> — broadened scope + added 2 user stories / 1 criterion for <smaller-piece> instead of forking a duplicate
 - Created: <slug> (status: in_progress, attached to vX.Y.Z) — genuinely separate concern
 - Body reconciled: <slug> (dropped phase 1 from User Stories; replaced Technical Details auth section)
+- Person attribution: <slug> tagged person:ada (multi-person project, ada drove this cycle's work) | OR: single-person project — no person tags injected
 - Version readiness: vX.Y.Z — 4/5 tasks ready for review
 - Cross-domain mentions: <slug> includes a memory-worthy decision about JWT — flagging for sleep-state
 - Skipped: <session_id> had no actionable task signal
@@ -167,3 +184,4 @@ If every task linked to the active version is `completed` (or only `in_review` r
 4. **Always attach to a planning version.** No orphan work.
 5. **Stay in your lane.** If you spot non-task work worth preserving, flag it — don't write it.
 6. **CLI first** for status/log/insert; **Edit** for surgical body reconciliation (including broadening `description:` / `## Why` when scope grows).
+7. **Person attribution is multi-person only.** Read `.config.json` `people` first. If 0 or 1 entry, step 2.5 is a complete NO-OP — never inject `person:` tags on solo projects. Derived multi-person status comes from `people.length > 1`; there is no `multiPerson` key to check.

--- a/agents/sleep-state.md
+++ b/agents/sleep-state.md
@@ -88,6 +88,7 @@ dreamcontext core changelog add \
   --summary "<≤200 char one-liner: what shipped, scannable in snapshot>" \
   --description "<one paragraph: what changed and why; mention key file/symbol where helpful>" \
   --references "commit:<sha>,file:<path>,knowledge:<slug>,feature:<slug>,task:<slug>,url:<href>" \
+  [--authors "<person-a,person-b>"] \
   [--supersedes "<date>|<scope>"] \
   $([ "$BREAKING" = "true" ] && echo "--breaking")
 ```
@@ -99,6 +100,8 @@ dreamcontext core changelog add \
 **References field**: optional, flat string array with prefix convention. Use freely — they help future recall queries follow the trail. Common shapes: `commit:abc1234`, `file:src/lib/recall.ts`, `knowledge:decision-mem0-vs-bm25-recall`, `feature:memory-recall-bm25`, `task:rice-prioritization`, `url:https://...`. **No `note:` prefix** — free-form goes in `description`. Auto-populate commit refs from `git log --oneline --since=<sleep-epoch>` when you can identify the commit(s) the change shipped in.
 
 **Supersedes field**: optional, only when a later entry reverses or replaces an earlier one (e.g., a "default-on" flip of a previously "opt-in" flag, or a v0.4 file path being deprecated). Use coarse keys like `"2026-05-23|memory"` (date + scope) — disambiguators only matter when multiple entries share the same date+scope, in which case fall back to the position-from-top index. Most entries do NOT supersede anything; leave the field absent.
+
+**Authors field (multi-person projects only)**: optional, attributes the change to the person(s) who drove it. Set it ONLY when the project is multi-person (`.config.json` `people` roster has >1 entry — see Pass B.5). Pass comma-separated kebab-case slugs matching the roster (`--authors "mehmet,ada"`). Determine attribution from the same signals Pass B.5 uses (git `%an` on the commits the entry clusters, self-identification in the session transcript). When a single change was driven by distinct people across clusters, attribute each `dreamcontext core changelog add` invocation to its own author(s). Single-person projects: OMIT `--authors` entirely — output stays byte-identical to today. Authors are excluded from the changelog dedup fingerprint, so adding them never re-opens an already-released entry.
 
 #### A3. Releases — surface readiness, never auto-release
 
@@ -179,6 +182,39 @@ dreamcontext trigger add "<when>" "<remind>"   # context-dependent reminders
 
 Cross-domain catches from your own changelog pass land here naturally — if you wrote a `feat` entry whose description revealed a preference enforced twice, write it into `1.user.md` in the same cycle (no flagging needed; you own both files).
 
+### Pass B.5 — People detection (multi-person awareness)
+
+dreamcontext defaults to single-person. When you have **corroborated evidence** that more than one human works in this project, record the roster so changelogs/tasks/memory can attribute work per person. This is **AI-driven detection** — there is no manual toggle and no persisted `multiPerson` flag (multi-person status is DERIVED from `people.length > 1`).
+
+**Detection gate — require ≥2 corroborated signals** before flipping a project to multi-person (this gate prevents false positives; one weak signal is never enough):
+
+- **Self-identification in user turns** — a person names themselves or another teammate ("this is Ada", "Mehmet asked me to…", "I'm covering for Lina").
+- **Distinct git authors since the epoch** — `git log --since="$CUTOFF" --format='%an <%ae>' | sort -u` returns more than one real human author (ignore bots/CI like `github-actions`, `dependabot`).
+- **Distinct voice / handoff** — the transcript shows a clear authorship handoff or a different working style/voice than the established user.
+
+```bash
+# Signal 2: distinct human git authors since the sleep epoch
+git log --since="$CUTOFF" --format='%an' | sort -u
+# Read the existing roster FIRST — you append, you never overwrite.
+jq -r '.people // [] | join(", ")' _dream_context/state/.config.json 2>/dev/null
+```
+
+When the gate is met:
+
+1. **Additive union to the roster — never overwrite.** Read the current `people` array first, then write the union (existing ∪ newly observed) back. Use kebab-case display-name slugs (`mehmet`, `ada`). A previously recorded person is NEVER dropped because they were quiet this cycle.
+
+   ```bash
+   dreamcontext config  # confirm current roster, then edit state/.config.json people[] = union
+   ```
+
+   (There is no CLI writer for `people` yet — edit `_dream_context/state/.config.json` directly with Edit, preserving every existing key. Do NOT add a `multiPerson` key; it is derived.)
+
+2. **Refresh `## People` in `1.user.md`** to enumerate the full roster. Use the `ensurePeopleSection(userMd, people)` helper semantics (idempotent insert/replace of a `## People` block; one bullet per person). This is a no-op for single-person projects.
+
+3. **Attribute this cycle's changelog entries** — re-run Pass A's `dreamcontext core changelog add` with `--authors "<slugs>"` for each entry, attributing it to the person(s) who drove that cluster (Pass A and this pass share the git-author analysis).
+
+**Single-person projects (gate NOT met): this entire pass is a NO-OP.** Do not create a roster, do not add a `## People` section, do not pass `--authors`. A solo project's `.config.json`, `1.user.md`, and changelog output must stay byte-identical to today. The cost of a false positive (spuriously attributing a solo user's work to a phantom teammate) is high — stay conservative.
+
 ### Pass C — Anti-bloat sweep + knowledge staleness flags
 
 #### C1. Anti-bloat sweep — ~150 line ceiling per core file
@@ -225,6 +261,10 @@ You do **not** edit knowledge files. Produce flags for `sleep-product` to act on
 - 1.user.md: untouched (no recurring preference observed)
 - 4.tech_stack.md: untouched
 - Triggers added: 0
+
+### People (multi-person detection)
+- Roster: single-person (no multi-person signals this cycle) — no changes
+  | OR: detected 2 humans (signals: 2 distinct git authors + self-id in transcript) → roster updated mehmet, ada (additive union; ada appended, mehmet preserved); `## People` refreshed in 1.user.md; 3 changelog entries attributed via --authors
 
 ### Anti-bloat & staleness
 - 2.memory.md at 287 lines — under ceiling, no extraction needed

--- a/agents/sleep-tasks.md
+++ b/agents/sleep-tasks.md
@@ -98,6 +98,22 @@ dreamcontext tasks create "<descriptive-slug>" --status in_progress --priority m
 
 Untracked, genuinely-separate work is invisible to future sessions — always link it. But a smaller slice of existing work belongs *inside* that task, never in a duplicate.
 
+### 2.5. Person attribution (multi-person projects only)
+
+When the project's `.config.json` `people` array has **>1 entry**, the person responsible for a task's progress this cycle must be recorded as a `person:<slug>` tag in the task's frontmatter `tags` array. Slug is kebab-case matching the roster (e.g., `person:mehmet`, `person:ada`). Determine attribution from the same signals sleep-state uses for Pass B.5 (git `%an` on the commits, self-identification in the session transcript).
+
+```bash
+# Read the current roster
+jq -r '.people // [] | join(", ")' _dream_context/state/.config.json 2>/dev/null
+```
+
+- **New task**: pass `--person <name>` to `dreamcontext tasks create` (the CLI injects a `person:<slug>` tag automatically).
+- **Existing task**: add the tag directly via Edit on the task frontmatter `tags:` array, or via `dreamcontext tasks insert`.
+
+When the person is already tagged on the task, no action is needed — the tag is additive. Do not remove a previously-set `person:` tag for a person who was quiet this cycle; they remain attributed for prior work.
+
+**Single-person projects (`.config.json` `people` has 0 or 1 entry): this step is a NO-OP.** Never inject a `person:` tag on a solo project. The output must stay byte-identical to today.
+
 ### 3. Log progress AND reconcile the body — both required
 
 **(a) Append a changelog entry** — what happened this session:
@@ -154,6 +170,7 @@ If every task linked to the active version is `completed` (or only `in_review` r
 - Folded in (no new task): <existing-slug> — broadened scope + added 2 user stories / 1 criterion for <smaller-piece> instead of forking a duplicate
 - Created: <slug> (status: in_progress, attached to vX.Y.Z) — genuinely separate concern
 - Body reconciled: <slug> (dropped phase 1 from User Stories; replaced Technical Details auth section)
+- Person attribution: <slug> tagged person:ada (multi-person project, ada drove this cycle's work) | OR: single-person project — no person tags injected
 - Version readiness: vX.Y.Z — 4/5 tasks ready for review
 - Cross-domain mentions: <slug> includes a memory-worthy decision about JWT — flagging for sleep-state
 - Skipped: <session_id> had no actionable task signal
@@ -167,3 +184,4 @@ If every task linked to the active version is `completed` (or only `in_review` r
 4. **Always attach to a planning version.** No orphan work.
 5. **Stay in your lane.** If you spot non-task work worth preserving, flag it — don't write it.
 6. **CLI first** for status/log/insert; **Edit** for surgical body reconciliation (including broadening `description:` / `## Why` when scope grows).
+7. **Person attribution is multi-person only.** Read `.config.json` `people` first. If 0 or 1 entry, step 2.5 is a complete NO-OP — never inject `person:` tags on solo projects. Derived multi-person status comes from `people.length > 1`; there is no `multiPerson` key to check.

--- a/dashboard/src/pages/FeaturesPage.css
+++ b/dashboard/src/pages/FeaturesPage.css
@@ -48,6 +48,13 @@
   margin-bottom: var(--space-2);
 }
 
+.feature-card-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
 .feature-card-name {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
@@ -152,6 +159,30 @@
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--color-text-secondary);
+}
+
+/* Freshness badge — mirrors .feature-status visual language */
+.feature-freshness {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.feature-freshness--stale {
+  background: #ffedd5;
+  color: #c2410c;
+  border-color: #fed7aa;
+}
+
+[data-theme='dark'] .feature-freshness--stale {
+  background: rgba(251, 146, 60, 0.16);
+  color: #fdba74;
+  border-color: rgba(251, 146, 60, 0.28);
 }
 
 /* CSS @media cannot use custom properties in this Vite setup, so 1024 is a

--- a/dashboard/src/pages/FeaturesPage.tsx
+++ b/dashboard/src/pages/FeaturesPage.tsx
@@ -6,6 +6,12 @@ import { MarkdownPreview } from '../components/core/MarkdownPreview';
 import { tagHue } from '../lib/tagColor';
 import './FeaturesPage.css';
 
+interface FeatureFreshness {
+  level: 'fresh' | 'stale' | 'unknown';
+  daysSinceUpdate: number | null;
+  note: string;
+}
+
 interface Feature {
   slug: string;
   id: string;
@@ -14,6 +20,7 @@ interface Feature {
   updated: string;
   tags: string[];
   related_tasks: string[];
+  freshness?: FeatureFreshness;
 }
 
 interface FeatureDetail extends Feature {
@@ -59,9 +66,14 @@ export function FeaturesPage() {
             >
               <div className="feature-card-header">
                 <span className="feature-card-name">{feature.slug}</span>
-                <span className={`feature-status feature-status--${feature.status}`}>
-                  {feature.status}
-                </span>
+                <div className="feature-card-badges">
+                  {feature.freshness?.level === 'stale' && (
+                    <span className="feature-freshness feature-freshness--stale">stale</span>
+                  )}
+                  <span className={`feature-status feature-status--${feature.status}`}>
+                    {feature.status}
+                  </span>
+                </div>
               </div>
               <div className="knowledge-card-tags">
                 {feature.tags.map(tag => (

--- a/skill-packs/excalidraw/SKILL.md
+++ b/skill-packs/excalidraw/SKILL.md
@@ -32,14 +32,90 @@ Write a spec JSON, then run it. The script prints `elements/images/texts` counts
 
 ### JS API (for pipelines that generate many boards)
 ```js
-const { buildExcalidraw, lane, grid } = require('.../scripts/build_excalidraw.js');
-buildExcalidraw({ out, elements: [ ...lane({ title, images, x, y, thumbW }) ] });
+const path = require('path');
+// skill lives at <project>/.claude/skills/excalidraw/ — adjust leading ../ count to match your script's depth from project root
+const { buildExcalidraw, lane, grid } = require(path.resolve(__dirname, '../.claude/skills/excalidraw/scripts/build_excalidraw.js'));
+buildExcalidraw({ out: path.resolve(__dirname, '../boards/Board.excalidraw.md'), elements: [ ...lane({ title, images, x, y, thumbW }) ] });
 ```
+
+## File layout
+
+### Single board (default)
+Keep the spec next to the generated board but clearly separated:
+```
+boards/
+├── MyBoard.excalidraw.md      ← generated deliverable; do not hand-edit
+└── _spec/
+    └── MyBoard.json           ← source of truth; edit this, then regenerate
+```
+The `.excalidraw.md` is **disposable** — it is fully derived from the spec. If the two ever
+disagree, the spec wins. Commit both (the board for Obsidian/GitHub preview, the spec for
+reproducibility), but only edit the spec.
+
+### Multi-board pipeline
+When a single generator produces several boards, isolate it in a `pipeline/` folder so the
+deliverable boards stay at the top of the project and are easy to open in Obsidian:
+```
+boards/
+├── Overview.excalidraw.md     ← generated
+├── Funnel.excalidraw.md       ← generated
+├── Pricing.excalidraw.md      ← generated
+└── pipeline/
+    ├── generate.js            ← single regen entrypoint: `node pipeline/generate.js`
+    ├── shared-style.js        ← shared palette / helpers
+    └── spec/
+        ├── Overview.json      ← source spec for Overview board
+        ├── Funnel.json        ← source spec for Funnel board
+        └── Pricing.json       ← source spec for Pricing board
+```
+- **Generated files** (`*.excalidraw.md`) live one level above `pipeline/` — open them in Obsidian without navigating into a sub-folder.
+- **Source specs** live in `pipeline/spec/` — one JSON per board.
+- **Single entrypoint**: `node pipeline/generate.js` rebuilds every board. No per-board manual commands.
+
+### Many boards from shared data (recipe)
+Use this pattern when multiple boards pull from the same data set (e.g. one board per product, per region, or per funnel step):
+
+```js
+// pipeline/generate.js  (lives at boards/pipeline/generate.js)
+const path = require('path');
+const ROOT  = path.resolve(__dirname, '..');          // boards/ directory
+// ../../ = project root (boards/ → project/); adjust if boards/ is nested deeper
+const { buildExcalidraw, lane } = require(path.resolve(__dirname, '../../.claude/skills/excalidraw/scripts/build_excalidraw.js'));
+const style  = require(path.resolve(__dirname, 'shared-style.js'));
+const items  = require(path.resolve(__dirname, 'spec/items.json'));  // shared data
+
+for (const item of items) {
+  const elements = style.buildItemBoard(item);        // per-item spec logic
+  buildExcalidraw({
+    out: path.resolve(ROOT, `${item.slug}.excalidraw.md`),
+    elements,
+  });
+  console.log('wrote', item.slug);
+}
+```
+
+```js
+// pipeline/shared-style.js  (lives at boards/pipeline/shared-style.js)
+const path = require('path');
+// ../../ = project root (boards/ → project/); adjust if boards/ is nested deeper
+const { card, connector, sectionTitle } = require(path.resolve(__dirname, '../../.claude/skills/excalidraw/scripts/lib/style.js'));
+
+exports.buildItemBoard = (item) => [
+  sectionTitle({ x: 0, y: 0, text: item.name, fontSize: 40 }),
+  // … common layout using item fields
+];
+```
+
+Key conventions:
+- `ROOT = path.resolve(__dirname, '..')` pins paths relative to the generator file, not the working directory. The generator works correctly wherever it is invoked from.
+- Each item produces exactly one board; the mapping is `items.json → <slug>.excalidraw.md`.
+- `shared-style.js` owns the layout logic — boards stay visually consistent; change the style once, regenerate all.
+- Add a `package.json` script or `Makefile` alias so the command is always `npm run boards` (or similar) and never has to be rediscovered.
 
 ## Spec schema
 ```jsonc
 {
-  "out": "/abs/path/Board.excalidraw.md",   // required (or pass --out)
+  "out": "./boards/Board.excalidraw.md",    // prefer __dirname-relative in JS generators; relative to cwd for CLI
   "vaultRoot": "/abs/vault",                  // optional; auto-detected by walking up to `.obsidian`
   "attachDir": "Attachments",                 // external images get copied here (relative to board dir)
   "wikilinkMode": "basename",                 // "basename" (default) or "path" (vault-relative)
@@ -47,6 +123,9 @@ buildExcalidraw({ out, elements: [ ...lane({ title, images, x, y, thumbW }) ] })
   "elements": [ /* ElementSpec… */ ]
 }
 ```
+
+**Paths in generators**: always use `path.resolve(__dirname, ...)` for `out` and image `path` fields — never
+hardcode absolute paths. This keeps the generator portable: move the folder and it still runs.
 
 ### Element types
 - `text`     — `{ x, y, text, fontSize?, color?, width?, align?, fontFamily? }` (fontFamily 1=hand, 2=normal, 3=code). **Set `width` for any caption/label that must stay inside a column or card** → the text WRAPS to that width (autoResize off) and its height is computed from the wrapped line count. Omit `width` only for short single-line text you want sized to content (it renders on one line and will overlap neighbours if long).

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -33,6 +33,11 @@ function printConfig(projectRoot: string): void {
   console.log(`  Platforms:      ${chalk.white(cfg.platforms.join(', ') || '(none)')}`);
   console.log(`  Packs:          ${chalk.white(cfg.packs.join(', ') || '(none)')}`);
   console.log(`  Products:       ${chalk.white(products)}`);
+  // Only surface a People line when a roster exists — single-person projects
+  // (absent/empty roster) print nothing, keeping the output unchanged.
+  if (cfg.people && cfg.people.length > 0) {
+    console.log(`  People:         ${chalk.white(cfg.people.join(', '))}`);
+  }
   console.log(
     `  Native memory:  ${cfg.disableNativeMemory
       ? chalk.green('disabled') + chalk.dim(' (dreamcontext owns project memory)')

--- a/src/cli/commands/core.ts
+++ b/src/cli/commands/core.ts
@@ -37,9 +37,10 @@ export function registerCoreCommand(program: Command): void {
     .option('--description <desc>', 'Description (long-form, full body)')
     .option('--summary <summary>', 'Optional ≤200-char one-liner for snapshot display')
     .option('--references <refs>', 'Optional comma-separated references (commit:<sha>, file:<path>, knowledge:<slug>, feature:<slug>, task:<slug>, url:<href>)')
+    .option('--authors <list>', 'Optional comma-separated people involved (e.g. "mehmet,ada")')
     .option('--supersedes <key>', 'Optional pointer to prior entry this supersedes (e.g., "2026-05-09|sleep")')
     .option('--breaking', 'Mark as a breaking change', false)
-    .action(async (opts: { type?: string; scope?: string; description?: string; summary?: string; references?: string; supersedes?: string; breaking?: boolean }) => {
+    .action(async (opts: { type?: string; scope?: string; description?: string; summary?: string; references?: string; authors?: string; supersedes?: string; breaking?: boolean }) => {
       const root = ensureContextRoot();
       const filePath = join(root, 'core', 'CHANGELOG.json');
 
@@ -73,6 +74,9 @@ export function registerCoreCommand(program: Command): void {
           info(`Warning: ${bad.length} reference(s) missing a known prefix (${validPrefixes.join('|')}): ${bad.join(', ')}. Stored anyway.`);
         }
       }
+      const authors = opts.authors
+        ? opts.authors.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined;
       const supersedes = opts.supersedes ?? undefined;
       const breaking = opts.breaking ?? (typeof opts.breaking === 'boolean'
         ? opts.breaking
@@ -94,6 +98,7 @@ export function registerCoreCommand(program: Command): void {
       };
       if (summary) entry.summary = summary;
       if (references && references.length > 0) entry.references = references;
+      if (authors && authors.length > 0) entry.authors = authors;
       if (supersedes) entry.supersedes = supersedes;
 
       insertToJsonArray(filePath, entry);

--- a/src/cli/commands/features.ts
+++ b/src/cli/commands/features.ts
@@ -1,14 +1,16 @@
 import { Command } from 'commander';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
+import chalk from 'chalk';
 import fg from 'fast-glob';
 import { ensureContextRoot } from '../../lib/context-path.js';
-import { updateFrontmatterFields } from '../../lib/frontmatter.js';
+import { readFrontmatter, updateFrontmatterFields } from '../../lib/frontmatter.js';
 import { insertToSection } from '../../lib/markdown.js';
 import { prepareSectionInsert, SECTION_MAP } from '../../lib/section-insert.js';
 import { promptInput } from '../../lib/prompt.js';
 import { generateId, slugify, today } from '../../lib/id.js';
-import { success, error } from '../../lib/format.js';
+import { success, error, header } from '../../lib/format.js';
+import { analyzeFeatures, type FeatureRef, type TaskRef } from '../../lib/feature-freshness.js';
 
 const VALID_FEATURE_STATUSES = ['planning', 'in_progress', 'in_review', 'active', 'shipped', 'deprecated'];
 
@@ -234,5 +236,92 @@ export function registerFeaturesCommand(program: Command): void {
       } catch (err: any) {
         error(err.message);
       }
+    });
+
+  // Doctor: read-only freshness + linkage health check
+  features
+    .command('doctor')
+    .description('Check feature PRDs for staleness, orphans, and dangling task references (read-only)')
+    .action(() => {
+      const root = ensureContextRoot();
+      const featuresDir = getFeaturesDir();
+      const stateDir = join(root, 'state');
+
+      // Read all feature PRDs
+      const featureFiles = existsSync(featuresDir)
+        ? fg.sync('*.md', { cwd: featuresDir, absolute: true })
+        : [];
+
+      const featureRefs: FeatureRef[] = [];
+      for (const file of featureFiles) {
+        try {
+          const { data } = readFrontmatter<Record<string, unknown>>(file);
+          featureRefs.push({
+            slug: basename(file, '.md'),
+            id: data.id ? String(data.id) : undefined,
+            created: data.created ? String(data.created) : undefined,
+            updated: data.updated ? String(data.updated) : undefined,
+            related_tasks: Array.isArray(data.related_tasks)
+              ? data.related_tasks.map(String)
+              : [],
+          });
+        } catch {
+          // skip unreadable files
+        }
+      }
+
+      // Read all task state files for related_feature back-refs
+      const taskFiles = existsSync(stateDir)
+        ? fg.sync('*.md', { cwd: stateDir, absolute: true })
+        : [];
+
+      const taskRefs: TaskRef[] = [];
+      for (const file of taskFiles) {
+        const taskSlug = basename(file, '.md');
+        if (taskSlug.startsWith('.')) continue; // skip hidden files
+        try {
+          const { data } = readFrontmatter<Record<string, unknown>>(file);
+          taskRefs.push({
+            task: taskSlug,
+            related_feature: data.related_feature ? String(data.related_feature) : null,
+          });
+        } catch {
+          // skip unreadable files
+        }
+      }
+
+      const { stale, orphaned, danglingTaskRefs } = analyzeFeatures(featureRefs, taskRefs);
+
+      console.log(header('Features doctor'));
+
+      const issueCount = stale.length + orphaned.length + danglingTaskRefs.length;
+
+      if (issueCount === 0) {
+        success(`All ${featureRefs.length} feature(s) fresh and linked.`);
+        return;
+      }
+
+      if (stale.length > 0) {
+        console.log(`\n  ${chalk.yellow('STALE')} (${stale.length})`);
+        for (const s of stale) {
+          console.log(`    ${chalk.yellow('·')} ${chalk.bold(s.slug)}  ${chalk.dim(`${s.daysSinceUpdate}d`)}  ${chalk.dim(s.note)}`);
+        }
+      }
+
+      if (orphaned.length > 0) {
+        console.log(`\n  ${chalk.red('ORPHANED')} (${orphaned.length})  — no related tasks in either direction`);
+        for (const o of orphaned) {
+          console.log(`    ${chalk.red('·')} ${chalk.bold(o.slug)}`);
+        }
+      }
+
+      if (danglingTaskRefs.length > 0) {
+        console.log(`\n  ${chalk.red('DANGLING TASK REFS')} (${danglingTaskRefs.length})  — task points to missing feature PRD`);
+        for (const d of danglingTaskRefs) {
+          console.log(`    ${chalk.red('·')} ${chalk.bold(d.task)} → ${chalk.dim(d.missingFeature)}`);
+        }
+      }
+
+      process.exitCode = 1;
     });
 }

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -121,10 +121,11 @@ export function registerMemoryCommand(program: Command): void {
     .option('--type <type>', 'Changelog type (default: note)', 'note')
     .option('--scope <scope>', 'Changelog scope (default: quick)', 'quick')
     .option('--references <refs>', 'Optional comma-separated references (commit:<sha>, file:<path>, knowledge:<slug>, feature:<slug>, task:<slug>, url:<href>)')
+    .option('--person <list>', 'Optional comma-separated people to attribute this memory to (e.g. "mehmet,ada")')
     .description('Quick-append a CHANGELOG entry. Fast path; for full control use `dreamcontext core changelog add`.')
     .action(async (
       textParts: string[],
-      opts: { summary?: string; type?: string; scope?: string; references?: string },
+      opts: { summary?: string; type?: string; scope?: string; references?: string; person?: string },
     ) => {
       const root = ensureContextRoot();
       const text = textParts.join(' ').trim();
@@ -137,6 +138,12 @@ export function registerMemoryCommand(program: Command): void {
       const references = opts.references
         ? opts.references.split(',').map((s) => s.trim()).filter(Boolean)
         : undefined;
+      // Person attribution uses the UNIFIED `authors` carrier (the same field as
+      // `core changelog add --authors`), NOT references. recall.ts indexes
+      // `authors` into the doc tags so the person name is searchable.
+      const authors = opts.person
+        ? opts.person.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined;
       const changelogPath = join(root, 'core', 'CHANGELOG.json');
       const entry: Record<string, unknown> = {
         date: today(),
@@ -147,6 +154,7 @@ export function registerMemoryCommand(program: Command): void {
         breaking: false,
       };
       if (references && references.length > 0) entry.references = references;
+      if (authors && authors.length > 0) entry.authors = authors;
       // insertToJsonArray is the canonical writer (LIFO via top-insert).
       const { insertToJsonArray } = await import('../../lib/json-file.js');
       insertToJsonArray(changelogPath, entry);

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -14,6 +14,7 @@ import { readSetupConfig, isMultiPerson } from '../../lib/setup-config.js';
 import { isSkillInstalled } from '../../lib/catalog.js';
 import { readVersionCache, isCacheFresh, buildNudge } from '../../lib/version-check.js';
 import { dreamcontextVersion } from '../../lib/manifest.js';
+import { computeFeatureFreshness, freshnessSnapshotNote } from '../../lib/feature-freshness.js';
 
 /**
  * Default line cap when inlining pinned knowledge into the auto-context snapshot.
@@ -617,7 +618,12 @@ export function generateSnapshot(): string {
         } catch { /* skip */ }
 
         // Build output
-        let featureLine = `- **${name}** (status: ${status}${tags ? `, tags: ${tags}` : ''})`;
+        const freshness = computeFeatureFreshness(
+          String(data.created ?? ''),
+          String(data.updated ?? ''),
+        );
+        const freshnessNote = freshnessSnapshotNote(freshness);
+        let featureLine = `- **${name}** (status: ${status}${tags ? `, tags: ${tags}` : ''})${freshnessNote}`;
         const details: string[] = [];
         if (why) details.push(`  Why: ${why}`);
         if (relatedTasks) details.push(`  Tasks: ${relatedTasks}`);

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -10,7 +10,7 @@ import { readSleepState, writeSleepState, readSleepHistory } from './sleep.js';
 import { buildKnowledgeIndex } from '../../lib/knowledge-index.js';
 import { buildCoreIndex } from '../../lib/core-index.js';
 import { buildMarketingSnapshot } from '../../lib/marketing/snapshot.js';
-import { readSetupConfig } from '../../lib/setup-config.js';
+import { readSetupConfig, isMultiPerson } from '../../lib/setup-config.js';
 import { isSkillInstalled } from '../../lib/catalog.js';
 import { readVersionCache, isCacheFresh, buildNudge } from '../../lib/version-check.js';
 import { dreamcontextVersion } from '../../lib/manifest.js';
@@ -464,6 +464,17 @@ export function generateSnapshot(): string {
   const CHANGELOG_TIER2 = 10;
   const TIER1_BODY_CHARS = 300;
   const TIER2_LINE_CHARS = 140;
+  // Person attribution is gated on DERIVED multi-person status. Single-person
+  // projects (no roster / roster ≤1) never render `— by …`, so their Recent
+  // Changelog output stays byte-identical to today.
+  const multiPerson = isMultiPerson(readSetupConfig(dirname(root)));
+  const authorSuffix = (e: Record<string, unknown>): string => {
+    if (!multiPerson) return '';
+    const authors = Array.isArray(e.authors)
+      ? e.authors.filter((a): a is string => typeof a === 'string')
+      : [];
+    return authors.length > 0 ? ` — by ${authors.join(', ')}` : '';
+  };
   const changelogPath = join(root, 'core', 'CHANGELOG.json');
   if (existsSync(changelogPath)) {
     try {
@@ -479,7 +490,7 @@ export function generateSnapshot(): string {
           const summary = typeof e.summary === 'string' ? e.summary : '';
           const desc = String(e.description ?? '');
           const headline = summary || (desc.length > 200 ? desc.slice(0, 197) + '...' : desc);
-          parts.push(`- ${date} [${type}] ${scope}: ${headline}`);
+          parts.push(`- ${date} [${type}] ${scope}: ${headline}${authorSuffix(e)}`);
           // Body preview only when summary is present (otherwise headline is
           // already the description). Avoids printing the same text twice.
           if (summary && desc && desc !== summary) {
@@ -502,7 +513,7 @@ export function generateSnapshot(): string {
             const line = raw.length > TIER2_LINE_CHARS
               ? raw.slice(0, TIER2_LINE_CHARS - 3) + '...'
               : raw;
-            parts.push(`- ${date} [${type}] ${scope}: ${line}`);
+            parts.push(`- ${date} [${type}] ${scope}: ${line}${authorSuffix(e)}`);
           }
         }
         parts.push('');

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
 import chalk from 'chalk';
 import fg from 'fast-glob';
 import { ensureContextRoot } from '../../lib/context-path.js';
@@ -10,6 +10,7 @@ import { prepareSectionInsert, SECTION_MAP } from '../../lib/section-insert.js';
 import { promptInput } from '../../lib/prompt.js';
 import { generateId, slugify, today } from '../../lib/id.js';
 import { success, error, header } from '../../lib/format.js';
+import { readSetupConfig, isMultiPerson } from '../../lib/setup-config.js';
 import { getActivePlanningVersion } from '../../lib/active-version.js';
 import { mergeRice, normalizeRice, validateRiceInput, type RiceFields, type RiceInput } from '../../lib/rice.js';
 import {
@@ -301,11 +302,12 @@ export function registerTasksCommand(program: Command): void {
     .option('-t, --tags <tags>', 'Comma-separated tags')
     .option('-w, --why <why>', 'Why is this task needed?')
     .option('-v, --version <version>', 'Version/milestone')
+    .option('--person <name>', 'Responsible person (records a person:<slug> tag when multi-person)')
     .option('--reach <n>', 'RICE reach (integer 1–10)')
     .option('--impact <n>', 'RICE impact (integer 1–5)')
     .option('--confidence <n>', 'RICE confidence (25, 50, 75, or 100)')
     .option('--effort <n>', 'RICE effort in weeks (> 0, ≤ 52)')
-    .action(async (name: string, opts: { description?: string; priority?: string; urgency?: string; status?: string; tags?: string; why?: string; version?: string; reach?: string; impact?: string; confidence?: string; effort?: string }) => {
+    .action(async (name: string, opts: { description?: string; priority?: string; urgency?: string; status?: string; tags?: string; why?: string; version?: string; person?: string; reach?: string; impact?: string; confidence?: string; effort?: string }) => {
       const dir = getStateDir();
       const slug = slugify(name);
       const filePath = join(dir, `${slug}.md`);
@@ -338,6 +340,18 @@ export function registerTasksCommand(program: Command): void {
 
       const description = opts.description || name;
       const tags = opts.tags ? opts.tags.split(',').map(t => t.trim()).filter(Boolean) : [];
+      // Person attribution rides the tags array as `person:<slug>` (no new
+      // frontmatter field, so existing task-query tag handling just works). The
+      // tag is injected ONLY when the project is multi-person; single-person
+      // projects never get it (`--person` is a silent no-op there). `dir` is
+      // `_dream_context/state`, so the project root is two levels up.
+      if (opts.person && opts.person.trim()) {
+        const projectRoot = dirname(dirname(dir));
+        if (isMultiPerson(readSetupConfig(projectRoot))) {
+          const personTag = `person:${slugify(opts.person)}`;
+          if (!tags.includes(personTag)) tags.push(personTag);
+        }
+      }
       const why = opts.why || '';
       const version = opts.version || getActivePlanningVersion();
 

--- a/src/lib/feature-freshness.ts
+++ b/src/lib/feature-freshness.ts
@@ -1,0 +1,193 @@
+/**
+ * Feature freshness helpers.
+ * Single deterministic core for freshness computation, snapshot notes, and doctor analysis.
+ * No separate feature-query.ts — toFeatureRecord normalization is inlined in analyzeFeatures.
+ */
+
+export const FEATURE_STALE_DAYS = 30;
+
+export interface FeatureFreshness {
+  level: 'fresh' | 'stale' | 'unknown';
+  daysSinceUpdate: number | null;
+  note: string;
+}
+
+/**
+ * Compute the number of whole days between an ISO date string and `now`.
+ * Returns null if `fromISO` is missing, empty, or unparseable.
+ */
+export function daysBetween(fromISO: string | undefined | null, now: Date): number | null {
+  if (!fromISO || !fromISO.trim()) return null;
+  const ms = new Date(fromISO).getTime();
+  if (isNaN(ms)) return null;
+  return Math.floor((now.getTime() - ms) / 86_400_000);
+}
+
+/**
+ * Compute freshness for a single feature PRD.
+ *
+ * Rules:
+ * - `updated` missing/unparseable => level:'unknown', daysSinceUpdate:null, note:''
+ * - daysSinceUpdate > 30 => level:'stale'
+ *   - if updated === created (never actually updated) => note includes '(never updated since creation)'
+ * - else => level:'fresh', note:''
+ *
+ * Inject `now` for deterministic tests (defaults to real clock).
+ */
+export function computeFeatureFreshness(
+  created?: string,
+  updated?: string,
+  now: Date = new Date(),
+): FeatureFreshness {
+  const days = daysBetween(updated, now);
+  if (days === null) {
+    return { level: 'unknown', daysSinceUpdate: null, note: '' };
+  }
+
+  if (days > FEATURE_STALE_DAYS) {
+    // Check if the PRD was never updated: created and updated are the same date string
+    const neverUpdated =
+      typeof created === 'string' &&
+      typeof updated === 'string' &&
+      created.trim() === updated.trim() &&
+      created.trim() !== '';
+
+    const note = neverUpdated
+      ? 'stale: never updated since creation (30+ days)'
+      : 'stale: not updated in 30+ days';
+
+    return { level: 'stale', daysSinceUpdate: days, note };
+  }
+
+  return { level: 'fresh', daysSinceUpdate: days, note: '' };
+}
+
+/**
+ * Returns the parenthesised snippet to append to the snapshot feature header line.
+ * Mirrors the knowledge stalenessNote string shape: ' (note)' when note is non-empty, else ''.
+ */
+export function freshnessSnapshotNote(f: FeatureFreshness): string {
+  return f.note ? ` (${f.note})` : '';
+}
+
+// ─── analyzeFeatures ─────────────────────────────────────────────────────────
+
+export interface FeatureRef {
+  /** slug == basename of the .md file (primary match key) */
+  slug: string;
+  /** id from frontmatter (fallback match key) */
+  id?: string;
+  created?: string;
+  updated?: string;
+  /** slugs/ids of related tasks recorded in the feature's own frontmatter */
+  related_tasks?: string[];
+}
+
+export interface TaskRef {
+  /** task slug (basename of state .md) */
+  task: string;
+  /** value of related_feature frontmatter field (null if absent) */
+  related_feature: string | null;
+}
+
+export interface AnalyzeResult {
+  stale: Array<{ slug: string; note: string; daysSinceUpdate: number }>;
+  orphaned: Array<{ slug: string }>;
+  danglingTaskRefs: Array<{ task: string; missingFeature: string }>;
+}
+
+/**
+ * Case-insensitive equality helper.
+ */
+function ieq(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Analyze a set of features and task back-references for health issues.
+ *
+ * Matching rules (BINDING — do not copy graph.ts which does id-first):
+ *   - Slug is PRIMARY: a task's `related_feature` is matched against feature.slug first.
+ *   - feature.id is FALLBACK only.
+ *   - Slug-matched refs must never be flagged dangling/orphaned.
+ *
+ * Definitions:
+ *   stale     : computeFeatureFreshness(created, updated, now).level === 'stale'
+ *   orphaned  : feature has no related_tasks entries AND no task points back via slug|id
+ *   dangling  : task has non-null related_feature that matches NO feature by slug OR id
+ *
+ * @param features  list of feature records (from PRD frontmatter)
+ * @param taskRefs  list of {task, related_feature} from task frontmatter
+ * @param now       injectable for deterministic tests
+ */
+export function analyzeFeatures(
+  features: FeatureRef[],
+  taskRefs: TaskRef[],
+  now: Date = new Date(),
+): AnalyzeResult {
+  const stale: AnalyzeResult['stale'] = [];
+  const orphaned: AnalyzeResult['orphaned'] = [];
+  const danglingTaskRefs: AnalyzeResult['danglingTaskRefs'] = [];
+
+  // Build a Set of all feature slugs and ids for O(1) lookups
+  const featureSlugs = new Set(features.map(f => f.slug.toLowerCase()));
+  const featureIds = new Set(
+    features.filter(f => f.id && f.id.trim()).map(f => f.id!.toLowerCase()),
+  );
+
+  // Build a Set of related_feature values that actually resolve (slug or id)
+  const resolvedRefs = new Set<string>();
+  for (const tr of taskRefs) {
+    if (!tr.related_feature) continue;
+    const rf = tr.related_feature.toLowerCase();
+    if (featureSlugs.has(rf) || featureIds.has(rf)) {
+      resolvedRefs.add(rf);
+    }
+  }
+
+  // Identify dangling refs (task.related_feature non-null, matches no feature)
+  for (const tr of taskRefs) {
+    if (!tr.related_feature) continue;
+    const rf = tr.related_feature.toLowerCase();
+    if (!featureSlugs.has(rf) && !featureIds.has(rf)) {
+      danglingTaskRefs.push({ task: tr.task, missingFeature: tr.related_feature });
+    }
+  }
+
+  // Analyze each feature for stale / orphaned
+  for (const feat of features) {
+    // Stale check
+    const freshness = computeFeatureFreshness(feat.created, feat.updated, now);
+    if (freshness.level === 'stale') {
+      stale.push({
+        slug: feat.slug,
+        note: freshness.note,
+        daysSinceUpdate: freshness.daysSinceUpdate!,
+      });
+    }
+
+    // Orphaned check
+    // 1. Feature's own frontmatter has related_tasks
+    const hasFrontmatterTasks =
+      Array.isArray(feat.related_tasks) && feat.related_tasks.length > 0;
+
+    // 2. Any task points back to this feature (by slug primary, id fallback)
+    const slug = feat.slug.toLowerCase();
+    const id = feat.id ? feat.id.toLowerCase() : '';
+    const hasBackRef = taskRefs.some(tr => {
+      if (!tr.related_feature) return false;
+      const rf = tr.related_feature.toLowerCase();
+      // slug is primary
+      if (ieq(rf, slug)) return true;
+      // id is fallback
+      if (id && ieq(rf, id)) return true;
+      return false;
+    });
+
+    if (!hasFrontmatterTasks && !hasBackRef) {
+      orphaned.push({ slug: feat.slug });
+    }
+  }
+
+  return { stale, orphaned, danglingTaskRefs };
+}

--- a/src/lib/people.ts
+++ b/src/lib/people.ts
@@ -1,0 +1,86 @@
+import { slugify } from './id.js';
+
+/**
+ * Multi-person attribution helpers.
+ *
+ * Person attribution rides existing carriers — there is no bespoke person data
+ * type. A person is identified by a kebab-case slug (`slugify(name)`), the same
+ * slug used in `person:<slug>` task tags and in changelog `authors`.
+ *
+ * `ensurePeopleSection` keeps a `## People` block in `1.user.md` in sync with the
+ * roster. It is a NO-OP for single-person projects (≤1 person) so single-person
+ * `user.md` stays byte-identical to today, and it is idempotent: repeated calls
+ * with the same roster yield identical output (it replaces the block in place).
+ */
+
+const PEOPLE_HEADING = '## People';
+
+/** Build the `## People` block body (heading + one bullet per person). */
+function renderPeopleSection(people: string[]): string {
+  const lines = [PEOPLE_HEADING, ''];
+  for (const name of people) {
+    lines.push(`- ${name} (\`person:${slugify(name)}\`)`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Find the `[start, end)` line range of an existing `## People` section, or null.
+ * The section runs from its heading up to (but not including) the next H2/H1
+ * heading, or to end-of-file.
+ */
+function findPeopleSection(lines: string[]): { start: number; end: number } | null {
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === PEOPLE_HEADING) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^#{1,2}\s/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+/**
+ * Return `userMd` with its `## People` section reflecting `people`.
+ *
+ * - ≤1 person ⇒ returns `userMd` UNCHANGED (no section is added or removed). A
+ *   single-person project never grows a People block.
+ * - >1 person ⇒ inserts the block (appended after a trailing blank line) when
+ *   absent, or replaces an existing block in place. Idempotent across repeated
+ *   calls with the same roster.
+ */
+export function ensurePeopleSection(userMd: string, people: string[]): string {
+  if (people.length <= 1) return userMd;
+
+  const block = renderPeopleSection(people);
+  const lines = userMd.split('\n');
+  const existing = findPeopleSection(lines);
+
+  if (existing) {
+    // Replace the existing section (heading through just-before the next
+    // heading) with the freshly rendered block. Normalise trailing whitespace
+    // on the segment after the block so the output is a stable fixed point:
+    // re-running with the same roster reproduces this exact string.
+    const before = lines.slice(0, existing.start);
+    const after = lines.slice(existing.end);
+    const head = before.join('\n').replace(/\s+$/, '');
+    const tail = after.join('\n').replace(/^\s+/, '').replace(/\s+$/, '');
+    const prefix = head.length > 0 ? `${head}\n\n` : '';
+    const suffix = tail.length > 0 ? `\n\n${tail}\n` : '\n';
+    return `${prefix}${block}${suffix}`;
+  }
+
+  // Append the block at the end, separated by a single blank line. Trim trailing
+  // whitespace first so appends are stable (idempotent block boundary).
+  const trimmed = userMd.replace(/\s+$/, '');
+  if (trimmed.length === 0) return `${block}\n`;
+  return `${trimmed}\n\n${block}\n`;
+}

--- a/src/lib/recall.ts
+++ b/src/lib/recall.ts
@@ -292,11 +292,14 @@ function loadChangelogEntries(contextRoot: string): CorpusDoc[] {
     const description = String(e.description ?? '');
     const summary = typeof e.summary === 'string' ? e.summary : '';
     const refs = Array.isArray(e.references) ? e.references.map(String) : [];
+    const authors = Array.isArray(e.authors) ? e.authors.map(String) : [];
     if (!description && !summary) continue;
     const slug = `changelog#${date}-${scope || type}-${i}`;
     const title = `${date} [${type}] ${scope}${summary ? ` — ${summary}` : ''}`.trim();
-    // description-field carries summary; tags carry type/scope; refs fold into body.
-    const tags = [type, scope].filter(Boolean);
+    // description-field carries summary; tags carry type/scope/authors; refs fold
+    // into body. Indexing `authors` as a tag (field-weight 2) makes person
+    // attribution searchable — recall surfaces an entry by the person's name.
+    const tags = [type, scope, ...authors].filter(Boolean);
     // No slug passed: a changelog's `changelog#…` slug + date-prefixed title are
     // synthetic, not a canonical identity — excluding them keeps the identity
     // boost from spuriously lifting changelogs on field-match queries.

--- a/src/lib/release-discovery.ts
+++ b/src/lib/release-discovery.ts
@@ -24,6 +24,15 @@ export interface ChangelogEntry {
    */
   references?: string[];
   /**
+   * Optional roster of people involved in this change (kebab-case display-name
+   * slugs, e.g. `mehmet`, `ada`). The unified person-attribution carrier — the
+   * SAME field used by `memory remember --person`. Backwards compatible: entries
+   * without `authors` keep working, and `authors` is DELIBERATELY EXCLUDED from
+   * `changelogFingerprint` so adding/removing it never changes dedup identity
+   * (no spurious "unreleased" entries).
+   */
+  authors?: string[];
+  /**
    * Optional pointer to a prior entry this one supersedes (e.g.,
    * `<date>|<scope>` or a coarser "{date}-{scope}" key). Used when a later
    * decision reverses or replaces an earlier one and the LIFO chain matters.

--- a/src/lib/setup-config.ts
+++ b/src/lib/setup-config.ts
@@ -8,6 +8,13 @@ export interface SetupConfig {
   platforms: PlatformId[];
   packs: string[];
   multiProduct: false | string[];
+  /**
+   * Canonical roster of humans working in this project (kebab-case display
+   * names). Optional + additive: absent ⇒ single-person project. There is NO
+   * persisted `multiPerson` flag — multi-person status is DERIVED from this
+   * roster via `isMultiPerson()` (people.length > 1) to avoid desync.
+   */
+  people?: string[];
   setupVersion: string;
   /**
    * When true (the default), dreamcontext disables Claude Code's native
@@ -33,6 +40,11 @@ export function readSetupConfig(projectRoot: string): SetupConfig | null {
       multiProduct: Array.isArray(parsed.multiProduct)
         ? parsed.multiProduct.filter((p): p is string => typeof p === 'string')
         : false,
+      // Absent / non-array ⇒ undefined (single-person). Filter to strings so a
+      // malformed roster can never leak non-string entries downstream.
+      people: Array.isArray(parsed.people)
+        ? parsed.people.filter((p): p is string => typeof p === 'string')
+        : undefined,
       setupVersion: typeof parsed.setupVersion === 'string' ? parsed.setupVersion : '0.0.0',
       // Default true: absent in legacy configs means "disable native memory".
       disableNativeMemory:
@@ -68,9 +80,19 @@ export function updateSetupConfig(
     platforms: patch.platforms ?? existing.platforms,
     packs: patch.packs ?? existing.packs,
     multiProduct: patch.multiProduct ?? existing.multiProduct,
+    people: patch.people ?? existing.people,
     setupVersion: patch.setupVersion ?? existing.setupVersion,
     disableNativeMemory: patch.disableNativeMemory ?? existing.disableNativeMemory,
   };
   writeSetupConfig(projectRoot, next);
   return next;
+}
+
+/**
+ * Multi-person status is DERIVED, never persisted: a project is multi-person iff
+ * its roster lists more than one human. Absent/short roster ⇒ single-person.
+ * Mirrors the `multiProduct` length check so every surface gates identically.
+ */
+export function isMultiPerson(config: SetupConfig | null | undefined): boolean {
+  return (config?.people?.length ?? 0) > 1;
 }

--- a/src/server/routes/features.ts
+++ b/src/server/routes/features.ts
@@ -6,6 +6,7 @@ import { readFrontmatter } from '../../lib/frontmatter.js';
 import { listSections, readSection } from '../../lib/markdown.js';
 import { sendJson, sendError } from '../middleware.js';
 import { safeChildPath } from '../safe-path.js';
+import { computeFeatureFreshness } from '../../lib/feature-freshness.js';
 
 function getFeaturesDir(contextRoot: string): string {
   return join(contextRoot, 'core', 'features');
@@ -38,6 +39,10 @@ export async function handleFeaturesList(
       updated: data.updated ?? '',
       tags: Array.isArray(data.tags) ? data.tags : [],
       related_tasks: Array.isArray(data.related_tasks) ? data.related_tasks : [],
+      freshness: computeFeatureFreshness(
+        String(data.created ?? ''),
+        String(data.updated ?? ''),
+      ),
     };
   });
 

--- a/tests/unit/feature-freshness.test.ts
+++ b/tests/unit/feature-freshness.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeFeatureFreshness,
+  daysBetween,
+  freshnessSnapshotNote,
+  analyzeFeatures,
+  FEATURE_STALE_DAYS,
+  type FeatureRef,
+  type TaskRef,
+} from '../../src/lib/feature-freshness.js';
+
+const NOW = new Date('2026-06-09T00:00:00Z');
+
+// ─── daysBetween ─────────────────────────────────────────────────────────────
+
+describe('daysBetween', () => {
+  it('returns null for undefined input', () => {
+    expect(daysBetween(undefined, NOW)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(daysBetween('', NOW)).toBeNull();
+  });
+
+  it('returns null for whitespace', () => {
+    expect(daysBetween('   ', NOW)).toBeNull();
+  });
+
+  it('returns null for unparseable string', () => {
+    expect(daysBetween('not-a-date', NOW)).toBeNull();
+  });
+
+  it('returns correct days for a valid ISO date', () => {
+    // 2026-06-09 minus 2026-04-30 = 40 days
+    expect(daysBetween('2026-04-30', NOW)).toBe(40);
+  });
+
+  it('returns 0 when date equals now', () => {
+    expect(daysBetween('2026-06-09', NOW)).toBe(0);
+  });
+
+  it('returns 30 for exactly 30 days ago', () => {
+    expect(daysBetween('2026-05-10', NOW)).toBe(30);
+  });
+});
+
+// ─── computeFeatureFreshness ─────────────────────────────────────────────────
+
+describe('computeFeatureFreshness', () => {
+  it('returns unknown when updated is undefined', () => {
+    const r = computeFeatureFreshness('2026-01-01', undefined, NOW);
+    expect(r.level).toBe('unknown');
+    expect(r.daysSinceUpdate).toBeNull();
+    expect(r.note).toBe('');
+  });
+
+  it('returns unknown when updated is empty string', () => {
+    const r = computeFeatureFreshness('2026-01-01', '', NOW);
+    expect(r.level).toBe('unknown');
+  });
+
+  it('returns unknown when updated is malformed', () => {
+    const r = computeFeatureFreshness('2026-01-01', 'bad-date', NOW);
+    expect(r.level).toBe('unknown');
+  });
+
+  it('returns stale for 40 days ago', () => {
+    const r = computeFeatureFreshness('2026-01-01', '2026-04-30', NOW);
+    expect(r.level).toBe('stale');
+    expect(r.daysSinceUpdate).toBe(40);
+    expect(r.note).toBe('stale: not updated in 30+ days');
+  });
+
+  it('returns fresh for 5 days ago', () => {
+    const r = computeFeatureFreshness('2026-06-04', '2026-06-04', NOW);
+    expect(r.level).toBe('fresh');
+    expect(r.note).toBe('');
+  });
+
+  it('returns fresh for exactly 30 days ago (boundary: > 30, not >=)', () => {
+    const r = computeFeatureFreshness('2026-05-01', '2026-05-10', NOW);
+    expect(daysBetween('2026-05-10', NOW)).toBe(30);
+    expect(r.level).toBe('fresh');
+  });
+
+  it('returns stale for 31 days ago', () => {
+    const r = computeFeatureFreshness('2026-05-01', '2026-05-09', NOW);
+    expect(daysBetween('2026-05-09', NOW)).toBe(31);
+    expect(r.level).toBe('stale');
+    expect(r.note).toBe('stale: not updated in 30+ days');
+  });
+
+  it('returns fresh when updated===created same-day (created today)', () => {
+    // same day, zero days old — fresh regardless of equality
+    const r = computeFeatureFreshness('2026-06-09', '2026-06-09', NOW);
+    expect(r.level).toBe('fresh');
+  });
+
+  it('returns stale + never-updated subnote when updated===created 60d ago', () => {
+    const r = computeFeatureFreshness('2026-04-10', '2026-04-10', NOW);
+    expect(r.level).toBe('stale');
+    expect(r.note).toBe('stale: never updated since creation (30+ days)');
+  });
+
+  it('uses FEATURE_STALE_DAYS constant (30)', () => {
+    expect(FEATURE_STALE_DAYS).toBe(30);
+  });
+});
+
+// ─── freshnessSnapshotNote ────────────────────────────────────────────────────
+
+describe('freshnessSnapshotNote', () => {
+  it('returns empty string when note is empty (fresh)', () => {
+    const f = computeFeatureFreshness('2026-06-04', '2026-06-04', NOW);
+    expect(freshnessSnapshotNote(f)).toBe('');
+  });
+
+  it('returns empty string when level is unknown', () => {
+    const f = computeFeatureFreshness(undefined, undefined, NOW);
+    expect(freshnessSnapshotNote(f)).toBe('');
+  });
+
+  it('wraps note in parentheses for stale', () => {
+    const f = computeFeatureFreshness('2026-01-01', '2026-04-30', NOW);
+    expect(f.level).toBe('stale');
+    expect(freshnessSnapshotNote(f)).toBe(' (stale: not updated in 30+ days)');
+  });
+
+  it('wraps never-updated note in parentheses', () => {
+    const f = computeFeatureFreshness('2026-04-10', '2026-04-10', NOW);
+    expect(freshnessSnapshotNote(f)).toBe(' (stale: never updated since creation (30+ days))');
+  });
+});
+
+// ─── analyzeFeatures ─────────────────────────────────────────────────────────
+
+describe('analyzeFeatures', () => {
+  it('returns empty buckets for empty inputs', () => {
+    const result = analyzeFeatures([], [], NOW);
+    expect(result.stale).toEqual([]);
+    expect(result.orphaned).toEqual([]);
+    expect(result.danglingTaskRefs).toEqual([]);
+  });
+
+  it('marks stale feature and does NOT orphan it when it has related tasks', () => {
+    const features: FeatureRef[] = [
+      {
+        slug: 'my-feature',
+        id: 'feat_abc',
+        created: '2026-04-10',
+        updated: '2026-04-10',  // same as created, 60d ago → stale + never-updated
+        related_tasks: ['some-task'],
+      },
+    ];
+    const taskRefs: TaskRef[] = [
+      { task: 'some-task', related_feature: 'my-feature' },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.stale).toHaveLength(1);
+    expect(result.stale[0].slug).toBe('my-feature');
+    expect(result.stale[0].note).toBe('stale: never updated since creation (30+ days)');
+    // Has frontmatter tasks → NOT orphaned
+    expect(result.orphaned).toHaveLength(0);
+    expect(result.danglingTaskRefs).toHaveLength(0);
+  });
+
+  it('marks orphaned when feature has empty related_tasks and no back-refs', () => {
+    const features: FeatureRef[] = [
+      {
+        slug: 'lonely-feature',
+        id: 'feat_xyz',
+        created: '2026-06-01',
+        updated: '2026-06-01',
+        related_tasks: [],
+      },
+    ];
+    const taskRefs: TaskRef[] = [
+      { task: 'unrelated-task', related_feature: null },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.orphaned).toHaveLength(1);
+    expect(result.orphaned[0].slug).toBe('lonely-feature');
+  });
+
+  it('does NOT orphan feature when task points back by slug (slug-primary matching)', () => {
+    const features: FeatureRef[] = [
+      {
+        slug: 'recall-engine',
+        id: 'feat_001',
+        created: '2026-06-01',
+        updated: '2026-06-01',
+        related_tasks: [],  // empty in frontmatter
+      },
+    ];
+    // Task uses the SLUG (as real state files do)
+    const taskRefs: TaskRef[] = [
+      { task: 'some-task', related_feature: 'recall-engine' },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.orphaned).toHaveLength(0);
+  });
+
+  it('does NOT orphan feature when task points back by id (id fallback)', () => {
+    const features: FeatureRef[] = [
+      {
+        slug: 'some-feature',
+        id: 'feat_001',
+        created: '2026-06-01',
+        updated: '2026-06-01',
+        related_tasks: [],
+      },
+    ];
+    // Task uses the feature's ID as related_feature
+    const taskRefs: TaskRef[] = [
+      { task: 'task-a', related_feature: 'feat_001' },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.orphaned).toHaveLength(0);
+  });
+
+  it('marks dangling task ref when related_feature matches no feature by slug or id', () => {
+    const features: FeatureRef[] = [
+      { slug: 'real-feature', id: 'feat_real', created: '2026-06-01', updated: '2026-06-01', related_tasks: [] },
+    ];
+    const taskRefs: TaskRef[] = [
+      { task: 'task-ghost', related_feature: 'ghost-feature' },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.danglingTaskRefs).toHaveLength(1);
+    expect(result.danglingTaskRefs[0].task).toBe('task-ghost');
+    expect(result.danglingTaskRefs[0].missingFeature).toBe('ghost-feature');
+    // real-feature has no back-ref and no related_tasks → orphaned
+    expect(result.orphaned).toHaveLength(1);
+  });
+
+  it('ignores tasks with null related_feature (no dangling, no back-ref effect)', () => {
+    const features: FeatureRef[] = [
+      { slug: 'my-feat', id: 'feat_1', created: '2026-06-01', updated: '2026-06-01', related_tasks: [] },
+    ];
+    const taskRefs: TaskRef[] = [
+      { task: 'task-with-no-feature', related_feature: null },
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.danglingTaskRefs).toHaveLength(0);
+    // no back-ref → orphaned
+    expect(result.orphaned).toHaveLength(1);
+  });
+
+  it('slug matching is case-insensitive', () => {
+    const features: FeatureRef[] = [
+      { slug: 'MyFeature', id: 'feat_2', created: '2026-06-01', updated: '2026-06-01', related_tasks: [] },
+    ];
+    const taskRefs: TaskRef[] = [
+      { task: 'task-b', related_feature: 'myfeature' },  // lowercase slug
+    ];
+
+    const result = analyzeFeatures(features, taskRefs, NOW);
+    expect(result.orphaned).toHaveLength(0);
+    expect(result.danglingTaskRefs).toHaveLength(0);
+  });
+});

--- a/tests/unit/multi-people-awareness.test.ts
+++ b/tests/unit/multi-people-awareness.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  readSetupConfig,
+  writeSetupConfig,
+  updateSetupConfig,
+  isMultiPerson,
+  type SetupConfig,
+} from '../../src/lib/setup-config.js';
+import { ensurePeopleSection } from '../../src/lib/people.js';
+import { findUnreleasedChangelog } from '../../src/lib/release-discovery.js';
+import { buildCorpus, bm25Search } from '../../src/lib/recall.js';
+import { registerConfigCommand } from '../../src/cli/commands/config.js';
+import { registerCoreCommand } from '../../src/cli/commands/core.js';
+import { registerTasksCommand } from '../../src/cli/commands/tasks.js';
+import { registerMemoryCommand } from '../../src/cli/commands/memory.js';
+import { generateSnapshot } from '../../src/cli/commands/snapshot.js';
+
+/**
+ * SPEC — Multi-people awareness
+ * GitHub: https://github.com/meanllbrl/dreamcontext/issues/8
+ *
+ * Problem: dreamcontext assumes a single human ("the user"). When more than one
+ * person works in the same project, changelogs, tasks, and memory lose track of
+ * WHO did WHAT. We want the agent to auto-detect multiple humans (NOT a
+ * hard-coded toggle) and attribute work per person across every surface.
+ *
+ * The 15 deterministic facets below are converted to passing `it(...)`. The 6
+ * AI-driven facets (detection + sleep consolidation) stay `it.todo` — they live
+ * in the sleep-state/sleep-tasks agent prompts and are inspection-validated.
+ *
+ * Schema deltas the implementation makes (kept here so the test is the single
+ * source of truth for the target shape):
+ *
+ *   1. .config.json  (src/lib/setup-config.ts, config.ts)
+ *        + people?: string[]            // canonical roster, kebab-case display names
+ *      multiPerson is DERIVED only: isMultiPerson(cfg) === people.length > 1.
+ *      It is NEVER persisted.
+ *
+ *   2. ChangelogEntry (src/lib/release-discovery.ts) + `core changelog add`:
+ *        + authors?: string[]           // who was involved (UNIFIED person carrier)
+ *        + `--authors <a,b>` flag.
+ *      Excluded from the fingerprint → adding/removing authors never changes
+ *      dedup identity (no spurious "unreleased").
+ *
+ *   3. Task tags (src/cli/commands/tasks.ts):
+ *        when multiPerson, `--person X` pushes `person:<slug>` into the tags
+ *        array (no new frontmatter field; existing tag filters just work).
+ *
+ *   4. Memory entries (`memory remember --person`):
+ *        attributed via the SAME `authors` carrier; recall indexes authors into
+ *        the doc tags field so the person name is searchable.
+ *
+ *   5. user.md: ensurePeopleSection adds a "## People" section when multiPerson;
+ *        single-person projects are unchanged (idempotent).
+ *
+ *   6. Snapshot (src/cli/commands/snapshot.ts): when multiPerson, per-entry
+ *        "— by <names>" attribution; single-person output is byte-identical.
+ */
+
+// ── Tmp-context fixture (mirrors release-discovery.test.ts) ──────────────────
+// projectRoot/_dream_context/{state,core,knowledge}. CLI commands resolve the
+// context root from process.cwd(), so each test chdir's into the project root.
+
+interface Fixture {
+  projectRoot: string;       // dir holding _dream_context/
+  contextRoot: string;       // the _dream_context/ dir
+}
+
+function makeFixture(): Fixture {
+  const raw = join(tmpdir(), `ac-people-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(raw, { recursive: true });
+  const projectRoot = realpathSync(raw);
+  const contextRoot = join(projectRoot, '_dream_context');
+  mkdirSync(join(contextRoot, 'state'), { recursive: true });
+  mkdirSync(join(contextRoot, 'core', 'features'), { recursive: true });
+  mkdirSync(join(contextRoot, 'knowledge'), { recursive: true });
+  writeFileSync(join(contextRoot, 'core', 'CHANGELOG.json'), '[]', 'utf-8');
+  writeFileSync(join(contextRoot, 'core', 'RELEASES.json'), '[]', 'utf-8');
+  return { projectRoot, contextRoot };
+}
+
+/** Build a fresh Command, register one command group, parse argv (from cwd). */
+async function runCli(
+  register: (program: Command) => void,
+  argv: string[],
+): Promise<void> {
+  const program = new Command();
+  program.exitOverride(); // throw instead of process.exit on errors
+  register(program);
+  await program.parseAsync(['node', 'dreamcontext', ...argv]);
+}
+
+/** Capture everything written to console.log during `fn`. */
+async function captureStdout(fn: () => void | Promise<void>): Promise<string> {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join('\n');
+}
+
+function readChangelog(contextRoot: string): Array<Record<string, unknown>> {
+  return JSON.parse(readFileSync(join(contextRoot, 'core', 'CHANGELOG.json'), 'utf-8'));
+}
+
+function baseConfig(overrides: Partial<SetupConfig> = {}): SetupConfig {
+  return {
+    platforms: [],
+    packs: [],
+    multiProduct: false,
+    setupVersion: '0.6.0',
+    disableNativeMemory: true,
+    ...overrides,
+  };
+}
+
+describe('multi-people awareness', () => {
+  let fx: Fixture;
+  let origCwd: string;
+
+  beforeEach(() => {
+    fx = makeFixture();
+    origCwd = process.cwd();
+    process.chdir(fx.projectRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(fx.projectRoot, { recursive: true, force: true });
+  });
+
+  describe('detection (AI-driven, not hard-coded)', () => {
+    it.todo('infers >1 distinct human from session signals (self-id, git authors, voice) and flips multiPerson on');
+    it.todo('stays single-person (multiPerson=false) when only one human is observed — no false positives');
+    it.todo('detection is additive: a newly observed person is appended to the roster, never overwrites it');
+  });
+
+  describe('.config.json roster', () => {
+    it('supports people: string[] alongside multiProduct (kebab-case display names)', () => {
+      writeSetupConfig(
+        fx.projectRoot,
+        baseConfig({ multiProduct: ['app', 'site'], people: ['mehmet', 'ada'] }),
+      );
+      const cfg = readSetupConfig(fx.projectRoot);
+      expect(cfg).not.toBeNull();
+      expect(cfg!.people).toEqual(['mehmet', 'ada']);
+      expect(cfg!.multiProduct).toEqual(['app', 'site']);
+    });
+
+    it('multiPerson is derived true when people.length > 1, false otherwise', () => {
+      // Derived only — never read from a persisted flag.
+      expect(isMultiPerson(baseConfig({ people: ['mehmet', 'ada'] }))).toBe(true);
+      expect(isMultiPerson(baseConfig({ people: ['mehmet'] }))).toBe(false);
+      expect(isMultiPerson(baseConfig({ people: [] }))).toBe(false);
+      expect(isMultiPerson(baseConfig())).toBe(false);
+      expect(isMultiPerson(null)).toBe(false);
+
+      // And it is NEVER persisted: writing then reading carries no multiPerson key.
+      writeSetupConfig(fx.projectRoot, baseConfig({ people: ['mehmet', 'ada'] }));
+      const raw = JSON.parse(
+        readFileSync(join(fx.contextRoot, 'state', '.config.json'), 'utf-8'),
+      );
+      expect(raw).not.toHaveProperty('multiPerson');
+
+      // updateSetupConfig merges people additively (patch.people ?? existing).
+      const merged = updateSetupConfig(fx.projectRoot, { platforms: [] });
+      expect(merged.people).toEqual(['mehmet', 'ada']);
+    });
+
+    it('config show prints the people roster when present', async () => {
+      writeSetupConfig(fx.projectRoot, baseConfig({ people: ['mehmet', 'ada'] }));
+      const out = await captureStdout(() =>
+        runCli(registerConfigCommand, ['config', 'show']),
+      );
+      expect(out).toMatch(/People:\s+mehmet, ada/);
+    });
+
+    it('missing people/multiPerson is treated as single-person (backwards compatible)', async () => {
+      // Legacy config without a `people` key.
+      writeSetupConfig(fx.projectRoot, baseConfig());
+      const cfg = readSetupConfig(fx.projectRoot);
+      expect(cfg!.people).toBeUndefined();
+      expect(isMultiPerson(cfg)).toBe(false);
+
+      // config show prints NO People line for a single-person project.
+      const out = await captureStdout(() =>
+        runCli(registerConfigCommand, ['config', 'show']),
+      );
+      expect(out).not.toMatch(/People:/);
+    });
+  });
+
+  describe('changelog attribution', () => {
+    it('ChangelogEntry accepts optional authors?: string[]', () => {
+      // The optional field round-trips through JSON on disk.
+      writeFileSync(
+        join(fx.contextRoot, 'core', 'CHANGELOG.json'),
+        JSON.stringify([
+          { date: '2026-06-09', type: 'feat', scope: 'x', description: 'd', breaking: false, authors: ['mehmet', 'ada'] },
+        ]),
+        'utf-8',
+      );
+      const entries = readChangelog(fx.contextRoot);
+      expect(entries[0].authors).toEqual(['mehmet', 'ada']);
+    });
+
+    it('core changelog add --authors "mehmet,ada" persists authors on the entry', async () => {
+      await runCli(registerCoreCommand, [
+        'core', 'changelog', 'add',
+        '--type', 'feat', '--scope', 'people', '--description', 'multi-person',
+        '--authors', 'mehmet, ada',
+      ]);
+      const entries = readChangelog(fx.contextRoot);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].authors).toEqual(['mehmet', 'ada']);
+      expect(entries[0].description).toBe('multi-person');
+    });
+
+    it('entries without authors still parse and render (backwards compatible)', () => {
+      // A legacy entry (no authors) and a new entry (with authors) coexist; the
+      // fingerprint EXCLUDES authors, so adding authors to an otherwise-identical
+      // entry does not change its dedup identity — no spurious "unreleased".
+      const legacy = { date: '2026-06-09', type: 'fix', scope: 'auth', description: 'bug', breaking: false };
+      const withAuthors = { ...legacy, authors: ['mehmet'] };
+      // Release already contains the legacy entry → it is "released".
+      writeFileSync(
+        join(fx.contextRoot, 'core', 'RELEASES.json'),
+        JSON.stringify([
+          { id: 'rel_1', version: '1.0.0', date: '2026-06-01', summary: 's', breaking: false, status: 'released', features: [], tasks: [], changelog: [legacy] },
+        ]),
+        'utf-8',
+      );
+      // The CHANGELOG carries the SAME entry but now with authors attached.
+      writeFileSync(
+        join(fx.contextRoot, 'core', 'CHANGELOG.json'),
+        JSON.stringify([withAuthors]),
+        'utf-8',
+      );
+      // Fingerprint excludes authors → the entry is recognised as already
+      // released, so it is NOT reported as unreleased.
+      const unreleased = findUnreleasedChangelog(fx.contextRoot);
+      expect(unreleased).toHaveLength(0);
+    });
+
+    it('snapshot Recent Changelog shows author attribution when multiPerson', async () => {
+      writeSetupConfig(fx.projectRoot, baseConfig({ people: ['mehmet', 'ada'] }));
+      writeFileSync(
+        join(fx.contextRoot, 'core', 'CHANGELOG.json'),
+        JSON.stringify([
+          { date: '2026-06-09', type: 'feat', scope: 'people', description: 'rostering', breaking: false, authors: ['mehmet', 'ada'] },
+        ]),
+        'utf-8',
+      );
+      const snapshot = generateSnapshot();
+      expect(snapshot).toContain('## Recent Changelog');
+      expect(snapshot).toContain('— by mehmet, ada');
+
+      // Single-person output is byte-identical to today: same CHANGELOG, no
+      // roster ⇒ no "— by" suffix anywhere.
+      writeSetupConfig(fx.projectRoot, baseConfig());
+      const singlePerson = generateSnapshot();
+      expect(singlePerson).toContain('## Recent Changelog');
+      expect(singlePerson).not.toContain('— by');
+    });
+  });
+
+  describe('task person tags', () => {
+    it('when multiPerson, the responsible person is recorded as a person:<name> tag in task frontmatter', async () => {
+      writeSetupConfig(fx.projectRoot, baseConfig({ people: ['mehmet', 'ada'] }));
+      await runCli(registerTasksCommand, [
+        'tasks', 'create', 'Ship rostering', '--person', 'Ada',
+      ]);
+      const taskMd = readFileSync(join(fx.contextRoot, 'state', 'ship-rostering.md'), 'utf-8');
+      expect(taskMd).toMatch(/tags:[^\n]*person:ada/);
+    });
+
+    it('tasks list can filter/group by person:<name> tag (reuses existing tag handling)', async () => {
+      writeSetupConfig(fx.projectRoot, baseConfig({ people: ['mehmet', 'ada'] }));
+      await runCli(registerTasksCommand, ['tasks', 'create', 'Task A', '--person', 'Ada']);
+      await runCli(registerTasksCommand, ['tasks', 'create', 'Task B', '--person', 'Mehmet']);
+
+      // --tag person:ada filters via the EXISTING task-query tag handling (the
+      // tag was injected into the generic tags array — task-query.ts unchanged).
+      const filtered = await captureStdout(() =>
+        runCli(registerTasksCommand, ['tasks', 'list', '--tag', 'person:ada', '--json']),
+      );
+      const parsed = JSON.parse(filtered);
+      // TaskRecord.name is the file-basename slug (see task-query.ts).
+      const slugs = parsed.map((t: { name: string }) => t.name);
+      expect(slugs).toContain('task-a');
+      expect(slugs).not.toContain('task-b');
+
+      // --group-by tag also works over the same tags array.
+      const grouped = await captureStdout(() =>
+        runCli(registerTasksCommand, ['tasks', 'list', '--group-by', 'tag', '--all']),
+      );
+      expect(grouped).toContain('person:ada');
+      expect(grouped).toContain('person:mehmet');
+    });
+
+    it('single-person projects do not get person tags injected', async () => {
+      writeSetupConfig(fx.projectRoot, baseConfig()); // no roster ⇒ single-person
+      await runCli(registerTasksCommand, [
+        'tasks', 'create', 'Solo task', '--person', 'Ada',
+      ]);
+      const taskMd = readFileSync(join(fx.contextRoot, 'state', 'solo-task.md'), 'utf-8');
+      expect(taskMd).not.toContain('person:');
+      expect(taskMd).toMatch(/tags:\s*\[\]/);
+    });
+  });
+
+  describe('memory person tags', () => {
+    it('memory remember accepts and preserves a person:<name> tag', async () => {
+      // Person attribution rides the UNIFIED `authors` carrier (NOT references).
+      await runCli(registerMemoryCommand, [
+        'memory', 'remember', 'decided', 'on', 'the', 'roster', 'shape',
+        '--person', 'mehmet,ada',
+      ]);
+      const entries = readChangelog(fx.contextRoot);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].authors).toEqual(['mehmet', 'ada']);
+      // It must NOT be folded into references.
+      expect(entries[0].references).toBeUndefined();
+    });
+
+    it('recall surfaces person-tagged memory; person tag is searchable', async () => {
+      await runCli(registerMemoryCommand, [
+        'memory', 'remember', 'we', 'wired', 'the', 'snapshot', 'render',
+        '--person', 'ada',
+      ]);
+      // recall indexes `authors` into the changelog doc's tags field → searching
+      // the person name returns the entry as a BM25 hit.
+      const corpus = buildCorpus(fx.contextRoot, { types: ['changelog'] });
+      const hits = bm25Search('ada', corpus, 5);
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits.some((h) => h.doc.tags.includes('ada'))).toBe(true);
+    });
+  });
+
+  describe('user.md People section', () => {
+    it('when multiPerson, 1.user.md gains a "## People" section enumerating each person', () => {
+      const userMd = '# User\n\nSome existing preferences.\n';
+      const updated = ensurePeopleSection(userMd, ['mehmet', 'ada']);
+      expect(updated).toContain('## People');
+      expect(updated).toContain('- mehmet (`person:mehmet`)');
+      expect(updated).toContain('- ada (`person:ada`)');
+      // Existing content is preserved.
+      expect(updated).toContain('Some existing preferences.');
+
+      // Idempotent: re-running with the same roster yields identical output.
+      expect(ensurePeopleSection(updated, ['mehmet', 'ada'])).toBe(updated);
+
+      // Additive update: a new person replaces the block in place (no duplicate
+      // ## People heading).
+      const withThree = ensurePeopleSection(updated, ['mehmet', 'ada', 'lina']);
+      expect(withThree.match(/## People/g)).toHaveLength(1);
+      expect(withThree).toContain('- lina (`person:lina`)');
+    });
+
+    it('single-person 1.user.md is left unchanged (no empty People section)', () => {
+      const userMd = '# User\n\nSolo project preferences.\n';
+      expect(ensurePeopleSection(userMd, ['mehmet'])).toBe(userMd);
+      expect(ensurePeopleSection(userMd, [])).toBe(userMd);
+      expect(ensurePeopleSection(userMd, ['mehmet'])).not.toContain('## People');
+    });
+  });
+
+  describe('sleep consolidation', () => {
+    it.todo('sleep-state detects multiple humans and writes the roster to .config.json + user.md');
+    it.todo('sleep-state attributes each changelog entry to the person(s) who drove the change');
+    it.todo('sleep-tasks attributes task progress to the responsible person via person:<name> tag');
+  });
+});


### PR DESCRIPTION
Three open issues resolved via subagent-driven orchestration (goal-skill: plan → parallel plan-review → implement → clean-context code review → test/build validation). Each is an isolated, scoped commit.

## Commits

### `docs(excalidraw)` — #16 (spec/output conventions)
Adds a **File layout** section to `skill-packs/excalidraw/SKILL.md`: single-board spec↔output layout, a multi-board `pipeline/` + `spec/` structure, a "many boards from shared data" recipe, `__dirname`-relative require paths (survive a folder move), and a documented source-of-truth convention. Review caught + fixed two real bugs (a `../../../` path overshoot → `MODULE_NOT_FOUND`, and a missing `require('path')`). All three skill mirrors byte-identical.

### `feat(context)` — #8 (multi-people awareness)
Attribute work per person across the data model, **additive + backwards-compatible** (missing roster ⇒ single-person, output byte-identical):
- config `people[]` + derived `isMultiPerson`; `config show` roster.
- `ChangelogEntry.authors` + `core changelog add --authors` (excluded from the dedup fingerprint).
- `tasks create --person` → `person:<slug>` tag (multi-person only; existing tag filter/group reused).
- `memory remember --person` via the unified `authors` carrier; recall indexes authors (searchable).
- snapshot per-entry "— by <names>" in Recent Changelog.
- new `src/lib/people.ts` (`isMultiPerson`, `ensurePeopleSection`).
- sleep agents detect >1 human (≥2 corroborated signals, additive-union roster) + attribute changelog/task work (mirrored to `.codex/agents/prompts`).

**15 deterministic specs** in `tests/unit/multi-people-awareness.test.ts` converted to passing tests (6 AI-driven facets stay `it.todo`).

### `feat(features)` — #13 (freshness + `features doctor`)
Deterministic PRD freshness from `created`/`updated` frontmatter, surfaced everywhere features show:
- `src/lib/feature-freshness.ts`: `computeFeatureFreshness` (>30d threshold; missing `updated` ⇒ never false-flagged; "never updated since creation" as a sub-note) + `analyzeFeatures` (stale/orphaned/dangling; **slug-primary** matching to match real state files).
- snapshot Features staleness note (byte-identical for fresh PRDs), `GET /api/features` `freshness` field, dashboard "stale" pill, and a read-only `dreamcontext features doctor` (exits 1 on issues — CI-usable). **29 unit tests.**

## Validation
- Full unit suite: **1263 passed** (60 todo), 0 failures.
- `npm run build:cli` + `npm run build:dashboard`: clean.
- `features doctor` live smoke on this repo surfaced 2 stale + 5 orphaned PRDs (exit 1).

## Scope notes
- Closes #16, Closes #8.
- **#13 is a scoped slice** — git-driven drift detection, the mandatory sleep-product reconcile, and the specialist-architecture decision (which lives in #9) are intentionally deferred. Leaving #13 open for those follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)