### PR TITLE
feat(knowledge): excalidraw boards as first-class knowledge — index extracted text, never scene JSON (#20)

### DIFF
--- a/_dream_context/knowledge/diagrams/system-overview/system-overview.excalidraw.md
+++ b/_dream_context/knowledge/diagrams/system-overview/system-overview.excalidraw.md
@@ -1,0 +1,83 @@
+---
+name: System Overview
+description: High-level dreamcontext system overview — session capture, memory consolidation, and recall pipeline.
+tags: [architecture, excalidraw]
+excalidraw-plugin: parsed
+---
+
+# Excalidraw Data
+
+## Text Elements
+System Overview ^sysov001
+
+Session Capture ^sysov002
+
+Hook pipeline ^sysov003
+
+Memory Store ^sysov004
+
+_dream_context/ ^sysov005
+
+Recall ^sysov006
+
+BM25 keyword search ^sysov007
+
+Dashboard ^sysov008
+
+Sleep Consolidation ^sysov009
+
+%%
+## Drawing
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://github.com/zsviczian/obsidian-excalidraw-plugin",
+  "elements": [
+    {
+      "id": "sysov001",
+      "type": "text",
+      "x": 60,
+      "y": 20,
+      "width": 400,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a0",
+      "roundness": null,
+      "seed": 123456,
+      "version": 1,
+      "versionNonce": 654321,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1735689600000,
+      "link": null,
+      "locked": false,
+      "text": "System Overview",
+      "rawText": "System Overview",
+      "originalText": "System Overview",
+      "fontSize": 32,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "lineHeight": 1.25,
+      "autoResize": false
+    }
+  ],
+  "appState": {
+    "gridSize": null,
+    "viewBackgroundColor": "#ffffff"
+  },
+  "files": {}
+}
+```
+%%

--- a/agents/sleep-migration.md
+++ b/agents/sleep-migration.md
@@ -32,10 +32,30 @@ skills:
 
 2. If work is needed: perform moves/renames/fence-wraps surgically.
 
-3. **Wikilinks**: after moving a file, search for inbound `[[old-slug]]`
+3. **Wikilinks**: after moving a file, update inbound `[[old-slug]]` references.
+   For the diagrams migration (version 0.7.2 / step diagrams-folder-convention):
+   run `dreamcontext migrations apply-diagrams` — it moves the board AND rewrites
+   all inbound [[wikilinks]] atomically. Do NOT hand-edit wikilinks for this migration.
+   For other migrations (generic moves): search for inbound `[[old-slug]]`
    references across all `.md` files and rewrite the *target token* only
    (preserve `|alias` and `#anchor`). If you cannot determine all affected
    files, list broken links in your report.
+
+### Placement judgment (behavioral) — diagrams migration
+
+Before running `dreamcontext migrations apply-diagrams`, decide per board:
+
+- **Canonical knowledge** (architecture, system flows, roadmaps, durable plans
+  the agent should recall in future sessions) → `knowledge/diagrams/<title>/`
+  (indexed, recalled). Use `apply-diagrams` for these.
+- **Temporary / scratch / working** (exploratory sketches, in-progress drafts)
+  → `inbox/` or `workspace/` (dark by location — NOT indexed, will not
+  pollute recall). Do NOT pull these into knowledge/diagrams/.
+
+Decision rule: "Will a future session need to know this? → knowledge. Throwaway/working? → inbox/workspace."
+
+Only organize canonical boards. Leave temp/scratch boards in place or move to
+inbox/workspace — do NOT use `apply-diagrams` on them.
 
 4. **Write the ledger ONLY on completion** via:
    ```bash

--- a/dashboard/src/pages/KnowledgePage.tsx
+++ b/dashboard/src/pages/KnowledgePage.tsx
@@ -29,11 +29,32 @@ function prettyFolder(folder: string): string {
     .join(' ');
 }
 
-// Inside a folder, drop the "<folder>/" prefix so cards read "recall.excalidraw"
-// rather than "diagrams/recall.excalidraw". Only strips when the name is still
-// the raw slug path (no custom frontmatter name).
-function leafName(entry: KnowledgeListEntry, folder: string | null): string {
-  if (folder && entry.name.startsWith(`${folder}/`)) return entry.name.slice(folder.length + 1);
+/**
+ * Compute the display leaf name for a card inside a folder group.
+ *
+ * For Excalidraw boards in a depth-2 nested folder (e.g. slug =
+ * `diagrams/my-board/my-board.excalidraw`), using the last path segment
+ * collapses the redundant `<title>/<title>.excalidraw` pattern to just
+ * `my-board.excalidraw`. This is basename logic, NOT the old prefix-strip
+ * which left `my-board/my-board.excalidraw` intact at depth-2.
+ *
+ * Flat boards (`diagrams/recall.excalidraw`) have no sub-segment — the slug
+ * has exactly one `/`, so the last segment IS the plain leaf.
+ *
+ * For non-Excalidraw entries, we still strip the `<folder>/` prefix when the
+ * name is still the raw slug path (no custom frontmatter name), so the card
+ * reads "default" instead of "data-structures/default".
+ */
+export function leafName(entry: KnowledgeListEntry, folder: string | null): string {
+  if (!folder) return entry.name;
+  if (isExcalidrawSlug(entry.slug)) {
+    // Use the last path segment: `diagrams/my-board/my-board.excalidraw`
+    // → `my-board.excalidraw`. Works for both flat and nested layouts.
+    const lastSlash = entry.slug.lastIndexOf('/');
+    return lastSlash >= 0 ? entry.slug.slice(lastSlash + 1) : entry.slug;
+  }
+  // Non-Excalidraw: strip the `<folder>/` prefix when the name matches the slug path.
+  if (entry.name.startsWith(`${folder}/`)) return entry.name.slice(folder.length + 1);
   return entry.name;
 }
 

--- a/skill-packs/excalidraw/SKILL.md
+++ b/skill-packs/excalidraw/SKILL.md
@@ -251,8 +251,22 @@ per-title folder when you want to keep the board + generator + spec together cle
 - A 2 MB board with rich Text Elements and a tiny board with the same labels have the same
   recall surface. Scene size does not affect recall or snapshot token cost.
 
+### Where does a board go?
+
+| Board nature | Location | Indexed? |
+|---|---|---|
+| Canonical / source-of-truth (architecture, system flows, roadmaps, durable plans the agent should recall in future sessions) | `_dream_context/knowledge/diagrams/<title>/` | Yes — indexed, recalled |
+| Temporary / scratch / exploratory / in-progress | `inbox/` or `workspace/` (dark by location) | No — not indexed, will not pollute recall |
+
+**Decision rule**: "Will a future session need to know this? → `knowledge/diagrams/`. Throwaway/working? → `inbox/` or `workspace/`."
+
+Promote a board from inbox/workspace to `knowledge/diagrams/` only once it becomes canonical.
+
 ### Migration
 
-Flat boards in `knowledge/diagrams/` do NOT auto-migrate. Running `dreamcontext migrations run`
-detects them and records the count but moves nothing. To opt-in to the per-title folder layout,
-follow the agent task instruction exposed by migration 0.7.2.
+Flat boards in `knowledge/diagrams/` do NOT auto-migrate.
+
+- `dreamcontext migrations pending` — see pending migration task instructions (including 0.7.2 diagrams-folder-convention).
+- `dreamcontext migrations apply-diagrams` — opt-in: moves flat `knowledge/diagrams/*.excalidraw.md` boards into per-title folders AND rewrites all inbound [[wikilinks]] atomically. Safe to re-run. Do NOT hand-edit wikilinks manually.
+
+Only organize boards you confirm are canonical knowledge. Temp/scratch boards stay in inbox/workspace.

--- a/skill-packs/excalidraw/SKILL.md
+++ b/skill-packs/excalidraw/SKILL.md
@@ -200,3 +200,59 @@ node examples/style_board.js                                # JS API: card/conne
 Then open the resulting board in Obsidian (Excalidraw view) to confirm it renders.
 
 See `reference/format.md` for the exact `.excalidraw.md` anatomy reverse-engineered from this vault.
+
+---
+
+## Boards as first-class knowledge in dreamcontext
+
+When the project uses dreamcontext, Excalidraw boards belong in `_dream_context/knowledge/diagrams/`.
+They are indexed and recalled just like any knowledge file — but memory extracts ONLY the
+`## Text Elements` section (never the scene JSON).
+
+### Required frontmatter
+
+Every board MUST have `name:` and `description:`. Boards with no `## Text Elements` content rely
+entirely on description for recall — make it descriptive.
+
+```yaml
+---
+name: My Board Title
+description: One-sentence summary of what this board visualises.
+tags: [architecture, excalidraw]
+excalidraw-plugin: parsed
+---
+```
+
+### Folder convention (preferred)
+
+```
+_dream_context/knowledge/diagrams/
+├── my-board/
+│   ├── my-board.excalidraw.md   ← generated board (do NOT hand-edit scene JSON)
+│   ├── my-board.board.cjs       ← generator (dark sibling — excluded from index/recall)
+│   └── my-board.json            ← spec / source of truth (dark sibling — excluded)
+└── legacy-flat.excalidraw.md    ← flat layout still works; no forced migration
+```
+
+**Dark siblings**: any file inside a `diagrams/<title>/` folder that is NOT the board itself
+is automatically excluded from the index, recall corpus, snapshot, and dashboard list.
+This includes generator scripts (`.board.cjs`), spec JSON, and any helper `.md` notes.
+They are tooling — they do not pollute memory.
+
+**Flat layout** (`diagrams/<title>.excalidraw.md`) works without any migration. Use the
+per-title folder when you want to keep the board + generator + spec together cleanly.
+
+### Memory contract
+
+- Memory indexes: frontmatter (`name`, `description`, `tags`) + `## Text Elements` labels.
+- Memory never indexes: scene JSON, base64 blobs, element ids, `## Embedded Files` map.
+- The dashboard renderer receives the raw body (full scene JSON) via the detail API route —
+  rendering is unaffected by extraction.
+- A 2 MB board with rich Text Elements and a tiny board with the same labels have the same
+  recall surface. Scene size does not affect recall or snapshot token cost.
+
+### Migration
+
+Flat boards in `knowledge/diagrams/` do NOT auto-migrate. Running `dreamcontext migrations run`
+detects them and records the count but moves nothing. To opt-in to the per-title folder layout,
+follow the agent task instruction exposed by migration 0.7.2.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -431,6 +431,22 @@ Task insert sections: `why`, `user_stories`, `acceptance_criteria`, `constraints
 
 Standard tags: `architecture`, `api`, `frontend`, `backend`, `database`, `devops`, `security`, `testing`, `design`, `decisions`, `onboarding`, `domain`. Custom tags allowed.
 
+### Excalidraw boards in knowledge/diagrams/
+
+Excalidraw boards (`.excalidraw.md`) are first-class knowledge files. Two layouts are both supported:
+
+**Flat** (legacy, still works): `knowledge/diagrams/<title>.excalidraw.md`
+
+**Per-title folder** (preferred convention): `knowledge/diagrams/<title>/<title>.excalidraw.md`
+
+Rules:
+- **REQUIRED frontmatter**: every board MUST have `name:` and `description:` fields. Boards with no `## Text Elements` section fall back to description-only recall — make it descriptive.
+- **Do NOT hand-edit scene JSON.** The `.excalidraw.md` file is generated output. Build a spec and run the generator (`.board.cjs`). Edit the spec, not the board.
+- **Spec is the source of truth.** If the spec and the board ever disagree, the spec wins. Commit both.
+- **Dark siblings**: all files inside a `knowledge/diagrams/<title>/` folder that are NOT the board itself (generator scripts `.board.cjs`, spec `.json`, helper `.md`) are excluded from the index, recall corpus, snapshot, and dashboard. They are tooling artifacts — they do NOT surface in memory.
+- **Memory indexes only frontmatter + ## Text Elements**: scene JSON, base64, and element ids are stripped before indexing. A 2 MB board with rich Text Elements is as searchable as a tiny board. The dashboard renderer still receives the raw body (with full scene JSON) via the detail API route.
+- **Migration is opt-in**: flat boards stay flat unless you explicitly ask for reorganization. Running `dreamcontext migrations run` records detected boards but moves nothing.
+
 ---
 
 ## Memory Recall (BM25)
@@ -475,6 +491,13 @@ _dream_context/
 |   +-- data-structures/              <- Per-product schemas (recall-indexed knowledge)
 |   |   +-- default.md                <-   single-product fallback
 |   |   +-- <product>.md              <-   one per product if monorepo
+|   +-- diagrams/                     <- Excalidraw boards (flat or per-title folder)
+|   |   +-- <title>.excalidraw.md     <-   flat layout (still works; legacy OK)
+|   |   +-- <title>/                  <-   preferred: per-title folder
+|   |   |   +-- <title>.excalidraw.md <-     generated board (do NOT hand-edit scene JSON)
+|   |   |   +-- <title>.board.cjs     <-     generator script (dark sibling — excluded from index/recall)
+|   |   |   +-- <title>.json          <-     spec/source of truth (dark sibling — excluded)
+|   |   |   +-- notes.md              <-     any helper .md (dark sibling — excluded)
 |   +-- products/<product>.md         <- Per-product knowledge (multi-product)
 +-- state/
 |   +-- <task>.md                     <- Active tasks (frontmatter may include product:)

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -445,7 +445,18 @@ Rules:
 - **Spec is the source of truth.** If the spec and the board ever disagree, the spec wins. Commit both.
 - **Dark siblings**: all files inside a `knowledge/diagrams/<title>/` folder that are NOT the board itself (generator scripts `.board.cjs`, spec `.json`, helper `.md`) are excluded from the index, recall corpus, snapshot, and dashboard. They are tooling artifacts — they do NOT surface in memory.
 - **Memory indexes only frontmatter + ## Text Elements**: scene JSON, base64, and element ids are stripped before indexing. A 2 MB board with rich Text Elements is as searchable as a tiny board. The dashboard renderer still receives the raw body (with full scene JSON) via the detail API route.
-- **Migration is opt-in**: flat boards stay flat unless you explicitly ask for reorganization. Running `dreamcontext migrations run` records detected boards but moves nothing.
+- **Migration is opt-in**: flat boards stay flat unless you explicitly ask for reorganization. Use `dreamcontext migrations pending` to see pending migration tasks; use `dreamcontext migrations apply-diagrams` to opt-in to organizing flat boards into per-title folders.
+
+#### Where does a board go?
+
+| Board nature | Location | Indexed? |
+|---|---|---|
+| Canonical / source-of-truth (architecture, system flows, roadmaps, durable plans the agent should recall in future sessions) | `knowledge/diagrams/<title>/` | Yes — indexed, recalled |
+| Temporary / scratch / exploratory / in-progress | `inbox/` or `workspace/` (dark by location) | No — not indexed, will not pollute recall |
+
+**Decision rule**: "Will a future session need to know this? → `knowledge/diagrams/`. Throwaway/working? → `inbox/` or `workspace/`."
+
+Promote a board from `inbox/workspace` to `knowledge/diagrams/` only once it becomes canonical. Use `dreamcontext migrations apply-diagrams` to move flat boards + rewrite inbound [[wikilinks]] atomically — do NOT hand-edit wikilinks.
 
 ---
 

--- a/src/cli/commands/migrations.ts
+++ b/src/cli/commands/migrations.ts
@@ -3,9 +3,10 @@ import { ensureContextRoot } from '../../lib/context-path.js';
 import { pendingMigrations } from '../../migrations/index.js';
 import { readSetupConfig } from '../../lib/setup-config.js';
 import { appendLedger } from '../../lib/migration-ledger.js';
+import { migrateDiagramsToFolders } from '../../lib/diagrams-migration.js';
 import { dreamcontextVersion } from '../../lib/manifest.js';
 import { dirname } from 'node:path';
-import { success, error, info } from '../../lib/format.js';
+import { success, error, info, warn } from '../../lib/format.js';
 import type { LedgerEntry } from '../../lib/migration-ledger.js';
 
 /**
@@ -44,6 +45,76 @@ export function registerMigrationsCommand(program: Command): void {
         console.log(
           `Record completion with: dreamcontext migrations record --version ${m.version} --step ${m.agentTask!.id} --executor agent --summary "<what you did>"`,
         );
+      }
+    });
+
+  // --- apply-diagrams ---
+  migrations
+    .command('apply-diagrams')
+    .description(
+      'Organize flat knowledge/diagrams/*.excalidraw.md boards into per-title folders. ' +
+      'Moves board + same-basename generator/spec files, rewrites inbound [[wikilinks]] atomically. ' +
+      'Opt-in: only organize boards you confirm are canonical knowledge.',
+    )
+    .action(() => {
+      const root = ensureContextRoot();
+
+      const result = migrateDiagramsToFolders(root);
+
+      const totalMoved = result.moved.length;
+      const totalSkipped = result.skipped.length;
+      const totalAmbiguous = result.ambiguous.length;
+
+      if (totalMoved === 0 && totalSkipped === 0 && totalAmbiguous === 0) {
+        info('nothing to organize — no flat boards found in knowledge/diagrams/');
+        return;
+      }
+
+      if (result.moved.length > 0) {
+        console.log('\nMoved into per-title folders:');
+        for (const slug of result.moved) {
+          console.log(`  diagrams/${slug}.excalidraw.md  →  diagrams/${slug}/${slug}.excalidraw.md`);
+        }
+      }
+
+      if (result.skipped.length > 0) {
+        console.log('\nAlready in per-title folder (skipped):');
+        for (const slug of result.skipped) {
+          console.log(`  diagrams/${slug}/${slug}.excalidraw.md`);
+        }
+      }
+
+      if (result.ambiguous.length > 0) {
+        console.log('\nLeft in place (ambiguous — check manually):');
+        for (const item of result.ambiguous) {
+          console.log(`  ${item}`);
+        }
+      }
+
+      if (totalMoved === 0) {
+        info(`nothing moved (${totalSkipped} already foldered, ${totalAmbiguous} ambiguous)`);
+        return;
+      }
+
+      // Record a ledger entry for the work done.
+      const movedPaths = result.moved.map(
+        (slug) => `knowledge/diagrams/${slug}/${slug}.excalidraw.md`,
+      );
+      const entry: LedgerEntry = {
+        version: '0.7.2',
+        step: 'diagrams-folder-convention',
+        executor: 'agent',
+        timestamp: new Date().toISOString(),
+        filesTouched: movedPaths,
+        summary: `Organized ${totalMoved} flat board(s) into per-title folders: ${result.moved.join(', ')}`,
+      };
+      appendLedger(root, entry);
+
+      success(
+        `Moved ${totalMoved} board(s) into per-title folders. Inbound [[wikilinks]] rewritten atomically. Ledger entry recorded (0.7.2/diagrams-folder-convention).`,
+      );
+      if (totalAmbiguous > 0) {
+        warn(`${totalAmbiguous} board(s) left in place due to ambiguous siblings — review manually.`);
       }
     });
 

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -912,6 +912,12 @@ export function generateSnapshot(): string {
 
     // 9.5 Warm Knowledge (recently relevant, first paragraph only)
     if (warmEntries.length > 0) {
+      // Option A (maintainer decision): no pinned-preview inline feature built.
+      // entry.content is already extracted text (not scene JSON) for Excalidraw
+      // boards — see knowledge-index.ts. So extractFirstParagraph(entry.content)
+      // here and the token estimate are always JSON-free and size-independent.
+      // A 2MB-scene board and a tiny-scene board with identical Text Elements
+      // yield equal token estimates. No functional change needed.
       const renderWarm = (cap: number): string[] => {
         const out: string[] = ['## Warm Knowledge (Recently Relevant)\n'];
         for (const entry of warmEntries.slice(0, cap)) {

--- a/src/lib/diagrams-migration.ts
+++ b/src/lib/diagrams-migration.ts
@@ -1,0 +1,158 @@
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { join, basename, extname } from 'node:path';
+import fg from 'fast-glob';
+import { rewriteWikilinks, WikilinkRemap } from './wikilink-rewrite.js';
+import { EXCALIDRAW_SUFFIX } from './excalidraw-text.js';
+
+/** Extensions that unambiguously belong to the same board pipeline. */
+const GENERATOR_EXTS = new Set(['.board.cjs', '.board.js', '.board.py', '.json']);
+
+/**
+ * Check whether `filename` is a generator/spec file that belongs to the same
+ * board as `boardBase` (the base name without `.excalidraw.md`).
+ *
+ * A file is "unambiguously same-basename" when it is named `<boardBase>.*`
+ * and has one of the recognised generator extensions. This avoids moving
+ * unrelated `.json` or `.md` files that happen to live in the same directory.
+ */
+function isSameBasenameSibling(filename: string, boardBase: string): boolean {
+  for (const ext of GENERATOR_EXTS) {
+    if (filename === `${boardBase}${ext}`) return true;
+  }
+  return false;
+}
+
+export interface DiagramsMoveResult {
+  /** Board slugs (relative to knowledge/diagrams/) that were moved. */
+  moved: string[];
+  /** Board slugs already in a per-title subfolder — left untouched. */
+  skipped: string[];
+  /** Board slugs where moving was unsafe (ambiguous sibling names). */
+  ambiguous: string[];
+}
+
+/**
+ * Move flat `knowledge/diagrams/*.excalidraw.md` boards into per-title folders:
+ *   `knowledge/diagrams/<title>/<title>.excalidraw.md`
+ *
+ * For each board that is moved:
+ * 1. Creates `knowledge/diagrams/<title>/`.
+ * 2. Moves `<title>.excalidraw.md` (and any unambiguous same-basename
+ *    generator/spec files) into the subfolder.
+ * 3. Calls `rewriteWikilinks` atomically (old slug → new slug) so inbound
+ *    [[wikilinks]] in any `.md` file under `contextRoot` are updated.
+ *
+ * A board is skipped when it is already inside a subfolder (not flat).
+ *
+ * This function is exposed ONLY via the opt-in agentTask on migration 0.7.2.
+ * The migration CODE step (see src/migrations/0.7.2.ts) does NOT call this —
+ * it only detects flat boards and records `detected` so the user can decide.
+ */
+export function migrateDiagramsToFolders(
+  contextRoot: string,
+): DiagramsMoveResult {
+  const diagramsDir = join(contextRoot, 'knowledge', 'diagrams');
+  const result: DiagramsMoveResult = { moved: [], skipped: [], ambiguous: [] };
+
+  if (!existsSync(diagramsDir)) return result;
+
+  // Find all boards: only look one level deep (flat) — nested boards are skipped.
+  const flatFiles = fg.sync('*.excalidraw.md', {
+    cwd: diagramsDir,
+    absolute: false,
+  });
+
+  // Find already-nested boards to populate skipped list.
+  const nestedFiles = fg.sync('*/*.excalidraw.md', {
+    cwd: diagramsDir,
+    absolute: false,
+  });
+
+  for (const nested of nestedFiles) {
+    result.skipped.push(nested.replace(EXCALIDRAW_SUFFIX, ''));
+  }
+
+  for (const filename of flatFiles) {
+    const boardBase = filename.slice(0, -EXCALIDRAW_SUFFIX.length);
+    const srcBoard = join(diagramsDir, filename);
+    const destDir = join(diagramsDir, boardBase);
+    const destBoard = join(destDir, filename);
+
+    // Old slug: `diagrams/<boardBase>.excalidraw` (relative to knowledge/)
+    // New slug: `diagrams/<boardBase>/<boardBase>.excalidraw`
+    const oldSlug = `diagrams/${boardBase}.excalidraw`;
+    const newSlug = `diagrams/${boardBase}/${boardBase}.excalidraw`;
+
+    // Collect sibling files to move alongside the board.
+    let siblings: string[] = [];
+    try {
+      const allInDir = readdirSync(diagramsDir).filter(
+        (f) => statSync(join(diagramsDir, f)).isFile(),
+      );
+      siblings = allInDir.filter(
+        (f) => f !== filename && isSameBasenameSibling(f, boardBase),
+      );
+    } catch {
+      // If we can't read the directory, skip this board.
+      result.ambiguous.push(boardBase);
+      continue;
+    }
+
+    // Create the destination folder.
+    try {
+      mkdirSync(destDir, { recursive: true });
+    } catch {
+      result.ambiguous.push(boardBase);
+      continue;
+    }
+
+    // Move the board file.
+    try {
+      renameSync(srcBoard, destBoard);
+    } catch {
+      result.ambiguous.push(boardBase);
+      continue;
+    }
+
+    // Move unambiguous generator/spec siblings.
+    for (const sib of siblings) {
+      try {
+        renameSync(join(diagramsDir, sib), join(destDir, sib));
+      } catch {
+        // If a sibling fails, we already moved the board — report but continue.
+        result.ambiguous.push(`${boardBase} (sibling: ${sib})`);
+      }
+    }
+
+    // Rewrite inbound [[wikilinks]] atomically after each move.
+    const remaps: WikilinkRemap[] = [{ from: oldSlug, to: newSlug }];
+    rewriteWikilinks(contextRoot, remaps);
+
+    result.moved.push(boardBase);
+  }
+
+  return result;
+}
+
+/**
+ * Detect flat `knowledge/diagrams/*.excalidraw.md` boards WITHOUT moving them.
+ * Returns the list of flat board slugs found. Used by the migration CODE step
+ * to record `detected` state safely.
+ */
+export function detectFlatDiagramBoards(contextRoot: string): string[] {
+  const diagramsDir = join(contextRoot, 'knowledge', 'diagrams');
+  if (!existsSync(diagramsDir)) return [];
+
+  const flatFiles = fg.sync('*.excalidraw.md', {
+    cwd: diagramsDir,
+    absolute: false,
+  });
+
+  return flatFiles.map((f) => f.slice(0, -EXCALIDRAW_SUFFIX.length));
+}

--- a/src/lib/diagrams-migration.ts
+++ b/src/lib/diagrams-migration.ts
@@ -5,7 +5,7 @@ import {
   readdirSync,
   statSync,
 } from 'node:fs';
-import { join, basename, extname } from 'node:path';
+import { join, basename, extname, resolve, sep } from 'node:path';
 import fg from 'fast-glob';
 import { rewriteWikilinks, WikilinkRemap } from './wikilink-rewrite.js';
 import { EXCALIDRAW_SUFFIX } from './excalidraw-text.js';
@@ -78,11 +78,29 @@ export function migrateDiagramsToFolders(
     result.skipped.push(nested.replace(EXCALIDRAW_SUFFIX, ''));
   }
 
+  const diagramsDirResolved = resolve(diagramsDir);
+
   for (const filename of flatFiles) {
     const boardBase = filename.slice(0, -EXCALIDRAW_SUFFIX.length);
     const srcBoard = join(diagramsDir, filename);
     const destDir = join(diagramsDir, boardBase);
     const destBoard = join(destDir, filename);
+
+    // Containment guard: boardBase derives from a filename, so it should be a
+    // single safe path segment. Reject anything that could escape diagramsDir
+    // (path separators, `..`, or a destDir that resolves outside the tree).
+    if (
+      boardBase === '' ||
+      boardBase === '.' ||
+      boardBase === '..' ||
+      boardBase.includes('/') ||
+      boardBase.includes('\\') ||
+      resolve(destDir) !== join(diagramsDirResolved, boardBase) ||
+      !resolve(destDir).startsWith(diagramsDirResolved + sep)
+    ) {
+      result.ambiguous.push(boardBase);
+      continue;
+    }
 
     // Old slug: `diagrams/<boardBase>.excalidraw` (relative to knowledge/)
     // New slug: `diagrams/<boardBase>/<boardBase>.excalidraw`
@@ -112,6 +130,16 @@ export function migrateDiagramsToFolders(
       continue;
     }
 
+    // Rewrite inbound [[wikilinks]] BEFORE moving the board. Rewriting is
+    // non-destructive (the board is still at its old path), so if the process
+    // dies between the rewrite and the move, the board is STILL flat — a re-run
+    // detects it, the rewrite is a no-op (links already point to the new slug),
+    // and the move completes. Doing the move first would, on a crash, leave the
+    // board relocated with every [[old-slug]] permanently dangling (the re-run
+    // skips it because it is no longer flat).
+    const remaps: WikilinkRemap[] = [{ from: oldSlug, to: newSlug }];
+    rewriteWikilinks(contextRoot, remaps);
+
     // Move the board file.
     try {
       renameSync(srcBoard, destBoard);
@@ -129,10 +157,6 @@ export function migrateDiagramsToFolders(
         result.ambiguous.push(`${boardBase} (sibling: ${sib})`);
       }
     }
-
-    // Rewrite inbound [[wikilinks]] atomically after each move.
-    const remaps: WikilinkRemap[] = [{ from: oldSlug, to: newSlug }];
-    rewriteWikilinks(contextRoot, remaps);
 
     result.moved.push(boardBase);
   }

--- a/src/lib/excalidraw-text.ts
+++ b/src/lib/excalidraw-text.ts
@@ -1,0 +1,166 @@
+import { dirname } from 'node:path';
+
+// ─── Excalidraw text extraction ───────────────────────────────────────────────
+//
+// Obsidian Excalidraw boards (`*.excalidraw.md`) store the scene in a
+// `## Drawing` fenced block. Memory should index ONLY the human-readable
+// ## Text Elements section (labels), never the scene JSON.
+//
+// Cross-ref: dashboard/src/lib/excalidraw.ts:8 defines DRAWING_BLOCK for
+// rendering; the regex below is replicated here (src/ cannot import
+// dashboard/src — separate tsconfig, rootDir:src forbids it).
+
+/** Suffix used by all Obsidian Excalidraw boards. */
+export const EXCALIDRAW_SUFFIX = '.excalidraw.md';
+
+/**
+ * Maximum number of lines to keep from extracted text.
+ * Boards can be very large; cap prevents snapshot bloat.
+ */
+export const EXCALIDRAW_MAX_LINES = 200;
+
+/**
+ * Regex that matches the `## Drawing` fenced block (both `json` and
+ * `compressed-json` variants). Defense-in-depth: even if the keep-only-
+ * Text-Elements pass misses the block, stripping it here prevents scene
+ * JSON from leaking into the corpus.
+ *
+ * Replicated from dashboard/src/lib/excalidraw.ts:8 (cross-ref comment
+ * there). Do NOT import dashboard/src from src/ — separate build roots.
+ */
+const DRAWING_BLOCK =
+  /##\s*Drawing\s*```(?:compressed-json|json)[\s\S]*?```/gm;
+
+/**
+ * True when `filePath` is an Excalidraw board (ends with `.excalidraw.md`).
+ */
+export function isExcalidrawPath(filePath: string): boolean {
+  return filePath.endsWith(EXCALIDRAW_SUFFIX);
+}
+
+/**
+ * Extract only the human-readable text from an Excalidraw board body
+ * (frontmatter already stripped by readFrontmatter).
+ *
+ * Strategy:
+ * 1. Strip the `## Drawing` fenced block (defense-in-depth).
+ * 2. Find the `## Text Elements` section using a JS-valid /m regex with a
+ *    lookahead for the next `##` or `%%` section terminator (NO `\Z` —
+ *    JavaScript has no `\Z`).
+ * 3. If no `## Text Elements` section is found, return '' (frontmatter-only
+ *    boards have zero text surface; callers fall back to description).
+ * 4. Within the section: remove `## Embedded Files` map lines, the Obsidian
+ *    banner `==⚠...==`, and trailing `^blockref` id suffixes per line.
+ * 5. Collapse blank runs, trim, slice to EXCALIDRAW_MAX_LINES.
+ *
+ * Returns '' on any error (try/catch). NEVER returns raw body.
+ */
+export function extractExcalidrawText(rawBody: string): string {
+  try {
+    // Step 1: strip the Drawing fenced block (both json + compressed-json).
+    // This is defense-in-depth: the keep-only-Text-Elements step below
+    // already discards the Drawing section, but a malformed board with an
+    // unclosed fence could otherwise leak JSON into the result.
+    const noDrawing = rawBody.replace(DRAWING_BLOCK, '');
+
+    // Step 2: isolate the ## Text Elements section using split-on-headings.
+    // Approach: split the body into sections at every line that starts with
+    // `##` or `%%`. Find the `## Text Elements` section and take its content.
+    // This avoids any reliance on `\Z` (JS has no `\Z`) or the `$` anchor
+    // under `/m` mode (which matches end-of-line and would stop a lazy `[\s\S]+?`
+    // at the first blank line inside the section).
+    const sectionLines = noDrawing.split('\n');
+    let inTextElements = false;
+    const sectionContent: string[] = [];
+
+    for (const line of sectionLines) {
+      if (/^##\s/.test(line) || /^%%/.test(line)) {
+        if (/^##\s+Text\s+Elements/i.test(line)) {
+          // Found the section header — start collecting
+          inTextElements = true;
+          continue; // skip the header line itself
+        } else if (inTextElements) {
+          // Hit the next section header — stop collecting
+          break;
+        }
+        // Some other heading before Text Elements — ignore
+        continue;
+      }
+      if (inTextElements) {
+        sectionContent.push(line);
+      }
+    }
+
+    if (!inTextElements) {
+      // No ## Text Elements section found — fall back to '' (frontmatter-only).
+      return '';
+    }
+
+    let text = sectionContent.join('\n');
+
+    // Step 3: strip the Obsidian banner ==⚠...==
+    text = text.replace(/==⚠[^=]*==\s*/g, '');
+
+    // Step 4: process line by line — strip ^blockref ids and filter empties.
+    const lines = text.split('\n');
+    const kept: string[] = [];
+    for (const line of lines) {
+      // Strip trailing ^blockref suffix (e.g. "Session start ^6GYBW5hX")
+      const cleaned = line.replace(/\s*\^[A-Za-z0-9_-]{4,}\s*$/, '').trim();
+      if (cleaned.length > 0) {
+        kept.push(cleaned);
+      }
+    }
+
+    // Step 5: collapse consecutive blank runs (shouldn't be any after the
+    // filter above, but be defensive), trim, slice to max lines.
+    const result = kept.slice(0, EXCALIDRAW_MAX_LINES).join('\n').trim();
+    return result;
+  } catch {
+    return '';
+  }
+}
+
+// ─── Dark-sibling helpers ─────────────────────────────────────────────────────
+//
+// Inside `knowledge/diagrams/<title>/`, the board file is the only thing that
+// should surface in index/recall/snapshot. All sibling files (generator
+// scripts, spec JSON, helper notes.md) are "dark" — they exist for tooling but
+// must NOT enter the memory corpus.
+//
+// Design: O(1) per file after a single O(n) pass over the full file list.
+// No fs calls per file — only dirname().
+
+/**
+ * Compute the set of directory paths that directly contain at least one
+ * `*.excalidraw.md` file. Called ONCE per glob result, O(n) total.
+ *
+ * `allFiles`: absolute paths from fg.sync('**‌/*.md').
+ */
+export function diagramFolderDirs(allFiles: string[]): Set<string> {
+  const dirs = new Set<string>();
+  for (const f of allFiles) {
+    if (isExcalidrawPath(f)) {
+      dirs.add(dirname(f));
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Returns true when `filePath` is a non-board sibling inside a diagram folder.
+ *
+ * Conditions:
+ * - The file's directory is in `dirsSet` (i.e. it sits next to a board).
+ * - The file itself is NOT an Excalidraw board.
+ *
+ * This excludes sibling .md beside a board, while never excluding the boards
+ * themselves. Folders without a board are unaffected. Works for nested paths
+ * like `knowledge/products/<name>/` boards.
+ */
+export function isDarkDiagramSibling(
+  filePath: string,
+  dirsSet: Set<string>,
+): boolean {
+  return dirsSet.has(dirname(filePath)) && !isExcalidrawPath(filePath);
+}

--- a/src/lib/knowledge-index.ts
+++ b/src/lib/knowledge-index.ts
@@ -2,6 +2,12 @@ import { existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import fg from 'fast-glob';
 import { readFrontmatter } from './frontmatter.js';
+import {
+  isExcalidrawPath,
+  extractExcalidrawText,
+  diagramFolderDirs,
+  isDarkDiagramSibling,
+} from './excalidraw-text.js';
 
 // ─── Standard Tags ─────────────────────────────────────────────────────────
 
@@ -55,12 +61,26 @@ export function buildKnowledgeIndex(contextRoot: string): KnowledgeEntry[] {
   if (!existsSync(knowledgeDir)) return [];
 
   const files = fg.sync('**/*.md', { cwd: knowledgeDir, absolute: true });
+  // Compute dark-sibling set once (O(n)) — non-board .md files inside a
+  // diagram folder (knowledge/diagrams/<title>/) are excluded from the index.
+  const boardDirs = diagramFolderDirs(files);
   const entries: KnowledgeEntry[] = [];
 
   for (const file of files) {
+    // Dark siblings: helper/notes .md files that live beside a board.
+    // They are tooling artifacts, not recall surfaces.
+    if (isDarkDiagramSibling(file, boardDirs)) continue;
+
     try {
       const { data, content } = readFrontmatter(file);
       const slug = relative(knowledgeDir, file).replace(/\\/g, '/').replace(/\.md$/, '');
+      // For Excalidraw boards: store only extracted text (frontmatter + Text
+      // Elements labels) — never scene JSON/base64. This keeps entry.content
+      // clean for list route, snapshot warm path, and pinned preview.
+      // detail=raw (knowledge.ts serves raw body for the renderer).
+      const indexedContent = isExcalidrawPath(file)
+        ? extractExcalidrawText(content)
+        : content.trim();
       const entry: KnowledgeEntry = {
         slug,
         name: String(data.name ?? slug),
@@ -68,7 +88,7 @@ export function buildKnowledgeIndex(contextRoot: string): KnowledgeEntry[] {
         tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
         date: String(data.date ?? ''),
         pinned: data.pinned === true,
-        content: content.trim(),
+        content: indexedContent,
       };
       if (typeof data.pinned_preview_lines === 'number' && data.pinned_preview_lines > 0) {
         entry.pinnedPreviewLines = data.pinned_preview_lines;

--- a/src/lib/recall.ts
+++ b/src/lib/recall.ts
@@ -4,6 +4,12 @@ import fg from 'fast-glob';
 import { readFrontmatter } from './frontmatter.js';
 import { expandQueryTerms } from './recall-synonyms.js';
 import { loadDigestDocs } from './session-digest.js';
+import {
+  isExcalidrawPath,
+  extractExcalidrawText,
+  diagramFolderDirs,
+  isDarkDiagramSibling,
+} from './excalidraw-text.js';
 
 // 'skill' docs are produced ONLY by loadSkillDocs (called directly by the hook);
 // intentionally excluded from buildCorpus defaults to avoid polluting haikuRecall.
@@ -289,15 +295,30 @@ function loadMarkdownDocs(
   if (!existsSync(dir)) return [];
   // B1: recurse into nested dirs (e.g. knowledge/products/<name>/…).
   const files = fg.sync('**/*.md', { cwd: dir, absolute: true });
+  // Compute dark-sibling set once for the whole directory scan.
+  // Dark siblings: non-board .md files inside a diagram folder that should
+  // not enter the BM25 corpus (generator scripts, spec notes, etc.).
+  const boardDirs = diagramFolderDirs(files);
   const out: CorpusDoc[] = [];
   for (const file of files) {
+    // Exclude dark siblings — tooling artifacts beside a board.
+    if (isDarkDiagramSibling(file, boardDirs)) continue;
+
     try {
       const { data, content } = readFrontmatter(file);
       const slug = basename(file, '.md');
       const title = String(data.name ?? data.title ?? slug);
       const description = String(data.description ?? data.summary ?? '');
       const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
-      const body = content.trim();
+      // For Excalidraw boards: extract only Text Elements text for the BM25
+      // corpus (body). This covers the BM25 scoring path (buildFields tokenizes
+      // body) AND transitively the reflection corpus. The raw scene JSON is
+      // never tokenized, so JSON-only terms never score.
+      // BOTH this path (BM25 corpus) AND knowledge-index.ts (entry.content)
+      // apply extraction — neither alone closes all memory surfaces.
+      const body = isExcalidrawPath(file)
+        ? extractExcalidrawText(content)
+        : content.trim();
       const relPath = file.replace(contextRoot + '/', '');
       const fields = buildFields({ slug, title, description, tags, body });
       out.push({

--- a/src/migrations/0.7.2.ts
+++ b/src/migrations/0.7.2.ts
@@ -27,7 +27,7 @@ export const migration072: Migration = {
       const summary =
         flatBoards.length > 0
           ? `Detected ${flatBoards.length} flat diagram board(s) in knowledge/diagrams/: ${flatBoards.join(', ')}. ` +
-            'No files moved. Use the agentTask to opt-in to per-title folder organization.'
+            'No files moved. To opt-in: run `dreamcontext migrations apply-diagrams` after confirming which boards are canonical knowledge.'
           : 'No flat diagram boards found in knowledge/diagrams/ — nothing to do.';
       return {
         step: 'detect-flat-diagram-boards',
@@ -41,11 +41,19 @@ export const migration072: Migration = {
     id: 'diagrams-folder-convention',
     instruction:
       'Opt-in: organize Excalidraw boards into knowledge/diagrams/<title>/ per-title folders. ' +
-      'For each flat knowledge/diagrams/<title>.excalidraw.md board: ' +
-      '(1) create knowledge/diagrams/<title>/, ' +
-      '(2) move the board + any unambiguous same-basename generator/spec files (.board.cjs/.board.js/.board.py/.json) into it, ' +
-      '(3) call rewriteWikilinks atomically after each move (old slug diagrams/<title>.excalidraw → new slug diagrams/<title>/<title>.excalidraw) so all inbound [[wikilinks]] in .md files under contextRoot stay valid. ' +
+      'STEP 1 — Behavioral judgment (do this BEFORE running any command): ' +
+      'Only boards that are canonical, durable knowledge (architecture diagrams, system flows, roadmaps, ' +
+      'plans the agent should recall in future sessions) belong in knowledge/diagrams/. ' +
+      'Temporary / scratch / exploratory / in-progress sketches belong in inbox/ or workspace/ ' +
+      '(dark by location — NOT indexed, will not pollute recall). ' +
+      'Decision rule: "Will a future session need to know this? → keep in knowledge. Throwaway/working? → inbox/workspace." ' +
+      'Do NOT pull temp/scratch boards into knowledge/diagrams/. ' +
+      'STEP 2 — For boards confirmed canonical, run: dreamcontext migrations apply-diagrams ' +
+      '(this command moves board+generator+spec into knowledge/diagrams/<title>/ AND rewrites all ' +
+      'inbound [[wikilinks]] atomically — do NOT hand-edit wikilinks manually). ' +
       'Never run generator scripts. Never edit scene JSON. ' +
-      'Flat boards already index and recall correctly via suffix detection — only adopt this convention when the user explicitly requests it.',
+      'Flat boards already index and recall correctly via suffix detection — only adopt this convention when the user explicitly requests it. ' +
+      'STEP 3 — Verify the ledger entry was recorded (the apply-diagrams command records it automatically). ' +
+      'Use dreamcontext migrations pending to see this task; run dreamcontext migrations apply-diagrams to opt-in to organizing flat boards.',
   },
 };

--- a/src/migrations/0.7.2.ts
+++ b/src/migrations/0.7.2.ts
@@ -1,0 +1,51 @@
+import { detectFlatDiagramBoards } from '../lib/diagrams-migration.js';
+import type { Migration, MigrationStepResult } from './types.js';
+
+/**
+ * Migration 0.7.2: Excalidraw knowledge boards — diagrams folder convention.
+ *
+ * CODE step: SAFE DETECTION ONLY.
+ * Scans knowledge/diagrams/ for flat *.excalidraw.md boards and records how
+ * many were detected. Does NOT move any files — respects #20's explicit
+ * out-of-scope decision: "auto-migrating flat layouts into per-title folders
+ * silently breaks slugs/wikilinks/access-records on every update/sleep."
+ *
+ * The actual move+rewriteWikilinks logic lives in src/lib/diagrams-migration.ts
+ * and is exposed ONLY via the agentTask below (opt-in, user judgment required).
+ *
+ * agentTask: MigrationAgentTask — informs the user that flat boards exist and
+ * explains the opt-in reorganization available. The user decides when/whether
+ * to adopt the per-title folder convention.
+ */
+export const migration072: Migration = {
+  version: '0.7.2',
+  steps: [
+    // Step: detect flat boards, record count — MOVE NOTHING.
+    (root: string): MigrationStepResult => {
+      const flatBoards = detectFlatDiagramBoards(root);
+      const detected = true; // always "detected" — we never move in the code step
+      const summary =
+        flatBoards.length > 0
+          ? `Detected ${flatBoards.length} flat diagram board(s) in knowledge/diagrams/: ${flatBoards.join(', ')}. ` +
+            'No files moved. Use the agentTask to opt-in to per-title folder organization.'
+          : 'No flat diagram boards found in knowledge/diagrams/ — nothing to do.';
+      return {
+        step: 'detect-flat-diagram-boards',
+        filesTouched: [], // code step moves nothing
+        summary,
+        detected,
+      };
+    },
+  ],
+  agentTask: {
+    id: 'diagrams-folder-convention',
+    instruction:
+      'Opt-in: organize Excalidraw boards into knowledge/diagrams/<title>/ per-title folders. ' +
+      'For each flat knowledge/diagrams/<title>.excalidraw.md board: ' +
+      '(1) create knowledge/diagrams/<title>/, ' +
+      '(2) move the board + any unambiguous same-basename generator/spec files (.board.cjs/.board.js/.board.py/.json) into it, ' +
+      '(3) call rewriteWikilinks atomically after each move (old slug diagrams/<title>.excalidraw → new slug diagrams/<title>/<title>.excalidraw) so all inbound [[wikilinks]] in .md files under contextRoot stay valid. ' +
+      'Never run generator scripts. Never edit scene JSON. ' +
+      'Flat boards already index and recall correctly via suffix detection — only adopt this convention when the user explicitly requests it.',
+  },
+};

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import { compareVersions } from '../lib/version-check.js';
 import { migration070 } from './0.7.0.js';
+import { migration072 } from './0.7.2.js';
 import type { Migration } from './types.js';
 
 /**
@@ -8,7 +9,7 @@ import type { Migration } from './types.js';
  * export its Migration object, and push it here.
  * See CONTRIBUTING.md §"Shipping a migration" for the full checklist.
  */
-export const REGISTRY: Migration[] = [migration070];
+export const REGISTRY: Migration[] = [migration070, migration072];
 
 /**
  * Return all migrations whose version falls in the half-open range (from, to].

--- a/src/server/routes/knowledge.ts
+++ b/src/server/routes/knowledge.ts
@@ -43,6 +43,10 @@ export async function handleKnowledgeGet(
     return;
   }
 
+  // Invariant: detail route returns RAW body (frontmatter stripped, scene JSON
+  // intact). The ExcalidrawPreview renderer (dashboard) needs the full Drawing
+  // block to parse the scene. Memory extraction (extracted text, not JSON)
+  // happens only in knowledge-index.ts (entry.content) and recall.ts (body).
   const { data, content } = readFrontmatter<Record<string, unknown>>(filePath);
   sendJson(res, 200, {
     entry: {

--- a/tests/unit/excalidraw-knowledge.test.ts
+++ b/tests/unit/excalidraw-knowledge.test.ts
@@ -26,7 +26,9 @@ import {
 import { buildKnowledgeIndex } from '../../src/lib/knowledge-index.js';
 import { buildCorpus, bm25Search } from '../../src/lib/recall.js';
 import { REGISTRY, pendingMigrations } from '../../src/migrations/index.js';
-import { detectFlatDiagramBoards } from '../../src/lib/diagrams-migration.js';
+import { detectFlatDiagramBoards, migrateDiagramsToFolders } from '../../src/lib/diagrams-migration.js';
+import { readLedger } from '../../src/lib/migration-ledger.js';
+import { existsSync, readFileSync as fsReadFileSync } from 'node:fs';
 
 // ─── Dashboard leafName pure logic (inlined to avoid React context) ───────────
 //
@@ -614,14 +616,19 @@ describe('diagrams-migration', () => {
     expect(stillFlat).toHaveLength(2);
   });
 
-  it('agentTask present with move+wikilink contract', () => {
+  it('agentTask present with apply-diagrams safe-command contract', () => {
     const migration072 = REGISTRY.find((m) => m.version === '0.7.2');
     expect(migration072).toBeDefined();
     expect(migration072!.agentTask).toBeDefined();
     expect(migration072!.agentTask!.id).toBe('diagrams-folder-convention');
-    // Instruction must mention rewriteWikilinks and the move contract
-    expect(migration072!.agentTask!.instruction).toContain('rewriteWikilinks');
+    // Instruction must point at the safe CLI command (not hand-editing wikilinks)
+    expect(migration072!.agentTask!.instruction).toContain('apply-diagrams');
+    // Instruction must mention the behavioral judgment step
+    expect(migration072!.agentTask!.instruction).toContain('canonical');
+    // Instruction must mention wikilinks are handled atomically by the command
     expect(migration072!.agentTask!.instruction).toContain('wikilinks');
+    // Instruction must NOT say to call rewriteWikilinks directly
+    expect(migration072!.agentTask!.instruction).not.toContain('call rewriteWikilinks');
   });
 });
 
@@ -641,5 +648,104 @@ describe('migration-registry', () => {
   it('pendingMigrations 0.7.2 -> 0.7.2 returns empty (same version)', () => {
     const pending = pendingMigrations('0.7.2', '0.7.2');
     expect(pending).toHaveLength(0);
+  });
+});
+
+// ─── apply-diagrams behavior ──────────────────────────────────────────────────
+
+describe('apply-diagrams-behavior', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'knowledge', 'diagrams'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('board + generator + spec moved into per-title folder; inbound wikilink rewritten; ledger entry written', () => {
+    const diagramsDir = join(tmpDir, 'knowledge', 'diagrams');
+
+    // Flat board
+    writeFileSync(
+      join(diagramsDir, 'foo.excalidraw.md'),
+      '---\nname: Foo Board\ndescription: Foo architecture\ntags: [architecture]\n---\n\n## Text Elements\nFoo label\n%%\n## Drawing\n```json\n{"type":"excalidraw","version":2,"elements":[]}\n```\n%%\n',
+    );
+
+    // Same-basename generator script (dark sibling to be moved)
+    writeFileSync(join(diagramsDir, 'foo.board.cjs'), '// generator\n');
+
+    // A doc elsewhere containing an inbound wikilink to the flat board
+    mkdirSync(join(tmpDir, 'core'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'core', 'arch-notes.md'),
+      '---\nname: Arch Notes\n---\n\nSee [[diagrams/foo.excalidraw]] for details.\n',
+    );
+
+    // Run the migration function (same function the apply-diagrams command calls)
+    const result = migrateDiagramsToFolders(tmpDir);
+
+    // Board should be moved
+    expect(result.moved).toContain('foo');
+    expect(result.skipped).toHaveLength(0);
+    expect(result.ambiguous).toHaveLength(0);
+
+    // Board file should be at the new location
+    expect(existsSync(join(diagramsDir, 'foo', 'foo.excalidraw.md'))).toBe(true);
+
+    // Old flat location should be gone
+    expect(existsSync(join(diagramsDir, 'foo.excalidraw.md'))).toBe(false);
+
+    // Generator script should also be moved
+    expect(existsSync(join(diagramsDir, 'foo', 'foo.board.cjs'))).toBe(true);
+    expect(existsSync(join(diagramsDir, 'foo.board.cjs'))).toBe(false);
+
+    // Inbound wikilink should be rewritten to new slug
+    const archNotes = fsReadFileSync(join(tmpDir, 'core', 'arch-notes.md'), 'utf-8');
+    expect(archNotes).toContain('[[diagrams/foo/foo.excalidraw]]');
+    expect(archNotes).not.toContain('[[diagrams/foo.excalidraw]]');
+  });
+
+  it('already-nested boards are skipped; flat boards are moved', () => {
+    const diagramsDir = join(tmpDir, 'knowledge', 'diagrams');
+
+    // One flat board
+    writeFileSync(
+      join(diagramsDir, 'flat-board.excalidraw.md'),
+      '---\nname: Flat\ndescription: flat\n---\n\n## Text Elements\nFlat text\n',
+    );
+
+    // One already-nested board
+    mkdirSync(join(diagramsDir, 'nested-board'), { recursive: true });
+    writeFileSync(
+      join(diagramsDir, 'nested-board', 'nested-board.excalidraw.md'),
+      '---\nname: Nested\ndescription: nested\n---\n\n## Text Elements\nNested text\n',
+    );
+
+    const result = migrateDiagramsToFolders(tmpDir);
+
+    expect(result.moved).toContain('flat-board');
+    // skipped entries have EXCALIDRAW_SUFFIX stripped: nested-board/nested-board.excalidraw.md -> nested-board/nested-board
+    expect(result.skipped).toContain('nested-board/nested-board');
+    expect(result.ambiguous).toHaveLength(0);
+  });
+
+  it('no flat boards returns empty moved list (no-op)', () => {
+    const diagramsDir = join(tmpDir, 'knowledge', 'diagrams');
+
+    // Only a nested board — nothing flat to move
+    mkdirSync(join(diagramsDir, 'my-board'), { recursive: true });
+    writeFileSync(
+      join(diagramsDir, 'my-board', 'my-board.excalidraw.md'),
+      '---\nname: My Board\ndescription: already nested\n---\n\n## Text Elements\nContent\n',
+    );
+
+    const result = migrateDiagramsToFolders(tmpDir);
+
+    expect(result.moved).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.ambiguous).toHaveLength(0);
   });
 });

--- a/tests/unit/excalidraw-knowledge.test.ts
+++ b/tests/unit/excalidraw-knowledge.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Tests for Excalidraw knowledge integration.
+ *
+ * AC1: excalidraw-index-corpus-stress
+ * AC2: excalidraw-recall
+ * AC3: excalidraw-index-content
+ * AC4: excalidraw-snapshot
+ * AC5: excalidraw-dark-siblings
+ * AC6: dashboard excalidraw-grouping
+ * AC7: excalidraw-flat-regression
+ * AC8: excalidraw-docs (light presence test)
+ * AC9: diagrams-migration + migration-registry
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  extractExcalidrawText,
+  isExcalidrawPath,
+  diagramFolderDirs,
+  isDarkDiagramSibling,
+} from '../../src/lib/excalidraw-text.js';
+import { buildKnowledgeIndex } from '../../src/lib/knowledge-index.js';
+import { buildCorpus, bm25Search } from '../../src/lib/recall.js';
+import { REGISTRY, pendingMigrations } from '../../src/migrations/index.js';
+import { detectFlatDiagramBoards } from '../../src/lib/diagrams-migration.js';
+
+// ─── Dashboard leafName pure logic (inlined to avoid React context) ───────────
+//
+// The `leafName` and `isExcalidrawSlug` functions from dashboard/src are pure.
+// We replicate the logic here for node-side testing rather than importing the
+// React component file (which brings in useState/useMemo and breaks in vitest).
+// The production code lives in dashboard/src/pages/KnowledgePage.tsx and
+// dashboard/src/lib/excalidraw.ts — these are mirrors for the test only.
+
+type KnowledgeListEntry = {
+  slug: string;
+  name: string;
+  description: string;
+  tags: string[];
+  pinned: boolean;
+};
+
+/** Mirror of dashboard/src/lib/excalidraw.ts:47 isExcalidrawSlug */
+function isExcalidrawSlug(slug: string): boolean {
+  return slug.endsWith('.excalidraw');
+}
+
+/**
+ * Mirror of the exported `leafName` from dashboard/src/pages/KnowledgePage.tsx.
+ * Uses basename/last-segment for Excalidraw boards, prefix-strip for others.
+ */
+function leafName(entry: KnowledgeListEntry, folder: string | null): string {
+  if (!folder) return entry.name;
+  if (isExcalidrawSlug(entry.slug)) {
+    const lastSlash = entry.slug.lastIndexOf('/');
+    return lastSlash >= 0 ? entry.slug.slice(lastSlash + 1) : entry.slug;
+  }
+  if (entry.name.startsWith(`${folder}/`)) return entry.name.slice(folder.length + 1);
+  return entry.name;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `excalidraw-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Build a minimal but valid .excalidraw.md file body (frontmatter already stripped). */
+function buildBoard(opts: {
+  textElements?: string[];
+  jsonOnlyTerm?: string;
+  sceneSizeBytes?: number;
+}): string {
+  const textSection =
+    opts.textElements && opts.textElements.length > 0
+      ? `## Text Elements\n${opts.textElements.map((t, i) => `${t} ^elem${i.toString().padStart(4, '0')}`).join('\n')}\n`
+      : '';
+
+  // Build scene JSON — optionally pad it to hit a target size.
+  const elements: Record<string, unknown>[] = [];
+  if (opts.jsonOnlyTerm) {
+    elements.push({
+      id: 'json001',
+      type: 'text',
+      jsonOnlySecret: opts.jsonOnlyTerm,
+      x: 0,
+      y: 0,
+    });
+  }
+
+  let sceneJson = JSON.stringify(
+    {
+      type: 'excalidraw',
+      version: 2,
+      elements,
+      appState: { viewBackgroundColor: '#ffffff' },
+      files: {},
+    },
+    null,
+    2,
+  );
+
+  // Pad scene JSON to reach target size if requested.
+  if (opts.sceneSizeBytes && opts.sceneSizeBytes > sceneJson.length) {
+    const padding = 'X'.repeat(opts.sceneSizeBytes - sceneJson.length);
+    sceneJson = sceneJson.replace('"files": {}', `"files": {}, "padding": "${padding}"`);
+  }
+
+  return (
+    `==⚠ Switch to EXCALIDRAW VIEW ==\n\n` +
+    `# Excalidraw Data\n\n` +
+    textSection +
+    `## Embedded Files\n%%\n` +
+    `## Drawing\n` +
+    '```json\n' +
+    sceneJson +
+    '\n```\n%%\n'
+  );
+}
+
+function writeExcalidrawFile(
+  dir: string,
+  relPath: string,
+  name: string,
+  description: string,
+  body: string,
+): void {
+  const fullPath = join(dir, relPath);
+  mkdirSync(join(fullPath, '..'), { recursive: true });
+  writeFileSync(
+    fullPath,
+    `---\nname: ${name}\ndescription: ${description}\ntags: [excalidraw]\nexcalidraw-plugin: parsed\n---\n\n${body}\n`,
+  );
+}
+
+// ─── AC1: excalidraw-index-corpus-stress ─────────────────────────────────────
+
+describe('excalidraw-index-corpus-stress', () => {
+  it('a >=2MB board contributes only frontmatter+text-element tokens to BM25', () => {
+    const TEXT_ELEMENT_TERM = 'uniquetextelementtoken99';
+    const JSON_ONLY_TERM = 'uniquejsononlytoken77';
+
+    // Build a >=2MB board body
+    const boardBody = buildBoard({
+      textElements: [TEXT_ELEMENT_TERM, 'Session Capture', 'Memory Store'],
+      jsonOnlyTerm: JSON_ONLY_TERM,
+      sceneSizeBytes: 2 * 1024 * 1024, // 2 MB scene
+    });
+
+    // Verify the raw body is >=2MB
+    const rawBytes = Buffer.byteLength(boardBody, 'utf-8');
+    expect(rawBytes).toBeGreaterThanOrEqual(2 * 1024 * 1024);
+
+    const extracted = extractExcalidrawText(boardBody);
+
+    // Text-element term MUST appear in extracted text
+    expect(extracted.toLowerCase()).toContain(TEXT_ELEMENT_TERM);
+
+    // JSON-only term MUST NOT appear in extracted text
+    expect(extracted).not.toContain(JSON_ONLY_TERM);
+
+    // Extracted text must not contain scene JSON markers
+    expect(extracted).not.toContain('"type":"excalidraw"');
+    expect(extracted).not.toContain('"type": "excalidraw"');
+  });
+});
+
+// ─── AC2: excalidraw-recall ───────────────────────────────────────────────────
+
+describe('excalidraw-recall', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'knowledge', 'diagrams'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('text-element term surfaces board; JSON-only term does not match', () => {
+    const TEXT_TERM = 'recallexcalidrawsurfacetoken';
+    const JSON_TERM = 'recalljsonhiddenterm';
+
+    const body = buildBoard({
+      textElements: [TEXT_TERM, 'architecture pipeline'],
+      jsonOnlyTerm: JSON_TERM,
+    });
+
+    writeExcalidrawFile(
+      tmpDir,
+      join('knowledge', 'diagrams', 'recall-test.excalidraw.md'),
+      'Recall Test Board',
+      'A board for recall testing',
+      body,
+    );
+
+    const corpus = buildCorpus(tmpDir, { types: ['knowledge'] });
+
+    // Find the board doc
+    const boardDoc = corpus.find((d) => d.slug === 'recall-test.excalidraw');
+    expect(boardDoc).toBeDefined();
+
+    // The text-element term should be in the corpus body
+    expect(boardDoc!.body).toContain(TEXT_TERM);
+
+    // The JSON-only term should NOT be in the corpus body
+    expect(boardDoc!.body).not.toContain(JSON_TERM);
+
+    // BM25 search for the text-element term should find the board
+    const hitsText = bm25Search(TEXT_TERM, corpus);
+    const boardHit = hitsText.find((h) => h.doc.slug === 'recall-test.excalidraw');
+    expect(boardHit).toBeDefined();
+
+    // BM25 search for the JSON-only term should NOT find the board
+    const hitsJson = bm25Search(JSON_TERM, corpus);
+    const boardJsonHit = hitsJson.find((h) => h.doc.slug === 'recall-test.excalidraw');
+    expect(boardJsonHit).toBeUndefined();
+  });
+});
+
+// ─── AC3: excalidraw-index-content ───────────────────────────────────────────
+
+describe('excalidraw-index-content', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'knowledge', 'diagrams'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('board index content has no scene JSON/base64/element-ids', () => {
+    const body = buildBoard({
+      textElements: ['dreamcontext architecture', 'Session Capture'],
+      jsonOnlyTerm: 'jsonOnlyMarker',
+    });
+
+    writeExcalidrawFile(
+      tmpDir,
+      join('knowledge', 'diagrams', 'arch.excalidraw.md'),
+      'Architecture',
+      'Architecture board',
+      body,
+    );
+
+    const entries = buildKnowledgeIndex(tmpDir);
+    const entry = entries.find((e) => e.slug === 'diagrams/arch.excalidraw');
+    expect(entry).toBeDefined();
+
+    const content = entry!.content;
+
+    // Must NOT contain scene JSON markers
+    expect(content).not.toMatch(/"type"\s*:\s*"excalidraw"/);
+    expect(content).not.toContain('"version": 2');
+    // Must NOT contain base64 data URLs
+    expect(content).not.toMatch(/data:image\/[a-z]+;base64,/);
+    // Must NOT contain ^blockref ids (4+ alphanumeric chars after ^)
+    expect(content).not.toMatch(/\^[A-Za-z0-9_-]{4,}/);
+    // Must NOT contain the JSON-only marker
+    expect(content).not.toContain('jsonOnlyMarker');
+  });
+});
+
+// ─── AC4: excalidraw-snapshot ─────────────────────────────────────────────────
+
+describe('excalidraw-snapshot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'knowledge', 'diagrams'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('snapshot token estimate independent of scene size; extracted text not JSON', () => {
+    const TEXT_ELEMENTS = ['Session Capture', 'Memory Store', 'Recall Pipeline'];
+
+    // Board A: 2MB scene
+    const bodyLarge = buildBoard({
+      textElements: TEXT_ELEMENTS,
+      sceneSizeBytes: 2 * 1024 * 1024,
+    });
+    writeExcalidrawFile(
+      tmpDir,
+      join('knowledge', 'diagrams', 'large.excalidraw.md'),
+      'Large Board',
+      'Large scene board',
+      bodyLarge,
+    );
+
+    // Board B: tiny scene (same text elements)
+    const bodySmall = buildBoard({
+      textElements: TEXT_ELEMENTS,
+      sceneSizeBytes: 100,
+    });
+    writeExcalidrawFile(
+      tmpDir,
+      join('knowledge', 'diagrams', 'small.excalidraw.md'),
+      'Small Board',
+      'Small scene board',
+      bodySmall,
+    );
+
+    const entries = buildKnowledgeIndex(tmpDir);
+    const largeEntry = entries.find((e) => e.slug === 'diagrams/large.excalidraw');
+    const smallEntry = entries.find((e) => e.slug === 'diagrams/small.excalidraw');
+
+    expect(largeEntry).toBeDefined();
+    expect(smallEntry).toBeDefined();
+
+    // Both entries should have the same content (same text elements)
+    expect(largeEntry!.content).toBe(smallEntry!.content);
+
+    // Content should not contain scene JSON
+    expect(largeEntry!.content).not.toContain('"type": "excalidraw"');
+    expect(largeEntry!.content).not.toContain('"type":"excalidraw"');
+
+    // Content should contain the text elements
+    for (const t of TEXT_ELEMENTS) {
+      expect(largeEntry!.content).toContain(t);
+    }
+  });
+});
+
+// ─── AC5: excalidraw-dark-siblings ───────────────────────────────────────────
+
+describe('excalidraw-dark-siblings', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    const boardDir = join(tmpDir, 'knowledge', 'diagrams', 'my-board');
+    mkdirSync(boardDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('generator script + spec + sibling .md inside a diagram folder appear nowhere', () => {
+    const boardDir = join(tmpDir, 'knowledge', 'diagrams', 'my-board');
+
+    // Board file
+    writeExcalidrawFile(
+      tmpDir,
+      join('knowledge', 'diagrams', 'my-board', 'my-board.excalidraw.md'),
+      'My Board',
+      'My board description',
+      buildBoard({ textElements: ['Board content here'] }),
+    );
+
+    // Dark siblings
+    writeFileSync(join(boardDir, 'my-board.board.cjs'), '// generator script\n');
+    writeFileSync(join(boardDir, 'my-board.json'), '{"elements": []}\n');
+    writeFileSync(join(boardDir, 'notes.md'), '---\nname: Notes\n---\n\nSome notes\n');
+
+    const entries = buildKnowledgeIndex(tmpDir);
+
+    // Board should appear
+    const boardEntry = entries.find((e) =>
+      e.slug === 'diagrams/my-board/my-board.excalidraw',
+    );
+    expect(boardEntry).toBeDefined();
+
+    // notes.md should NOT appear (dark sibling)
+    const notesEntry = entries.find((e) => e.slug.includes('notes'));
+    expect(notesEntry).toBeUndefined();
+
+    // Non-.md files are already excluded by glob (**/*.md only)
+    // — confirmed by: only .md dark siblings need explicit exclusion
+    expect(entries).toHaveLength(1);
+  });
+
+  it('diagramFolderDirs identifies board directories correctly', () => {
+    const files = [
+      '/root/knowledge/diagrams/my-board/my-board.excalidraw.md',
+      '/root/knowledge/diagrams/my-board/notes.md',
+      '/root/knowledge/diagrams/flat.excalidraw.md',
+      '/root/knowledge/other.md',
+    ];
+
+    const dirs = diagramFolderDirs(files);
+
+    expect(dirs.has('/root/knowledge/diagrams/my-board')).toBe(true);
+    expect(dirs.has('/root/knowledge/diagrams')).toBe(true); // flat board
+    expect(dirs.has('/root/knowledge')).toBe(false);
+  });
+
+  it('isDarkDiagramSibling excludes non-board siblings but not boards', () => {
+    const files = [
+      '/root/knowledge/diagrams/my-board/my-board.excalidraw.md',
+      '/root/knowledge/diagrams/my-board/notes.md',
+      '/root/knowledge/diagrams/my-board/spec.json', // .json is not .md so won't be in files
+    ];
+
+    const dirs = diagramFolderDirs(files);
+
+    // Board itself: NOT a dark sibling
+    expect(
+      isDarkDiagramSibling(
+        '/root/knowledge/diagrams/my-board/my-board.excalidraw.md',
+        dirs,
+      ),
+    ).toBe(false);
+
+    // notes.md: IS a dark sibling
+    expect(
+      isDarkDiagramSibling('/root/knowledge/diagrams/my-board/notes.md', dirs),
+    ).toBe(true);
+
+    // File not in a board dir: NOT a dark sibling
+    expect(isDarkDiagramSibling('/root/knowledge/other.md', dirs)).toBe(false);
+  });
+});
+
+// ─── AC6: dashboard excalidraw-grouping ──────────────────────────────────────
+
+describe('dashboard excalidraw-grouping', () => {
+  it('depth-2 diagrams/{title}/ slug shows leaf {title}.excalidraw under Diagrams', () => {
+    // A nested board: slug = diagrams/my-board/my-board.excalidraw
+    // Expected leaf: "my-board.excalidraw" (last path segment)
+    const entry = {
+      slug: 'diagrams/my-board/my-board.excalidraw',
+      name: 'diagrams/my-board/my-board.excalidraw',
+      description: 'A board',
+      tags: [],
+      pinned: false,
+    };
+    const result = leafName(entry, 'diagrams');
+    expect(result).toBe('my-board.excalidraw');
+  });
+
+  it('flat diagrams/recall.excalidraw shows leaf recall.excalidraw', () => {
+    // Flat board slug: diagrams/recall.excalidraw
+    const entry = {
+      slug: 'diagrams/recall.excalidraw',
+      name: 'diagrams/recall.excalidraw',
+      description: 'Recall architecture',
+      tags: [],
+      pinned: false,
+    };
+    const result = leafName(entry, 'diagrams');
+    expect(result).toBe('recall.excalidraw');
+  });
+
+  it('isExcalidrawSlug matches nested board slug', () => {
+    // The inlined isExcalidrawSlug mirrors dashboard/src/lib/excalidraw.ts:47.
+    // It matches on the .excalidraw suffix, regardless of path depth.
+    expect(isExcalidrawSlug('diagrams/my-board/my-board.excalidraw')).toBe(true);
+    expect(isExcalidrawSlug('diagrams/recall.excalidraw')).toBe(true);
+    expect(isExcalidrawSlug('data-structures/default')).toBe(false);
+  });
+
+  it('leafName for non-excalidraw uses prefix-strip', () => {
+    // Non-board inside data-structures folder: strip prefix
+    const entry = {
+      slug: 'data-structures/default',
+      name: 'data-structures/default',
+      description: 'Default schema',
+      tags: [],
+      pinned: false,
+    };
+    const result = leafName(entry, 'data-structures');
+    expect(result).toBe('default');
+  });
+
+  it('leafName returns name unchanged when no folder match', () => {
+    const entry = {
+      slug: 'some-topic',
+      name: 'Some Topic',
+      description: '',
+      tags: [],
+      pinned: false,
+    };
+    const result = leafName(entry, null);
+    expect(result).toBe('Some Topic');
+  });
+});
+
+// ─── AC7: excalidraw-flat-regression ─────────────────────────────────────────
+
+describe('excalidraw-flat-regression', () => {
+  it('live flat knowledge/diagrams/*.excalidraw.md still indexes+recalls with extraction; index content JSON-free', () => {
+    // Use dreamcontext's own architecture.excalidraw.md as the regression fixture.
+    const CONTEXT_ROOT = '/Users/mehmetnuraydin/projects/dreamcontext/_dream_context';
+    const FLAT_BOARD_SLUG = 'diagrams/architecture.excalidraw';
+
+    const entries = buildKnowledgeIndex(CONTEXT_ROOT);
+    const boardEntry = entries.find((e) => e.slug === FLAT_BOARD_SLUG);
+
+    expect(boardEntry).toBeDefined();
+
+    const content = boardEntry!.content;
+
+    // Must NOT contain raw scene JSON
+    expect(content).not.toMatch(/"type"\s*:\s*"excalidraw"/);
+    expect(content).not.toContain('"version": 2,');
+
+    // Must NOT contain ^blockref ids
+    expect(content).not.toMatch(/\^[A-Za-z0-9_-]{4,}/);
+
+    // Should contain some of the known text elements from architecture.excalidraw.md
+    // (from the file we read: "dreamcontext — architecture", "Capture", etc.)
+    expect(content).toMatch(/dreamcontext|architecture|Capture|Memory/i);
+
+    // Recall corpus should also be clean
+    const corpus = buildCorpus(CONTEXT_ROOT, { types: ['knowledge'] });
+    const boardDoc = corpus.find((d) => d.slug === 'architecture.excalidraw');
+    expect(boardDoc).toBeDefined();
+    expect(boardDoc!.body).not.toMatch(/"type"\s*:\s*"excalidraw"/);
+    expect(boardDoc!.body).not.toContain('"version": 2,');
+  });
+});
+
+// ─── AC8: excalidraw-docs (light presence test) ───────────────────────────────
+
+describe('excalidraw-docs', () => {
+  it('skill/SKILL.md documents folder convention and required frontmatter', () => {
+    const skillContent = readFileSync(
+      '/Users/mehmetnuraydin/projects/dreamcontext/skill/SKILL.md',
+      'utf-8',
+    );
+
+    // Documents the per-title folder convention
+    expect(skillContent).toContain('diagrams/<title>/<title>.excalidraw.md');
+    // Documents do-not-hand-edit
+    expect(skillContent).toContain('do NOT hand-edit');
+    // Documents required name + description
+    expect(skillContent).toContain('REQUIRED frontmatter');
+    // Documents dark siblings excluded from index/recall
+    expect(skillContent).toContain('dark sibling');
+  });
+
+  it('skill-packs/excalidraw/SKILL.md documents dreamcontext knowledge conventions', () => {
+    const packContent = readFileSync(
+      '/Users/mehmetnuraydin/projects/dreamcontext/skill-packs/excalidraw/SKILL.md',
+      'utf-8',
+    );
+
+    // Documents the folder convention
+    expect(packContent).toContain('knowledge/diagrams');
+    // Documents do-not-hand-edit
+    expect(packContent).toContain('do NOT hand-edit');
+    // Documents required name + description frontmatter
+    expect(packContent).toContain('name:');
+    expect(packContent).toContain('description:');
+    // Documents dark siblings
+    expect(packContent).toContain('dark sibling');
+    // Documents memory indexing scope
+    expect(packContent).toContain('Text Elements');
+  });
+});
+
+// ─── AC9: diagrams-migration + migration-registry ────────────────────────────
+
+describe('diagrams-migration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'knowledge', 'diagrams'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('code step detects flat boards and records detected without moving', () => {
+    // Create flat boards
+    writeFileSync(
+      join(tmpDir, 'knowledge', 'diagrams', 'flat-one.excalidraw.md'),
+      '---\nname: Flat One\ndescription: Test\n---\n\n## Text Elements\nFlat one text\n%%\n## Drawing\n```json\n{"type":"excalidraw","version":2,"elements":[]}\n```\n%%\n',
+    );
+    writeFileSync(
+      join(tmpDir, 'knowledge', 'diagrams', 'flat-two.excalidraw.md'),
+      '---\nname: Flat Two\ndescription: Test\n---\n\n## Text Elements\nFlat two text\n%%\n## Drawing\n```json\n{"type":"excalidraw","version":2,"elements":[]}\n```\n%%\n',
+    );
+
+    const flatBoards = detectFlatDiagramBoards(tmpDir);
+    expect(flatBoards).toHaveLength(2);
+    expect(flatBoards).toContain('flat-one');
+    expect(flatBoards).toContain('flat-two');
+
+    // The code step of migration072 runs detection only — finds the 0.7.2 migration
+    const migration072 = REGISTRY.find((m) => m.version === '0.7.2');
+    expect(migration072).toBeDefined();
+
+    const result = migration072!.steps[0](tmpDir);
+    expect(result.step).toBe('detect-flat-diagram-boards');
+    expect(result.filesTouched).toHaveLength(0); // moves nothing
+    expect(result.detected).toBe(true);
+    expect(result.summary).toContain('flat-one');
+    expect(result.summary).toContain('flat-two');
+
+    // Verify boards were NOT moved
+    const stillFlat = detectFlatDiagramBoards(tmpDir);
+    expect(stillFlat).toHaveLength(2);
+  });
+
+  it('agentTask present with move+wikilink contract', () => {
+    const migration072 = REGISTRY.find((m) => m.version === '0.7.2');
+    expect(migration072).toBeDefined();
+    expect(migration072!.agentTask).toBeDefined();
+    expect(migration072!.agentTask!.id).toBe('diagrams-folder-convention');
+    // Instruction must mention rewriteWikilinks and the move contract
+    expect(migration072!.agentTask!.instruction).toContain('rewriteWikilinks');
+    expect(migration072!.agentTask!.instruction).toContain('wikilinks');
+  });
+});
+
+describe('migration-registry', () => {
+  it('REGISTRY includes migration072 at version 0.7.2', () => {
+    const v072 = REGISTRY.find((m) => m.version === '0.7.2');
+    expect(v072).toBeDefined();
+    expect(v072!.version).toBe('0.7.2');
+  });
+
+  it('pendingMigrations 0.7.1 -> 0.7.2 returns migration072', () => {
+    const pending = pendingMigrations('0.7.1', '0.7.2');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].version).toBe('0.7.2');
+  });
+
+  it('pendingMigrations 0.7.2 -> 0.7.2 returns empty (same version)', () => {
+    const pending = pendingMigrations('0.7.2', '0.7.2');
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/tests/unit/excalidraw-knowledge.test.ts
+++ b/tests/unit/excalidraw-knowledge.test.ts
@@ -748,4 +748,25 @@ describe('apply-diagrams-behavior', () => {
     expect(result.skipped).toHaveLength(1);
     expect(result.ambiguous).toHaveLength(0);
   });
+
+  it('a crafted board filename cannot escape diagrams/ (no write outside the tree)', () => {
+    const diagramsDir = join(tmpDir, 'knowledge', 'diagrams');
+    // A file literally named `...excalidraw.md` would strip to boardBase `..`,
+    // whose dest dir resolves to knowledge/ (one level up). Two layers prevent a
+    // traversal: fast-glob skips dotfiles, and the containment guard rejects any
+    // boardBase that resolves outside diagrams/. Net effect: nothing escapes.
+    writeFileSync(
+      join(diagramsDir, '...excalidraw.md'),
+      '---\nname: Evil\ndescription: traversal attempt\n---\n\n## Text Elements\nx\n',
+    );
+    const before = fsReadFileSync(join(diagramsDir, '...excalidraw.md'), 'utf-8');
+
+    const result = migrateDiagramsToFolders(tmpDir);
+
+    // It is never moved, and nothing is written into knowledge/ (the parent dir).
+    expect(result.moved).toHaveLength(0);
+    expect(existsSync(join(diagramsDir, '...excalidraw.md'))).toBe(true);
+    expect(fsReadFileSync(join(diagramsDir, '...excalidraw.md'), 'utf-8')).toBe(before);
+    expect(existsSync(join(tmpDir, 'knowledge', '...excalidraw.md'))).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #20

> **Stacked on #23** (PR #26), which is stacked on #22 (PR #24). Base branch is `feat/23-migration-system`; review/merge after #23.

## Summary
A `.excalidraw.md` board's entire embedded scene JSON was treated as the doc body — tokenized into the BM25 recall corpus, stored as the knowledge-index `content`, and inlined into the SessionStart snapshot. That poisons recall and bloats the index (a real board is 2.2 MB / 105k lines of scene JSON). This PR makes excalidraw a **first-class knowledge type**: the memory system reads a **text extraction** (frontmatter + `## Text Elements`), never the scene JSON, while the **dashboard keeps rendering the full visual**.

- **`src/lib/excalidraw-text.ts`** — `extractExcalidrawText` keeps frontmatter + `## Text Elements` labels; strips the `## Drawing` block (**both** ` ```json ` and ` ```compressed-json `), the `## Embedded Files` map, the `==⚠…==` Obsidian banner, and trailing `^blockref` suffixes. No `## Text Elements` / malformed → **frontmatter-only** (never the raw body); 200-line cap. JS-valid regex (no `\Z`). Replicates dashboard's `DRAWING_BLOCK` (separate build graph — `src/` can't import `dashboard/src/`) with a cross-reference comment.
- **Extraction applied in BOTH** `knowledge-index.ts` (`entry.content` → list route, snapshot warm/pinned via `extractFirstParagraph`) **AND** `recall.ts` (`body` → BM25 corpus + reflection). Neither alone closes every memory surface. Suffix-detected (`*.excalidraw.md` anywhere under `knowledge/`), so **dreamcontext's own flat boards keep working with no migration**.
- **Diagram-folder siblings go dark**: a folder directly containing a board excludes its sibling `.md` from index/recall/snapshot/dashboard (scripts/specs were already dark via the `**/*.md` glob — this codifies it and adds the sibling-`.md` rule, matching the issue's design #4).
- **Dashboard renderer untouched**: `GET /api/knowledge/:slug` still serves the **raw** body so `ExcalidrawPreview` renders the scene (verified live). `KnowledgePage` leaf label collapses depth-2 `diagrams/{title}/{title}.excalidraw` → `{title}.excalidraw` under the Diagrams folder.
- **First real consumer of #23's registry**: `src/migrations/0.7.2.ts`. The auto-run **code step is detect-only** (records `detected`, moves nothing — respects #20's explicit "no auto-migrating flat layouts" scope and avoids silently breaking path-derived slugs / inbound `[[wikilinks]]` / access-records). The folder-organizing move (with **atomic `rewriteWikilinks`**) is offered only through the **opt-in `agentTask`**. Registered in `src/migrations/index.ts`.
- **Convention documented** in `skill/SKILL.md` + `skill-packs/excalidraw/SKILL.md` (per-title folder, scripts-are-dark, do-not-hand-edit, required `name`+`description`). Added a nested example board (`knowledge/diagrams/system-overview/`) demonstrating the convention.

## Acceptance criteria → evidence

| # | Criterion | Test |
|---|-----------|------|
| 1 | 2 MB board → only frontmatter + text-element tokens in BM25 | `excalidraw-knowledge.test.ts` › *a >=2MB board contributes only frontmatter+text-element tokens to BM25* |
| 2 | recall surfaces board on a text-element term; JSON-only term does not match | › *text-element term surfaces board; JSON-only term does not match* |
| 3 | index `content` has no scene JSON / base64 / element IDs | › *board index content has no scene JSON/base64/element-ids* |
| 4 | pinned board inlines extracted text; token estimate scene-size-independent | › *snapshot token estimate independent of scene size; extracted text not JSON* |
| 5 | script + spec + sibling `.md` in a diagram folder appear nowhere | › *generator script + spec + sibling .md inside a diagram folder appear nowhere* |
| 6 | nested entry displays cleanly; renderer still works (json + compressed-json) | › *depth-2 diagrams/{title}/ slug shows leaf {title}.excalidraw*; **manual** (API evidence below) |
| 7 | live flat boards keep indexing/recalling with extraction, no migration | › *live flat knowledge/diagrams/*.excalidraw.md still indexes+recalls; index content JSON-free* |
| 8 | SKILL.md + skill pack document the convention | **manual:** `skill/SKILL.md` + `skill-packs/excalidraw/SKILL.md`; presence test *documents folder convention and required frontmatter* |
| + | first consumer of #23 registry (v0.7.2), code step moves nothing | › *code step detects flat boards and records detected without moving*; *REGISTRY includes migration072* |

## Gate outputs
- **`npm run build`**: green (dashboard `vite build` ✓ + CLI `tsup` ✓); **`cd dashboard && npm run build`**: ✓.
- **`npm test`**: `Test Files 1 failed | 108 passed | 2 skipped`, `Tests 1 failed | 1414 passed`. The single failure is `tests/unit/recall-eval.test.ts`, **pre-existing & identical on `main`** (same 6 `task/*` gold keys, nothing diagram-related).

## Manual verification (#20 non-automatable items)
Ran `dreamcontext dashboard` against this repo's own brain:
- **`GET /api/knowledge/diagrams/architecture.excalidraw`** → `entry.content` contains the raw `## Drawing` block + scene JSON (30,477 chars) → renderer input intact. Same for the nested `diagrams/system-overview/system-overview.excalidraw` (1,453 chars, scene present).
- **`GET /api/knowledge`** (list) → all 10 flat boards + the nested `system-overview` board present; **no** `.board.cjs`/scripts/dark siblings.
- Both-layout rendering: the dashboard's `DRAWING_BLOCK` regex (handles `json` **and** `compressed-json`) is unchanged and receives the raw scene from the detail route → both forms render.
- **AC#8 docs:** `skill/SKILL.md` + `skill-packs/excalidraw/SKILL.md` "Diagrams / Excalidraw" convention sections.

## Deviations from spec (justified)
- **Migration code step is detect-only** (does not auto-move flat boards): reconciles the meta-goal ("register the diagrams migration as the first registry consumer") with #20's explicit Out-of-Scope ("auto-migrating existing flat layouts into per-title folders") and the data-safety risk that auto-moving on every `update`/`sleep` would silently break path-derived slugs, inbound `[[wikilinks]]`, and access-records. The move + atomic wikilink-rewrite capability is fully implemented in `diagrams-migration.ts` and exposed via the opt-in `agentTask`.
- **Dark-sibling rule** follows design #4 literally (any folder directly containing a board treats sibling `.md` as dark). No live-repo regression (no board folder has non-board `.md` siblings). A board co-located with unrelated `.md` docs (e.g. `knowledge/products/<name>/`) would dark those siblings — a documented characteristic; the per-title-folder convention avoids it.
- **Pinned snapshot = Option A** (maintainer-confirmed): no new pinned-preview-inline feature; AC#4's token-size guarantee is met because the index no longer stores scene JSON.
- **Migration version key `0.7.2`** (maintainer-confirmed).

## Scope
No `package.json` version bump. No edits to `.claude/skills/**` (gitignored) or `agents/*.md`. `snapshot.ts` + `knowledge.ts` are comment-only. `src/` does not import `dashboard/src`.