### PR TITLE
feat(tasks): clearable due dates + start/end date ranges, reliably synced to backend

### DIFF
--- a/dashboard/src/components/tasks/KanbanBoard.tsx
+++ b/dashboard/src/components/tasks/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import type { Task } from '../../hooks/useTasks';
-import { useTasks, useUpdateTask, useSyncStatus, useSyncTasks, useDeleteTask } from '../../hooks/useTasks';
+import { useTasks, useUpdateTask, useSyncStatus, useSyncTasks, useDeleteTask, useTaskMembers } from '../../hooks/useTasks';
 import { useVersions } from '../../hooks/useVersions';
 import { useProject } from '../../context/ProjectContext';
 import { useI18n } from '../../context/I18nContext';
@@ -89,6 +89,13 @@ function applyFilters(tasks: Task[], filters: FilterState): Task[] {
 
   if (filters.versionFilter.length > 0) {
     result = result.filter(t => t.version !== null && filters.versionFilter.includes(t.version));
+  }
+
+  if (filters.assigneeFilter.length > 0) {
+    result = result.filter(t =>
+      t.tags.some(tag => tag.startsWith('person:') && filters.assigneeFilter.includes(tag.slice('person:'.length)))
+      || (t.assignee != null && filters.assigneeFilter.includes(t.assignee)),
+    );
   }
 
   if (filters.dateFrom || filters.dateTo) {
@@ -225,8 +232,16 @@ export function KanbanBoard() {
   const { data: versions } = useVersions();
   const updateTask = useUpdateTask();
   const { data: syncStatus } = useSyncStatus();
+  const { data: members } = useTaskMembers();
   const syncTasks = useSyncTasks();
   const deleteTask = useDeleteTask();
+
+  const isCloud = !!syncStatus && syncStatus.backend !== 'local';
+  const assigneeOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const m of members ?? []) if (!seen.has(m.slug)) seen.set(m.slug, m.name || m.slug);
+    return [...seen].map(([value, label]) => ({ value, label }));
+  }, [members]);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; task: Task } | null>(null);
 
   const handleTaskContextMenu = (task: Task, e: React.MouseEvent) => {
@@ -500,6 +515,8 @@ export function KanbanBoard() {
         allVersions={allVersions}
         onVersionManagerClick={() => setShowVersionManager(true)}
         syncSlot={syncSlot}
+        showAssignee={isCloud}
+        assigneeOptions={assigneeOptions}
       />
 
       {filters.viewMode === 'eisenhower' ? (

--- a/dashboard/src/components/tasks/TaskDetailPanel.tsx
+++ b/dashboard/src/components/tasks/TaskDetailPanel.tsx
@@ -466,6 +466,13 @@ export function TaskDetailPanel({ task, onClose, initialRiceExpanded }: TaskDeta
     });
   };
 
+  const handleStartChange = (value: string) => {
+    updateTask.mutate(
+      { slug: task.slug, updates: { start_date: value || null } },
+      { onError: onMutationError },
+    );
+  };
+
   const handleDueChange = (value: string) => {
     updateTask.mutate(
       { slug: task.slug, updates: { due_date: value || null } },
@@ -962,6 +969,21 @@ export function TaskDetailPanel({ task, onClose, initialRiceExpanded }: TaskDeta
                 allowCustom
                 onChange={v => handleTextField('related_feature', v ?? '')}
               />
+            </PropertyRow>
+
+            <PropertyRow label="Start">
+              {task.tags.some(t => t.toLowerCase() === 'backlog') ? (
+                <span className="prop-text" title="Backlog tasks are undated by rule — remove the backlog tag to schedule.">
+                  — backlog tasks are undated
+                </span>
+              ) : (
+                <input
+                  type="date"
+                  className="field-select prop-select"
+                  value={task.start_date ?? ''}
+                  onChange={e => handleStartChange(e.target.value)}
+                />
+              )}
             </PropertyRow>
 
             <PropertyRow label="Due">

--- a/dashboard/src/components/tasks/TaskFilters.tsx
+++ b/dashboard/src/components/tasks/TaskFilters.tsx
@@ -16,6 +16,7 @@ export interface FilterState {
   urgencyFilter: string[];
   tagFilter: string[];
   versionFilter: string[];
+  assigneeFilter: string[];
   searchQuery: string;
   dateField: DateField;
   dateFrom: string;
@@ -33,6 +34,7 @@ export const DEFAULT_FILTERS: FilterState = {
   urgencyFilter: [],
   tagFilter: [],
   versionFilter: [],
+  assigneeFilter: [],
   searchQuery: '',
   dateField: 'updated_at',
   dateFrom: '',
@@ -62,6 +64,8 @@ interface TaskFiltersProps {
   allTags: string[];
   allVersions: string[];
   onVersionManagerClick: () => void;
+  showAssignee?: boolean;
+  assigneeOptions?: { value: string; label: string }[];
 }
 
 // ─── Icons ───
@@ -216,6 +220,7 @@ function countActiveFilters(f: FilterState): number {
   if (f.urgencyFilter.length > 0) n++;
   if (f.tagFilter.length > 0) n++;
   if (f.versionFilter.length > 0) n++;
+  if (f.assigneeFilter.length > 0) n++;
   if (f.searchQuery.trim()) n++;
   if (f.dateFrom || f.dateTo) n++;
   if (f.minRice !== null && f.minRice !== undefined) n++;
@@ -254,6 +259,8 @@ export function TaskFilters({
   allTags,
   allVersions,
   onVersionManagerClick,
+  showAssignee,
+  assigneeOptions = [],
 }: TaskFiltersProps) {
   const { t } = useI18n();
   const [openPopover, setOpenPopover] = useState<string | null>(null);
@@ -356,6 +363,20 @@ export function TaskFilters({
           onChange={v => onFilterChange('versionFilter', v)}
           isOpen={openPopover === 'version'}
           onToggle={() => toggle('version')}
+          onClose={close}
+        />
+      )}
+
+      {/* Assignee multi-select (cloud-backed) */}
+      {showAssignee && assigneeOptions.length > 0 && (
+        <MultiSelectFilter
+          id="assignee"
+          label="Assignee"
+          options={assigneeOptions}
+          selected={filters.assigneeFilter}
+          onChange={v => onFilterChange('assigneeFilter', v)}
+          isOpen={openPopover === 'assignee'}
+          onToggle={() => toggle('assignee')}
           onClose={close}
         />
       )}

--- a/dashboard/src/hooks/useTasks.ts
+++ b/dashboard/src/hooks/useTasks.ts
@@ -25,6 +25,7 @@ export interface Task {
   parent_task: string | null;
   related_feature: string | null;
   version: string | null;
+  start_date?: string | null;
   due_date?: string | null;
   assignee?: string | null;
   rice: RiceFields | null;
@@ -59,7 +60,7 @@ interface CreateTaskInput {
 
 interface UpdateTaskInput {
   slug: string;
-  updates: Partial<Pick<Task, 'status' | 'priority' | 'urgency' | 'description' | 'tags' | 'name' | 'related_feature' | 'version' | 'due_date' | 'assignee' | 'body'>> & {
+  updates: Partial<Pick<Task, 'status' | 'priority' | 'urgency' | 'description' | 'tags' | 'name' | 'related_feature' | 'version' | 'due_date' | 'start_date' | 'assignee' | 'body'>> & {
     rice?: RiceInput | null;
   };
 }

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -37,6 +37,49 @@ function collectOption(value: string, previous: string[]): string[] {
   return previous.concat(value);
 }
 
+/** True for a real calendar date in YYYY-MM-DD form (rejects e.g. 2026-13-40). */
+function isCalendarDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00Z`));
+}
+
+/**
+ * Set or CLEAR one end of a task's date range. `raw` is a YYYY-MM-DD or the
+ * literal "clear". Shared by `tasks start` and `tasks due` so both behave
+ * identically (validation, range sanity start≤due, backlog-removal notice, and
+ * the same remote-synced write path). Backlog handling is enforced in the
+ * backend; here we just surface the "backlog removed" notice.
+ */
+async function setTaskDate(
+  backend: TaskBackend,
+  slug: string,
+  field: 'start_date' | 'due_date',
+  raw: string,
+): Promise<void> {
+  const label = field === 'start_date' ? 'Start date' : 'Due date';
+  if (raw.toLowerCase() === 'clear') {
+    await backend.updateFields(slug, { [field]: null, updated_at: today() });
+    success(`${label} cleared on ${slug}`);
+    return;
+  }
+  if (!isCalendarDate(raw)) {
+    error(`${label} must be a valid YYYY-MM-DD (or "clear").`);
+    return;
+  }
+  const before = await backend.get(slug);
+  // Range sanity: a start date can never be after the due date.
+  const start = field === 'start_date' ? raw : (before?.start_date ?? null);
+  const due = field === 'due_date' ? raw : (before?.due_date ?? null);
+  if (start && due && start > due) {
+    error(`Start date (${start}) cannot be after the due date (${due}). Adjust or clear the other date first.`);
+    return;
+  }
+  const updated = await backend.updateFields(slug, { [field]: raw, updated_at: today() });
+  success(`${label} on ${slug}: ${raw}`);
+  if (before?.tags.some((t) => t.toLowerCase() === 'backlog') && !updated.tags.some((t) => t.toLowerCase() === 'backlog')) {
+    console.log(chalk.dim('  backlog tag removed — a dated task is planned, not backlog.'));
+  }
+}
+
 /** Render one task as a colorized human-readable line. */
 function renderTaskLine(t: TaskRecord, opts: { long?: boolean } = {}): string {
   const statusColor =
@@ -200,8 +243,9 @@ export function registerTasksCommand(program: Command): void {
     .option('--impact <n>', 'RICE impact (integer 1–5)')
     .option('--confidence <n>', 'RICE confidence (25, 50, 75, or 100)')
     .option('--effort <n>', 'RICE effort in weeks (> 0, ≤ 52)')
-    .option('--due <date>', 'Due date (YYYY-MM-DD)')
-    .action(async (name: string, opts: { description?: string; priority?: string; urgency?: string; status?: string; tags?: string; why?: string; version?: string; person?: string; reach?: string; impact?: string; confidence?: string; effort?: string; due?: string }) => {
+    .option('--start <date>', 'Planned start date (YYYY-MM-DD)')
+    .option('--due <date>', 'Due/end date (YYYY-MM-DD)')
+    .action(async (name: string, opts: { description?: string; priority?: string; urgency?: string; status?: string; tags?: string; why?: string; version?: string; person?: string; reach?: string; impact?: string; confidence?: string; effort?: string; start?: string; due?: string }) => {
       const backend = getTaskBackend();
       const slug = slugify(name);
 
@@ -262,8 +306,16 @@ export function registerTasksCommand(program: Command): void {
         riceBlock = mergeRice(null, riceInput);
       }
 
-      if (opts.due !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(opts.due)) {
-        error('Due date must be YYYY-MM-DD.');
+      if (opts.due !== undefined && !isCalendarDate(opts.due)) {
+        error('Due date must be a valid YYYY-MM-DD.');
+        return;
+      }
+      if (opts.start !== undefined && !isCalendarDate(opts.start)) {
+        error('Start date must be a valid YYYY-MM-DD.');
+        return;
+      }
+      if (opts.start && opts.due && opts.start > opts.due) {
+        error(`Start date (${opts.start}) cannot be after the due date (${opts.due}).`);
         return;
       }
 
@@ -278,6 +330,7 @@ export function registerTasksCommand(program: Command): void {
           why,
           version,
           rice: riceBlock,
+          start_date: opts.start ?? null,
           due_date: opts.due ?? null,
           variant: 'cli',
         });
@@ -385,32 +438,30 @@ export function registerTasksCommand(program: Command): void {
       success(`Task deleted: ${slug}${backend.name !== 'local' ? ' (remote deletion on next sync)' : ''}`);
     });
 
-  // Due date on existing tasks (synced natively to the remote backend)
+  // Planned START date on existing tasks (synced to the remote backend)
   tasks
-    .command('due')
+    .command('start')
     .argument('<name>', 'Task slug or name')
     .argument('<date>', 'YYYY-MM-DD, or "clear" to remove')
-    .description('Set or clear a task due date')
+    .description('Set or clear a task planned start date (the range start)')
     .action(async (name: string, date: string) => {
       const backend = getTaskBackend();
       const slug = await resolveTaskSlug(backend, name);
       if (!slug) return;
+      await setTaskDate(backend, slug, 'start_date', date);
+    });
 
-      if (date.toLowerCase() === 'clear') {
-        await backend.updateFields(slug, { due_date: null, updated_at: today() });
-        success(`Due date cleared on ${slug}`);
-        return;
-      }
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T00:00:00Z`))) {
-        error('Due date must be a valid YYYY-MM-DD (or "clear").');
-        return;
-      }
-      const before = await backend.get(slug);
-      const updated = await backend.updateFields(slug, { due_date: date, updated_at: today() });
-      success(`Due date on ${slug}: ${date}`);
-      if (before?.tags.some((t) => t.toLowerCase() === 'backlog') && !updated.tags.some((t) => t.toLowerCase() === 'backlog')) {
-        console.log(chalk.dim('  backlog tag removed — a dated task is planned, not backlog.'));
-      }
+  // DUE/end date on existing tasks (synced to the remote backend)
+  tasks
+    .command('due')
+    .argument('<name>', 'Task slug or name')
+    .argument('<date>', 'YYYY-MM-DD, or "clear" to remove')
+    .description('Set or clear a task due/end date (the range end)')
+    .action(async (name: string, date: string) => {
+      const backend = getTaskBackend();
+      const slug = await resolveTaskSlug(backend, name);
+      if (!slug) return;
+      await setTaskDate(backend, slug, 'due_date', date);
     });
 
   // Tag management on existing tasks (person:<slug> tags drive remote assignees)

--- a/src/lib/task-backend/clickup-map.ts
+++ b/src/lib/task-backend/clickup-map.ts
@@ -18,6 +18,8 @@ export interface ClickUpTask {
   date_created?: string | null;
   /** Epoch-ms as a string — ClickUp SERVER time. The watermark source. */
   date_updated?: string | null;
+  /** Epoch-ms (string or number) — ClickUp's native planned-start field. */
+  start_date?: string | number | null;
   due_date?: string | number | null;
   custom_fields?: Array<Record<string, unknown>> | null;
 }
@@ -145,20 +147,32 @@ export function tagsFromClickUp(remote: ClickUpTask['tags']): { tags: string[]; 
   };
 }
 
-// ─── Due date ──────────────────────────────────────────────────────────────
+// ─── Calendar dates (start_date / due_date) ──────────────────────────────────
+// ClickUp's start_date and due_date are both native epoch-ms fields, so a
+// single calendar-date codec serves both. The `dueDate*`/`startDate*` names
+// below are thin, self-documenting aliases over the shared codec.
 
 /** YYYY-MM-DD → ClickUp epoch-ms. UTC noon keeps the calendar day stable in any timezone. */
-export function dueDateToClickUp(date: string | null | undefined): number | null {
+export function calendarDateToClickUp(date: string | null | undefined): number | null {
   if (!date) return null;
   const ms = Date.parse(`${date}T12:00:00Z`);
   return Number.isFinite(ms) ? ms : null;
 }
 
-/** ClickUp due_date (epoch-ms string) → YYYY-MM-DD (UTC date part). */
-export function dueDateFromClickUp(value: string | number | null | undefined): string | null {
+/** ClickUp epoch-ms (string or number) → YYYY-MM-DD (UTC date part). */
+export function calendarDateFromClickUp(value: string | number | null | undefined): string | null {
   const ms = serverTimeMs(value ?? null);
   return ms === null ? null : new Date(ms).toISOString().split('T')[0];
 }
+
+/** YYYY-MM-DD → ClickUp due_date epoch-ms. */
+export const dueDateToClickUp = calendarDateToClickUp;
+/** ClickUp due_date (epoch-ms) → YYYY-MM-DD. */
+export const dueDateFromClickUp = calendarDateFromClickUp;
+/** YYYY-MM-DD → ClickUp start_date epoch-ms. */
+export const startDateToClickUp = calendarDateToClickUp;
+/** ClickUp start_date (epoch-ms) → YYYY-MM-DD. */
+export const startDateFromClickUp = calendarDateFromClickUp;
 
 // ─── Server time ───────────────────────────────────────────────────────────
 

--- a/src/lib/task-backend/clickup.ts
+++ b/src/lib/task-backend/clickup.ts
@@ -9,6 +9,8 @@ import {
   bodyToDescription,
   dueDateFromClickUp,
   dueDateToClickUp,
+  startDateFromClickUp,
+  startDateToClickUp,
   foldAscii,
   normalizeEntry,
   priorityFromClickUp,
@@ -591,18 +593,25 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     // Map the status against the list's actual status set; an unmappable
     // status is OMITTED (the remote keeps its value) instead of 400-ing.
     const mappedStatus = statusToClickUp(task.status, this.ledger.readListStatuses());
-    // due_date rides the same single PUT/POST (a NATIVE ClickUp field).
-    // Sent when set, or as null to clear one the remote already had.
+    // start_date + due_date ride the same single PUT/POST (both NATIVE ClickUp
+    // fields). Each is sent when set, or as null to CLEAR one the remote already
+    // had (so clears propagate). Backlog tasks are undated by rule → both null.
     const isBacklog = task.tags.some((t) => t.toLowerCase() === BACKLOG_TAG);
     const dueLocal = isBacklog ? null : ((task.raw.due_date as string | null | undefined) ?? null);
-    const baseFmDue = entry?.base_snapshot
-      ? (((matter(entry.base_snapshot.body).data as Record<string, unknown>).due_date as string | null | undefined) ?? null)
+    const startLocal = isBacklog ? null : ((task.raw.start_date as string | null | undefined) ?? null);
+    const baseSnapshotFm = entry?.base_snapshot
+      ? (matter(entry.base_snapshot.body).data as Record<string, unknown>)
       : null;
+    const baseFmDue = (baseSnapshotFm?.due_date as string | null | undefined) ?? null;
+    const baseFmStart = (baseSnapshotFm?.start_date as string | null | undefined) ?? null;
     const fields = {
       name: task.name,
       description: bodyToDescription(task.body),
       ...(mappedStatus !== null ? { status: mappedStatus } : {}),
       priority: priorityToClickUp(task.priority),
+      ...(startLocal !== null || baseFmStart !== null
+        ? { start_date: startDateToClickUp(startLocal), start_date_time: false }
+        : {}),
       ...(dueLocal !== null || baseFmDue !== null
         ? { due_date: dueDateToClickUp(dueLocal), due_date_time: false }
         : {}),
@@ -912,6 +921,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     const remotePriority = priorityFromClickUp(remote.priority);
     const remoteDesc = (remote.description ?? '').replace(/\r\n/g, '\n').trim();
     const remoteDue = dueDateFromClickUp(remote.due_date);
+    const remoteStart = startDateFromClickUp(remote.start_date);
     // Every remote assignee maps back to a person:<slug> tag (sorted + deduped
     // for order-stable merges). dreamcontext leans on person tags, not a single
     // assignee field, so the full set round-trips.
@@ -944,6 +954,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
         related_feature: null,
         version: remoteVersion,
         rice: null,
+        start_date: remoteStart,
         due_date: remoteDue,
         created_by: 'clickup',
         updated_by: 'clickup',
@@ -1067,8 +1078,13 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
       ((local.raw.due_date as string | null | undefined) ?? null),
       remoteDue,
     );
+    const startM = scalar(
+      ((baseFm?.start_date as string | null | undefined) ?? null) as string | null,
+      ((local.raw.start_date as string | null | undefined) ?? null),
+      remoteStart,
+    );
 
-    const scalarResults = [statusM, priorityM, nameM, tagsM, versionM, assigneeM, dueM];
+    const scalarResults = [statusM, priorityM, nameM, tagsM, versionM, assigneeM, dueM, startM];
     const anyLocalWin = scalarResults.some((r) => r.winner === 'local')
       || fieldWinners.some((r) => r.winner === 'local');
     const anyRemoteWin = scalarResults.some((r) => r.winner === 'remote')
@@ -1091,6 +1107,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
       tags: withPersonTags(tagsM.value, assigneeM.value),
       version: versionM.value,
       // Product rule: backlog ⇒ undated (applies to remote-originated state too).
+      start_date: tagsM.value.some((t) => t.toLowerCase() === BACKLOG_TAG) ? null : startM.value,
       due_date: tagsM.value.some((t) => t.toLowerCase() === BACKLOG_TAG) ? null : dueM.value,
       updated_at: remoteContributed && remoteTime !== null ? dateOf(remoteTime) : local.updated_at,
       // updated_by records the WINNER of the merge.
@@ -1139,7 +1156,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
         }
       }
       const remoteRender = this.renderMirror(
-        { ...fm, name: remote.name, status: remoteStatus, priority: remotePriority, tags: withPersonTags(remoteTags, remoteAssignees), version: remoteVersion, due_date: remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG) ? null : remoteDue, ...remoteFmOverrides, rice: remoteRice },
+        { ...fm, name: remote.name, status: remoteStatus, priority: remotePriority, tags: withPersonTags(remoteTags, remoteAssignees), version: remoteVersion, start_date: remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG) ? null : remoteStart, due_date: remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG) ? null : remoteDue, ...remoteFmOverrides, rice: remoteRice },
         remoteDesc,
         remoteEntries,
       );
@@ -1174,6 +1191,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
         ['version', versionM, local.version],
         ['assignees', assigneeM, assigneeSlugsOf(local.raw, local.tags)],
         ['due_date', dueM, (local.raw.due_date as string | null | undefined) ?? null],
+        ['start_date', startM, (local.raw.start_date as string | null | undefined) ?? null],
       ];
       for (const [field, merged, from] of namedScalars) {
         if (merged.winner === 'remote') {

--- a/src/lib/task-backend/github-map.ts
+++ b/src/lib/task-backend/github-map.ts
@@ -264,6 +264,79 @@ export function bodyToIssueBody(body: string): string {
   return out.join('\n').trimEnd() + '\n';
 }
 
+// ─── Dates (start_date / due_date) — encoded IN the issue body ─────────────────
+// GitHub Issues have no native date fields, so to make dates RELIABLY sync we
+// persist them inside the issue body as a marked, human-visible block. The block
+// is the single source of truth on the remote: it round-trips deterministically,
+// is stripped from the prose before any 3-way merge (so dates never collide with
+// prose edits), and is re-composed on push from the merged frontmatter values.
+// A task with no dates carries NO block (the body bytes stay exactly as before).
+
+const DATES_OPEN = '<!-- dc:dates -->';
+const DATES_CLOSE = '<!-- /dc:dates -->';
+const DATE_RE = /\b(\d{4}-\d{2}-\d{2})\b/;
+
+/**
+ * Render the dates block for an issue body, or '' when neither date is set.
+ * Visible form (so it reads well in the GitHub UI):
+ *   <!-- dc:dates -->
+ *   > 🗓️ **Start:** 2026-06-22 · **Due:** 2026-06-27
+ *   <!-- /dc:dates -->
+ */
+export function renderDatesBlock(start: string | null | undefined, due: string | null | undefined): string {
+  const parts: string[] = [];
+  if (start) parts.push(`**Start:** ${start}`);
+  if (due) parts.push(`**Due:** ${due}`);
+  if (parts.length === 0) return '';
+  return `${DATES_OPEN}\n> 🗓️ ${parts.join(' · ')}\n${DATES_CLOSE}`;
+}
+
+/** Parse the dates block out of an issue body. Missing block / dates → nulls. */
+export function parseDatesBlock(body: string | null | undefined): { start: string | null; due: string | null } {
+  if (!body) return { start: null, due: null };
+  const open = body.indexOf(DATES_OPEN);
+  const close = body.indexOf(DATES_CLOSE);
+  if (open === -1 || close === -1 || close < open) return { start: null, due: null };
+  const inner = body.slice(open + DATES_OPEN.length, close);
+  const startMatch = inner.match(/\*\*Start:\*\*\s*/);
+  const dueMatch = inner.match(/\*\*Due:\*\*\s*/);
+  const after = (m: RegExpMatchArray | null): string | null => {
+    if (!m || m.index === undefined) return null;
+    const d = inner.slice(m.index + m[0].length).match(DATE_RE);
+    return d ? d[1] : null;
+  };
+  return { start: after(startMatch), due: after(dueMatch) };
+}
+
+/** Remove the dates block (and the blank lines hugging it) from an issue body. */
+export function stripDatesBlock(body: string | null | undefined): string {
+  if (!body) return '';
+  const open = body.indexOf(DATES_OPEN);
+  const close = body.indexOf(DATES_CLOSE);
+  if (open === -1 || close === -1 || close < open) return body;
+  const before = body.slice(0, open).replace(/\n+$/, '');
+  const after = body.slice(close + DATES_CLOSE.length).replace(/^\n+/, '');
+  if (before && after) return `${before}\n\n${after}`;
+  return before || after;
+}
+
+/**
+ * Compose the full issue body for a push: the dates block (when any date is set)
+ * above the changelog-free prose. `prose` is expected to already be the output
+ * of {@link bodyToIssueBody}. Idempotent — strips any stray block from `prose`
+ * first so re-pushes never stack duplicate blocks.
+ */
+export function composeIssueBody(
+  prose: string,
+  start: string | null | undefined,
+  due: string | null | undefined,
+): string {
+  const cleanProse = stripDatesBlock(prose).trimEnd();
+  const block = renderDatesBlock(start, due);
+  if (!block) return cleanProse ? `${cleanProse}\n` : '';
+  return cleanProse ? `${block}\n\n${cleanProse}\n` : `${block}\n`;
+}
+
 // ─── Server time / watermark ──────────────────────────────────────────────────
 
 /**

--- a/src/lib/task-backend/github.ts
+++ b/src/lib/task-backend/github.ts
@@ -7,6 +7,9 @@ import { ApiAdapter } from './api-adapter.js';
 import { foldAscii } from './clickup-map.js';
 import {
   bodyToIssueBody,
+  composeIssueBody,
+  parseDatesBlock,
+  stripDatesBlock,
   deleteToGitHub,
   githubTimeMs,
   githubTimeIso,
@@ -553,7 +556,13 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       status: task.status,
     });
 
-    const body = bodyToIssueBody(task.body);
+    // GitHub has no native date fields, so start/due ride INSIDE the issue body
+    // as a marked block (the only way they reliably sync over plain REST).
+    // Backlog tasks are undated by rule → no block.
+    const isBacklog = task.tags.some((t) => t.toLowerCase() === BACKLOG_TAG);
+    const startLocal = isBacklog ? null : ((task.raw.start_date as string | null | undefined) ?? null);
+    const dueLocal = isBacklog ? null : ((task.raw.due_date as string | null | undefined) ?? null);
+    const body = composeIssueBody(bodyToIssueBody(task.body), startLocal, dueLocal);
 
     let remoteId = this.ledger.remoteIdFor(slug);
     let serverTime: number | null = null;
@@ -793,7 +802,14 @@ export class GitHubTaskBackend extends LocalTaskBackend {
 
     const { tags: remoteTags, priority: remotePriority, urgency: remoteUrgency, version: remoteVersion } =
       labelsFromGitHub(issue.labels);
-    const remoteBody = (issue.body ?? '').replace(/\r\n/g, '\n').trim();
+    // Dates live in a marked block inside the issue body — parse them out, then
+    // strip the block so the prose that goes into the 3-way merge is date-free.
+    const normalizedIssueBody = (issue.body ?? '').replace(/\r\n/g, '\n');
+    const { start: remoteStartRaw, due: remoteDueRaw } = parseDatesBlock(normalizedIssueBody);
+    const remoteBacklog = remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG);
+    const remoteStart = remoteBacklog ? null : remoteStartRaw;
+    const remoteDue = remoteBacklog ? null : remoteDueRaw;
+    const remoteBody = stripDatesBlock(normalizedIssueBody).trim();
     // Every assignee login maps back to a person:<slug> tag. Guard the resolve
     // path so a non-collaborator / unknown login is skipped, not a crash.
     const remoteAssignees: string[] = [
@@ -829,7 +845,8 @@ export class GitHubTaskBackend extends LocalTaskBackend {
         related_feature: null,
         version: remoteVersion,
         rice: null,
-        due_date: null,
+        start_date: remoteStart,
+        due_date: remoteDue,
         created_by: 'github',
         updated_by: 'github',
       };
@@ -929,8 +946,20 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       assigneeSlugsOf(local.raw, local.tags),
       remoteAssignees,
     );
+    // Dates round-trip through the issue-body block (parsed above), merged LWW
+    // just like the other scalars so a clear or an edit propagates either way.
+    const dueM = scalar(
+      (baseFm?.due_date as string | null | undefined) ?? null,
+      (local.raw.due_date as string | null | undefined) ?? null,
+      remoteDue,
+    );
+    const startM = scalar(
+      (baseFm?.start_date as string | null | undefined) ?? null,
+      (local.raw.start_date as string | null | undefined) ?? null,
+      remoteStart,
+    );
 
-    const scalarResults = [statusM, priorityM, urgencyM, nameM, tagsM, versionM, assigneeM];
+    const scalarResults = [statusM, priorityM, urgencyM, nameM, tagsM, versionM, assigneeM, dueM, startM];
     const anyLocalWin = scalarResults.some((r) => r.winner === 'local');
     const anyRemoteWin = scalarResults.some((r) => r.winner === 'remote');
     const remoteAddedEntries = mergedEntries.length > localEntries.length;
@@ -949,9 +978,12 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       urgency: urgencyM.value,
       tags: withPersonTags(tagsM.value, assigneeM.value),
       version: versionM.value,
+      start_date: tagsM.value.some((t) => t.toLowerCase() === BACKLOG_TAG)
+        ? null
+        : startM.value,
       due_date: tagsM.value.some((t) => t.toLowerCase() === BACKLOG_TAG)
         ? null
-        : ((local.raw.due_date as string | null | undefined) ?? null),
+        : dueM.value,
       updated_at: remoteContributed && remoteTime !== null ? dateOf(remoteTime) : local.updated_at,
       updated_by: anyRemoteWin || conflicts.length > 0 ? 'github' : (local.raw.updated_by ?? null),
     };
@@ -970,9 +1002,12 @@ export class GitHubTaskBackend extends LocalTaskBackend {
           urgency: remoteUrgency ?? fm.urgency,
           tags: withPersonTags(remoteTags, remoteAssignees),
           version: remoteVersion,
+          start_date: remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG)
+            ? null
+            : remoteStart,
           due_date: remoteTags.some((t) => t.toLowerCase() === BACKLOG_TAG)
             ? null
-            : ((local.raw.due_date as string | null | undefined) ?? null),
+            : remoteDue,
         },
         remoteBody,
         remoteEntries,
@@ -1006,6 +1041,8 @@ export class GitHubTaskBackend extends LocalTaskBackend {
         ['tags', tagsM, stripPersonTags(local.tags)],
         ['version', versionM, local.version],
         ['assignees', assigneeM, assigneeSlugsOf(local.raw, local.tags)],
+        ['due_date', dueM, (local.raw.due_date as string | null | undefined) ?? null],
+        ['start_date', startM, (local.raw.start_date as string | null | undefined) ?? null],
       ];
       for (const [field, merged, from] of namedScalars) {
         if (merged.winner === 'remote') {

--- a/src/lib/task-backend/local.ts
+++ b/src/lib/task-backend/local.ts
@@ -35,10 +35,10 @@ export function isSafeTaskSlug(slug: string): boolean {
 
 /**
  * Product rule: a `backlog` tag means "not planned" — backlog tasks carry NO
- * due date. The invariant is enforced at the backend so every surface (CLI,
- * dashboard, sync) behaves identically:
- *  - adding the backlog tag clears the due date
- *  - explicitly setting a due date pulls the task OUT of backlog
+ * dates (neither a start nor a due date). The invariant is enforced at the
+ * backend so every surface (CLI, dashboard, sync) behaves identically:
+ *  - adding the backlog tag clears both the start and due date
+ *  - explicitly setting EITHER date pulls the task OUT of backlog
  *  - if both arrive in one patch, backlog wins (the stronger statement)
  */
 export const BACKLOG_TAG = 'backlog';
@@ -47,26 +47,34 @@ function hasBacklogTag(tags: unknown): boolean {
   return Array.isArray(tags) && tags.some((t) => String(t).toLowerCase() === BACKLOG_TAG);
 }
 
+function isSet(v: unknown): boolean {
+  return v !== null && v !== undefined;
+}
+
 export function normalizeBacklogFields(
   prev: Record<string, unknown>,
   patch: Record<string, unknown>,
 ): Record<string, unknown> {
   const nextTags = patch.tags !== undefined ? patch.tags : prev.tags;
   const nextDue = patch.due_date !== undefined ? patch.due_date : (prev.due_date ?? null);
-  if (!hasBacklogTag(nextTags) || nextDue === null || nextDue === undefined) return patch;
+  const nextStart = patch.start_date !== undefined ? patch.start_date : (prev.start_date ?? null);
+  if (!hasBacklogTag(nextTags) || (!isSet(nextDue) && !isSet(nextStart))) return patch;
 
-  const dueExplicit = patch.due_date !== undefined && patch.due_date !== null;
+  // A date arriving explicitly in THIS patch is the user scheduling the task.
+  const dateExplicit =
+    (patch.due_date !== undefined && patch.due_date !== null) ||
+    (patch.start_date !== undefined && patch.start_date !== null);
   const backlogAdded = patch.tags !== undefined && hasBacklogTag(patch.tags) && !hasBacklogTag(prev.tags);
 
-  if (dueExplicit && !backlogAdded) {
+  if (dateExplicit && !backlogAdded) {
     // Scheduling an existing backlog task → it is planned now, drop the tag.
     const tags = (Array.isArray(nextTags) ? nextTags : []).filter(
       (t) => String(t).toLowerCase() !== BACKLOG_TAG,
     );
     return { ...patch, tags };
   }
-  // Backlog (newly added, or both in one patch) → undated.
-  return { ...patch, due_date: null };
+  // Backlog (newly added, or both in one patch) → undated: clear BOTH dates.
+  return { ...patch, due_date: null, start_date: null };
 }
 
 /** Resolve the task template exactly as the pre-refactor CLI did. */
@@ -187,6 +195,7 @@ export function readTaskFile(filePath: string): TaskData {
     related_feature: (data.related_feature as string) ?? null,
     version: (data.version as string) ?? null,
     rice: normalizeRice(data.rice),
+    start_date: (data.start_date as string) ?? null,
     due_date: (data.due_date as string) ?? null,
     assignee: (data.assignee as string) ?? null,
     why: readSectionSafe(filePath, 'Why'),
@@ -252,8 +261,8 @@ export class LocalTaskBackend implements TaskBackend {
   }
 
   async create(input: CreateTaskInput): Promise<TaskData> {
-    if (input.due_date && (input.tags ?? []).some((t) => t.toLowerCase() === BACKLOG_TAG)) {
-      input = { ...input, due_date: null }; // backlog tasks are undated by rule
+    if ((input.due_date || input.start_date) && (input.tags ?? []).some((t) => t.toLowerCase() === BACKLOG_TAG)) {
+      input = { ...input, due_date: null, start_date: null }; // backlog tasks are undated by rule
     }
     const slug = slugify(input.name.trim());
     if (!isSafeTaskSlug(slug)) {
@@ -286,8 +295,11 @@ export class LocalTaskBackend implements TaskBackend {
       if (input.rice) {
         updateFrontmatterFields(filePath, { rice: input.rice });
       }
-      // due_date is additive: only written when provided, so tasks created
-      // without one keep the exact pre-#11 bytes (golden-pinned).
+      // start_date / due_date are additive: only written when provided, so
+      // tasks created without them keep the exact pre-#11 bytes (golden-pinned).
+      if (input.start_date) {
+        updateFrontmatterFields(filePath, { start_date: input.start_date });
+      }
       if (input.due_date) {
         updateFrontmatterFields(filePath, { due_date: input.due_date });
       }
@@ -347,6 +359,9 @@ ${input.why || '(To be defined)'}
 - Task created.
 `;
       writeFileSync(filePath, content, 'utf-8');
+      if (input.start_date) {
+        updateFrontmatterFields(filePath, { start_date: input.start_date });
+      }
       if (input.due_date) {
         updateFrontmatterFields(filePath, { due_date: input.due_date });
       }
@@ -361,7 +376,7 @@ ${input.why || '(To be defined)'}
     opts?: UpdateFieldsOptions,
   ): Promise<TaskData> {
     const path = this.requirePath(slug);
-    if (fields.tags !== undefined || fields.due_date !== undefined) {
+    if (fields.tags !== undefined || fields.due_date !== undefined || fields.start_date !== undefined) {
       const { data: prev } = readFrontmatter<Record<string, unknown>>(path);
       fields = normalizeBacklogFields(prev, fields);
     }

--- a/src/lib/task-backend/types.ts
+++ b/src/lib/task-backend/types.ts
@@ -28,7 +28,9 @@ export interface TaskFrontmatter {
   related_feature: string | null;
   version: string | null;
   rice: RiceFields | null;
-  /** Optional due date (YYYY-MM-DD). Absent on tasks that never set one. */
+  /** Optional planned START of the task's date range (YYYY-MM-DD). */
+  start_date?: string | null;
+  /** Optional due/END date (YYYY-MM-DD). Absent on tasks that never set one. */
   due_date?: string | null;
   /** Remote identity — present only for synced tasks on a remote backend. */
   assignee?: string | null;
@@ -55,6 +57,7 @@ export interface TaskData {
   related_feature: string | null;
   version: string | null;
   rice: RiceFields | null;
+  start_date: string | null;
   due_date: string | null;
   assignee: string | null;
   why: string;
@@ -97,6 +100,7 @@ export interface CreateTaskInput {
   why?: string;
   version?: string | null;
   rice?: RiceFields | null;
+  start_date?: string | null;
   due_date?: string | null;
   /**
    * Which historical template produced the file. The CLI and the dashboard

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -95,6 +95,26 @@ export async function handleTasksCreate(
     riceBlock = mergeRice(null, riceInput);
   }
 
+  // Optional date range — validated YYYY-MM-DD (or absent). Synced to the remote
+  // backend like any other field; the backend enforces the backlog-undated rule.
+  const isYmdDate = (v: unknown): v is string =>
+    typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v) && !Number.isNaN(Date.parse(`${v}T00:00:00Z`));
+  let startDate: string | null = null;
+  let dueDate: string | null = null;
+  for (const [key, set] of [['start_date', (v: string) => { startDate = v; }], ['due_date', (v: string) => { dueDate = v; }]] as const) {
+    if (body[key] !== undefined && body[key] !== null) {
+      if (!isYmdDate(body[key])) {
+        sendError(res, 400, `invalid_${key}`, `${key} must be YYYY-MM-DD or null.`);
+        return;
+      }
+      set(body[key] as string);
+    }
+  }
+  if (startDate && dueDate && startDate > dueDate) {
+    sendError(res, 400, 'invalid_date_range', `start_date (${startDate}) cannot be after due_date (${dueDate}).`);
+    return;
+  }
+
   const backend = backendFor(contextRoot);
   let task: TaskData;
   try {
@@ -107,6 +127,8 @@ export async function handleTasksCreate(
       why,
       version,
       rice: riceBlock,
+      start_date: startDate,
+      due_date: dueDate,
       variant: 'dashboard',
     });
   } catch (err) {
@@ -419,7 +441,7 @@ export async function handleTasksUpdate(
     }
   }
 
-  const allowedFields = ['status', 'priority', 'urgency', 'description', 'tags', 'name', 'related_feature', 'version', 'due_date', 'assignee'];
+  const allowedFields = ['status', 'priority', 'urgency', 'description', 'tags', 'name', 'related_feature', 'version', 'start_date', 'due_date', 'assignee'];
   for (const field of allowedFields) {
     if (body[field] !== undefined) {
       const oldVal = (oldData[field] ?? null) as FieldChange['from'];
@@ -471,10 +493,24 @@ export async function handleTasksUpdate(
     return;
   }
 
-  // Validate due_date (YYYY-MM-DD or null to clear)
-  if (updates.due_date !== undefined && updates.due_date !== null) {
-    if (typeof updates.due_date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(updates.due_date)) {
-      sendError(res, 400, 'invalid_due_date', 'due_date must be YYYY-MM-DD or null.');
+  // Validate start_date / due_date (YYYY-MM-DD or null to clear). Both ride the
+  // same shape and both sync to the remote backend.
+  const isYmd = (v: unknown): v is string =>
+    typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v) && !Number.isNaN(Date.parse(`${v}T00:00:00Z`));
+  for (const dateField of ['start_date', 'due_date'] as const) {
+    if (updates[dateField] !== undefined && updates[dateField] !== null && !isYmd(updates[dateField])) {
+      sendError(res, 400, `invalid_${dateField}`, `${dateField} must be YYYY-MM-DD or null.`);
+      return;
+    }
+  }
+  // Range sanity: the EFFECTIVE start (after this patch) must not be after the
+  // effective due. A backlog task clears both in the backend, so only check when
+  // both resolve to a real date here.
+  {
+    const effStart = updates.start_date !== undefined ? updates.start_date : existing.start_date;
+    const effDue = updates.due_date !== undefined ? updates.due_date : existing.due_date;
+    if (isYmd(effStart) && isYmd(effDue) && effStart > effDue) {
+      sendError(res, 400, 'invalid_date_range', `start_date (${effStart}) cannot be after due_date (${effDue}).`);
       return;
     }
   }

--- a/tests/unit/clickup-fake.ts
+++ b/tests/unit/clickup-fake.ts
@@ -23,6 +23,7 @@ export interface FakeTask {
   assignees: Array<{ id: number }>;
   date_created: string;
   date_updated: string;
+  start_date?: string | null;
   due_date?: string | null;
   /** def + value merged, like the real API's task payload. */
   custom_fields: Array<FakeFieldDef & { value?: unknown }>;
@@ -167,6 +168,7 @@ export function makeFakeClickUp(opts: { serverStart?: number } = {}): FakeClickU
           assignees: (body.assignees ?? []).map((id2: number) => ({ id: id2 })),
           date_created: String(serverTime),
           date_updated: String(serverTime),
+          start_date: body.start_date !== undefined && body.start_date !== null ? String(body.start_date) : null,
           due_date: body.due_date !== undefined && body.due_date !== null ? String(body.due_date) : null,
           custom_fields: fake.customFields.map((f) => ({ ...f })),
         };
@@ -217,6 +219,7 @@ export function makeFakeClickUp(opts: { serverStart?: number } = {}): FakeClickU
           if (body.description !== undefined) task.description = body.description;
           if (body.status !== undefined) task.status = { status: body.status };
           if (body.priority !== undefined) task.priority = { id: String(body.priority) };
+          if (body.start_date !== undefined) task.start_date = body.start_date === null ? null : String(body.start_date);
           if (body.due_date !== undefined) task.due_date = body.due_date === null ? null : String(body.due_date);
           if (body.assignees?.add) {
             for (const a of body.assignees.add) {

--- a/tests/unit/clickup-start-date.test.ts
+++ b/tests/unit/clickup-start-date.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, readFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { ClickUpTaskBackend } from '../../src/lib/task-backend/clickup.js';
+import { ApiAdapter } from '../../src/lib/task-backend/api-adapter.js';
+import { startDateToClickUp, startDateFromClickUp } from '../../src/lib/task-backend/clickup-map.js';
+import type { SetupConfig } from '../../src/lib/setup-config.js';
+import { makeFakeClickUp, type FakeClickUp } from './clickup-fake.js';
+
+/**
+ * start_date — a NATIVE ClickUp field, the planned START of a task's date range
+ * (the due_date is the END). Same epoch-ms wire shape as due_date; both ride the
+ * single PUT/POST and both clear by sending null.
+ */
+
+const CONFIG: SetupConfig = {
+  platforms: [],
+  packs: [],
+  multiProduct: false,
+  setupVersion: '0.0.0',
+  disableNativeMemory: true,
+  taskBackend: 'clickup',
+  cloudTaskManagement: true,
+  clickup: { teamId: 'team1', spaceId: 'space1', listId: 'list1', changelogTarget: 'comments' },
+};
+
+let projectRoot: string;
+let contextRoot: string;
+let fake: FakeClickUp;
+let backend: ClickUpTaskBackend;
+let localClock: number;
+
+beforeEach(() => {
+  delete process.env.DREAMCONTEXT_PERSON;
+  const raw = join(tmpdir(), `dc-cus-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(raw, { recursive: true });
+  projectRoot = realpathSync(raw);
+  contextRoot = join(projectRoot, '_dream_context');
+  mkdirSync(join(contextRoot, 'state'), { recursive: true });
+  localClock = 1000;
+  fake = makeFakeClickUp();
+  const now = () => (localClock += 7);
+  const sleep = async () => { localClock += 1; };
+  const adapter = new ApiAdapter({
+    baseUrl: 'https://api.clickup.com/api/v2',
+    authHeaders: () => ({ Authorization: 'pk_test' }),
+    fetchImpl: fake.fetchImpl,
+    now,
+    sleep,
+  });
+  backend = new ClickUpTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function mirror(slug: string): string {
+  return readFileSync(join(contextRoot, 'state', `${slug}.md`), 'utf-8');
+}
+
+describe('start_date sync (native ClickUp field)', () => {
+  it('conversion round-trips on the same calendar day', () => {
+    const ms = startDateToClickUp('2026-07-01');
+    expect(ms).toBe(Date.parse('2026-07-01T12:00:00Z'));
+    expect(startDateFromClickUp(String(ms))).toBe('2026-07-01');
+    expect(startDateToClickUp(null)).toBeNull();
+    expect(startDateFromClickUp(null)).toBeNull();
+  });
+
+  it('creating with a start+due range pushes BOTH native fields', async () => {
+    await backend.create({ name: 'Sprint', start_date: '2026-07-01', due_date: '2026-07-15', variant: 'cli' });
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    const remote = [...fake.tasks.values()][0];
+    expect(remote.start_date).toBe(String(Date.parse('2026-07-01T12:00:00Z')));
+    expect(remote.due_date).toBe(String(Date.parse('2026-07-15T12:00:00Z')));
+  });
+
+  it('setting then clearing start_date rides the single PUT and propagates the clear', async () => {
+    await backend.create({ name: 'Planner', variant: 'cli' });
+    await backend.sync('push');
+    const rid = [...fake.tasks.keys()][0];
+
+    await backend.updateFields('planner', { start_date: '2026-08-01', updated_at: '2026-06-11' });
+    await backend.sync('push');
+    expect(fake.tasks.get(rid)!.start_date).toBe(String(Date.parse('2026-08-01T12:00:00Z')));
+
+    await backend.updateFields('planner', { start_date: null, updated_at: '2026-06-11' });
+    await backend.sync('push');
+    expect(fake.tasks.get(rid)!.start_date).toBeNull();
+  });
+
+  it('a remote start-date change pulls into the mirror', async () => {
+    await backend.create({ name: 'Pull Start', start_date: '2026-07-01', variant: 'cli' });
+    await backend.sync('push');
+    const rid = [...fake.tasks.keys()][0];
+
+    fake.editTask(rid, { start_date: String(Date.parse('2026-09-09T12:00:00Z')) });
+    await backend.sync('pull');
+    expect(mirror('pull-start')).toContain("start_date: '2026-09-09'");
+  });
+
+  it('a start+due range converges (follow-up sync is a no-op)', async () => {
+    await backend.create({ name: 'Range Conv', start_date: '2026-07-01', due_date: '2026-07-09', variant: 'cli' });
+    await backend.sync('both');
+    fake.requests.length = 0;
+    const again = await backend.sync('both');
+    expect(again.pushed).toBe(0);
+    expect(again.pulled).toBe(0);
+    expect(fake.requests.filter((r) => r.method !== 'GET')).toHaveLength(0);
+  });
+});

--- a/tests/unit/github-dates.test.ts
+++ b/tests/unit/github-dates.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, readFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { GitHubTaskBackend } from '../../src/lib/task-backend/github.js';
+import { ApiAdapter } from '../../src/lib/task-backend/api-adapter.js';
+import type { SetupConfig } from '../../src/lib/setup-config.js';
+import { makeFakeGitHub, type FakeGitHub } from './github-fake.js';
+import {
+  renderDatesBlock,
+  parseDatesBlock,
+  stripDatesBlock,
+  composeIssueBody,
+} from '../../src/lib/task-backend/github-map.js';
+
+/**
+ * GitHub Issues have NO native date fields, so start/due are persisted INSIDE
+ * the issue body as a marked block. These tests pin (1) the pure block codec and
+ * (2) a full push→pull round-trip proving the dates reliably survive the remote.
+ */
+
+// ─── Pure block codec ────────────────────────────────────────────────────────
+
+describe('github dates block codec', () => {
+  it('renders nothing when neither date is set', () => {
+    expect(renderDatesBlock(null, null)).toBe('');
+    expect(renderDatesBlock(undefined, undefined)).toBe('');
+  });
+
+  it('renders start, due, or both', () => {
+    expect(renderDatesBlock('2026-07-01', null)).toContain('**Start:** 2026-07-01');
+    expect(renderDatesBlock(null, '2026-07-15')).toContain('**Due:** 2026-07-15');
+    const both = renderDatesBlock('2026-07-01', '2026-07-15');
+    expect(both).toContain('**Start:** 2026-07-01');
+    expect(both).toContain('**Due:** 2026-07-15');
+  });
+
+  it('parse(render(x)) round-trips both dates', () => {
+    const body = renderDatesBlock('2026-07-01', '2026-07-15');
+    expect(parseDatesBlock(body)).toEqual({ start: '2026-07-01', due: '2026-07-15' });
+  });
+
+  it('parses dates embedded in a larger body and ignores prose dates', () => {
+    const body = composeIssueBody('## Why\n\nShip by 2099-01-01 ideally.\n', '2026-07-01', '2026-07-15');
+    expect(parseDatesBlock(body)).toEqual({ start: '2026-07-01', due: '2026-07-15' });
+  });
+
+  it('parses missing block as nulls', () => {
+    expect(parseDatesBlock('## Why\n\nNo dates here.')).toEqual({ start: null, due: null });
+    expect(parseDatesBlock('')).toEqual({ start: null, due: null });
+  });
+
+  it('strips the block and leaves clean prose', () => {
+    const prose = '## Why\n\nDo the thing.\n';
+    const composed = composeIssueBody(prose, '2026-07-01', '2026-07-15');
+    expect(composed).toContain('dc:dates');
+    expect(stripDatesBlock(composed).trim()).toBe(prose.trim());
+  });
+
+  it('composeIssueBody is idempotent (never stacks duplicate blocks)', () => {
+    const once = composeIssueBody('## Why\n\nx\n', '2026-07-01', '2026-07-15');
+    const twice = composeIssueBody(once, '2026-07-01', '2026-07-15');
+    expect(twice).toBe(once);
+    // exactly one OPEN marker (the close marker is `<!-- /dc:dates -->`)
+    expect(twice.match(/<!-- dc:dates -->/g)?.length).toBe(1);
+  });
+
+  it('a task with no dates yields a date-free body (byte-stable)', () => {
+    const prose = '## Why\n\nNothing scheduled.\n';
+    expect(composeIssueBody(prose, null, null)).toBe(prose);
+  });
+});
+
+// ─── Full push → pull round-trip through the fake remote ─────────────────────
+
+const CONFIG: SetupConfig = {
+  platforms: [],
+  packs: [],
+  multiProduct: false,
+  setupVersion: '0.0.0',
+  disableNativeMemory: true,
+  taskBackend: 'github',
+  cloudTaskManagement: true,
+  github: { owner: 'meanllbrl', repo: 'dreamcontext', changelogTarget: 'comments' },
+};
+
+let projectRoot: string;
+let contextRoot: string;
+let fake: FakeGitHub;
+let backend: GitHubTaskBackend;
+let localClock: number;
+
+function makeBackend(): GitHubTaskBackend {
+  const now = () => (localClock += 7);
+  const sleep = async () => { localClock += 1; };
+  const adapter = new ApiAdapter({
+    baseUrl: 'https://api.github.com',
+    authHeaders: () => ({ Authorization: 'Bearer ghp_test' }),
+    fetchImpl: fake.fetchImpl,
+    now,
+    sleep,
+  });
+  return new GitHubTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+}
+
+beforeEach(() => {
+  delete process.env.DREAMCONTEXT_PERSON;
+  const raw = join(tmpdir(), `dc-ghd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(raw, { recursive: true });
+  projectRoot = realpathSync(raw);
+  contextRoot = join(projectRoot, '_dream_context');
+  mkdirSync(join(contextRoot, 'state'), { recursive: true });
+  localClock = 1000;
+  fake = makeFakeGitHub();
+  backend = makeBackend();
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function mirror(slug: string): string {
+  return readFileSync(join(contextRoot, 'state', `${slug}.md`), 'utf-8');
+}
+
+describe('github date sync (encoded in the issue body)', () => {
+  it('pushes start+due into the issue body and they survive the remote', async () => {
+    await backend.create({ name: 'Dated GH', start_date: '2026-07-01', due_date: '2026-07-15', variant: 'cli' });
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    const issue = [...fake.issues.values()][0];
+    expect(parseDatesBlock(issue.body)).toEqual({ start: '2026-07-01', due: '2026-07-15' });
+  });
+
+  it('a remote-created issue with a date block pulls dates into the mirror', async () => {
+    const issue = fake.seedIssue({
+      title: 'Remote Dated',
+      body: composeIssueBody('## Why\n\nremote work\n', '2026-08-01', '2026-08-20'),
+    });
+    expect(issue.number).toBeGreaterThan(0);
+    await backend.sync('pull');
+    const slug = JSON.parse(readFileSync(join(contextRoot, 'state', '.tasks-map.json'), 'utf-8'))[0].slug;
+    const file = mirror(slug);
+    expect(file).toContain("start_date: '2026-08-01'");
+    expect(file).toContain("due_date: '2026-08-20'");
+    // the date block must NOT leak into the local prose
+    expect(file).not.toContain('dc:dates');
+  });
+
+  it('clearing a due date locally removes it from the remote body on push', async () => {
+    await backend.create({ name: 'Clearable GH', due_date: '2026-07-15', variant: 'cli' });
+    await backend.sync('push');
+    const num = [...fake.issues.keys()][0];
+    expect(parseDatesBlock(fake.issues.get(num)!.body).due).toBe('2026-07-15');
+
+    await backend.updateFields('clearable-gh', { due_date: null, updated_at: '2026-06-11' });
+    await backend.sync('push');
+    expect(parseDatesBlock(fake.issues.get(num)!.body).due).toBeNull();
+  });
+
+  it('a date round-trip converges (follow-up sync is a no-op)', async () => {
+    await backend.create({ name: 'Conv GH', start_date: '2026-07-01', due_date: '2026-07-09', variant: 'cli' });
+    await backend.sync('both');
+    fake.requests.length = 0;
+    const again = await backend.sync('both');
+    expect(again.pushed).toBe(0);
+    expect(again.pulled).toBe(0);
+  });
+});

--- a/tests/unit/task-backend-conformance.ts
+++ b/tests/unit/task-backend-conformance.ts
@@ -163,26 +163,28 @@ export function describeTaskBackendConformance(
     });
 
     it('BACKLOG RULE: backlog-tagged tasks are undated; dating one un-backlogs it', async () => {
-      // create with both → backlog wins, due dropped
+      // create with both → backlog wins, BOTH start + due dropped
       const created = await backend.create({
-        name: 'Backlog Born', tags: ['backlog', 'x'], due_date: '2026-09-09', variant: 'cli',
+        name: 'Backlog Born', tags: ['backlog', 'x'], start_date: '2026-09-01', due_date: '2026-09-09', variant: 'cli',
       });
       expect(created.due_date).toBeNull();
+      expect(created.start_date).toBeNull();
       expect(created.tags).toContain('backlog');
 
-      // tagging an existing dated task as backlog clears the due date
-      await backend.create({ name: 'Dated Then Parked', due_date: '2026-10-10', variant: 'cli' });
+      // tagging an existing dated task as backlog clears BOTH dates
+      await backend.create({ name: 'Dated Then Parked', start_date: '2026-10-01', due_date: '2026-10-10', variant: 'cli' });
       const parked = await backend.updateFields('dated-then-parked', {
         tags: ['backlog'], updated_at: '2026-06-12',
       });
       expect(parked.due_date).toBeNull();
+      expect(parked.start_date).toBeNull();
       expect(parked.tags).toContain('backlog');
 
-      // explicitly scheduling a backlog task pulls it OUT of backlog
+      // explicitly scheduling a backlog task (via the START date) un-backlogs it
       const scheduled = await backend.updateFields('backlog-born', {
-        due_date: '2026-11-11', updated_at: '2026-06-12',
+        start_date: '2026-11-01', updated_at: '2026-06-12',
       });
-      expect(scheduled.due_date).toBe('2026-11-11');
+      expect(scheduled.start_date).toBe('2026-11-01');
       expect(scheduled.tags).not.toContain('backlog');
       expect(scheduled.tags).toContain('x'); // other tags survive
     });


### PR DESCRIPTION
## Summary

Tasks gain an optional **date range**: a planned `start_date` alongside the existing `due_date` (end). Both are `YYYY-MM-DD | null`, **clearable**, and reliably sync to the remote task backends.

This fixes the **root cause** behind "due dates don't reliably sync": on the GitHub backend, dates were **local-only** — never pushed. The original design mapped `due_date → milestone (coarse)`, but GitHub milestones are shared/repo-level with no "start" concept and that mapping was never implemented.

## What changed

**Model**
- Additive `start_date` on `TaskFrontmatter` / `TaskData` / `CreateTaskInput` + `readTaskFile`. Existing data and byte-exact golden tests are unaffected.
- Backlog rule extended: a `backlog`-tagged task clears **both** dates (`normalizeBacklogFields`), enforced in the backend so every surface (CLI, dashboard, sync) behaves identically.

**Sync — reliably synced both ways, clears propagate**
- **ClickUp**: `start_date` is a NATIVE epoch-ms field, fully symmetric with `due_date` — create POST, update PUT, base-snapshot clear propagation, LWW merge, mirror + base render, sleep journal.
- **GitHub**: Issues have no native date fields, so start/due ride in a marked `<!-- dc:dates -->` block **inside the issue body** — composed above the changelog-free prose on push, parsed out + stripped **before** the 3-way prose merge on pull, and LWW-merged as scalars. Per-issue, visible in the GitHub UI, deterministic round-trip. Supersedes the never-implemented, range-incapable milestone idea.

**CLI**
- `tasks start <name> <date|clear>`, clearable `tasks due <name> <date|clear>`, and `create --start/--due` — all with `start <= due` range validation.

**Server**
- PATCH and POST validate `start_date`/`due_date` and the range.

**Dashboard**
- A **Start date** editor in the task detail panel (clearable native date input).
- An **Assignee** multi-select filter in the tasks view, shown **only for cloud backends** (`backend !== 'local'`), matching `person:<slug>` tags.

## Tests
- New: ClickUp `start_date` sync, GitHub date-block codec + push/pull/clear/convergence round-trip.
- Extended: cross-backend conformance backlog rule now asserts both dates clear.
- All unit tests green; all 350 integration tests pass after build; dashboard Vite build clean. Manual CLI smoke test confirms set/clear, range rejection, invalid-date rejection, and backlog-clears-both.

## Notes
- Branched off clean `main` and developed in an isolated worktree to avoid colliding with concurrent in-flight work on the same checkout (timeline/calendar views + a member-match sync fix). `start_date` is a dependency those timeline views want.
- Follow-up for consolidation: record the GitHub-dates design decision (issue-body marked-block over milestone) in `knowledge/decision-github-task-backend.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)