### PR TITLE
feat(dashboard): timeline (Gantt), calendar & activity heatmap task views

### DIFF
--- a/dashboard/src/components/tasks/ActivityHeatmap.css
+++ b/dashboard/src/components/tasks/ActivityHeatmap.css
@@ -1,0 +1,206 @@
+.heatmap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ─── Toolbar ─── */
+.heatmap-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.heatmap-metric-toggle {
+  display: flex;
+  gap: 2px;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-md);
+  padding: 2px;
+}
+
+.heatmap-metric-btn {
+  padding: 5px var(--space-3);
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.heatmap-metric-btn:hover {
+  color: var(--color-text);
+}
+
+.heatmap-metric-btn--active {
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+}
+
+.heatmap-stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.heatmap-stat {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.heatmap-stat strong {
+  color: var(--color-text);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+.heatmap-stat--muted {
+  color: var(--color-text-tertiary);
+}
+
+/* ─── Canvas ─── */
+.heatmap-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-3);
+}
+
+.heatmap-canvas {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: min-content;
+}
+
+/* Cell sizing tokens */
+.heatmap {
+  --hm-cell: 12px;
+  --hm-gap: 3px;
+  --hm-label-w: 30px;
+}
+
+/* ─── Month row ─── */
+.heatmap-months {
+  display: grid;
+  grid-template-columns: var(--hm-label-w) repeat(53, calc(var(--hm-cell) + var(--hm-gap)));
+  height: 14px;
+  align-items: end;
+}
+
+.heatmap-month {
+  grid-row: 1;
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  line-height: 1;
+}
+
+/* ─── Body: weekday labels + week columns ─── */
+.heatmap-body {
+  display: flex;
+  gap: var(--hm-gap);
+}
+
+.heatmap-weekdays {
+  display: grid;
+  grid-template-rows: repeat(7, var(--hm-cell));
+  gap: var(--hm-gap);
+  width: calc(var(--hm-label-w) - var(--hm-gap));
+}
+
+.heatmap-weekdays span {
+  font-size: 9px;
+  color: var(--color-text-tertiary);
+  line-height: var(--hm-cell);
+  height: var(--hm-cell);
+}
+
+.heatmap-weeks {
+  display: flex;
+  gap: var(--hm-gap);
+}
+
+.heatmap-week {
+  display: grid;
+  grid-template-rows: repeat(7, var(--hm-cell));
+  gap: var(--hm-gap);
+}
+
+/* ─── Cells ─── */
+.heatmap-cell {
+  width: var(--hm-cell);
+  height: var(--hm-cell);
+  border-radius: 3px;
+  border: none;
+  padding: 0;
+  background: var(--color-bg-tertiary);
+  cursor: pointer;
+  transition: transform var(--transition-fast), outline-color var(--transition-fast);
+}
+
+.heatmap-cell:not(:disabled):hover {
+  transform: scale(1.25);
+  outline: 1px solid var(--color-accent);
+}
+
+.heatmap-cell--empty {
+  background: transparent;
+  cursor: default;
+  pointer-events: none;
+}
+
+.heatmap-cell--l0 {
+  background: var(--color-bg-tertiary);
+  cursor: default;
+}
+
+.heatmap-cell--l1 { background: color-mix(in srgb, var(--color-accent) 28%, transparent); }
+.heatmap-cell--l2 { background: color-mix(in srgb, var(--color-accent) 50%, transparent); }
+.heatmap-cell--l3 { background: color-mix(in srgb, var(--color-accent) 74%, transparent); }
+.heatmap-cell--l4 { background: var(--color-accent); }
+
+/* ─── Legend ─── */
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  align-self: flex-end;
+  margin-top: 2px;
+}
+
+.heatmap-legend .heatmap-cell {
+  cursor: default;
+}
+
+.heatmap-legend .heatmap-cell:hover {
+  transform: none;
+  outline: none;
+}
+
+.heatmap-legend-label {
+  font-size: 10px;
+  color: var(--color-text-tertiary);
+  margin: 0 4px;
+}
+
+/* Visually hidden, still read by screen readers (clip pattern, as RiceScatter). */
+.heatmap-sr-list {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/dashboard/src/components/tasks/ActivityHeatmap.tsx
+++ b/dashboard/src/components/tasks/ActivityHeatmap.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from 'react';
+import type { Task } from '../../hooks/useTasks';
+import {
+  MONTH_SHORT, formatISO, todayISO, parseISO, addDays, dateOf, isoWeekday,
+} from './calendar-utils';
+import './ActivityHeatmap.css';
+
+interface ActivityHeatmapProps {
+  tasks: Task[];
+  onSelectDay?: (date: string, tasks: Task[]) => void;
+}
+
+type Metric = 'created' | 'updated' | 'completed' | 'due';
+
+const METRICS: { key: Metric; label: string; verb: string }[] = [
+  { key: 'created', label: 'Created', verb: 'created' },
+  { key: 'updated', label: 'Updated', verb: 'updated' },
+  { key: 'completed', label: 'Completed', verb: 'completed' },
+  { key: 'due', label: 'Due', verb: 'due' },
+];
+
+const WEEKS = 53;
+
+/** The date a task contributes to for a given metric (null = no contribution). */
+function metricDate(task: Task, metric: Metric): string | null {
+  switch (metric) {
+    case 'created': return dateOf(task.created_at);
+    case 'updated': return dateOf(task.updated_at);
+    case 'completed': return task.status === 'completed' ? dateOf(task.updated_at) : null;
+    case 'due': return dateOf(task.due_date);
+  }
+}
+
+function levelFor(count: number, max: number): number {
+  if (count <= 0) return 0;
+  // Sparse projects where no day exceeds one task: render a mid-tone, not peak,
+  // so the Less↔More scale stays meaningful instead of collapsing to all-dark.
+  if (max <= 1) return 2;
+  return Math.min(4, Math.ceil((count / max) * 4));
+}
+
+export function ActivityHeatmap({ tasks, onSelectDay }: ActivityHeatmapProps) {
+  const [metric, setMetric] = useState<Metric>('updated');
+
+  const byDate = useMemo(() => {
+    const map = new Map<string, Task[]>();
+    for (const task of tasks) {
+      const d = metricDate(task, metric);
+      if (!d) continue;
+      const arr = map.get(d) ?? [];
+      arr.push(task);
+      map.set(d, arr);
+    }
+    return map;
+  }, [tasks, metric]);
+
+  const { weeks, monthLabels, max, total, activeDays, busiest } = useMemo(() => {
+    const todayMid = parseISO(todayISO());
+    const curMonday = addDays(todayMid, -isoWeekday(todayMid));
+    const firstMonday = addDays(curMonday, -(WEEKS - 1) * 7);
+    const todayStr = todayISO();
+
+    const cols: { date: string | null; count: number; tasks: Task[] }[][] = [];
+    const labels: { col: number; label: string }[] = [];
+    let prevMonth = -1;
+    let maxCount = 0;
+    let totalCount = 0;
+    let active = 0;
+    let busy: { date: string; count: number } | null = null;
+
+    for (let w = 0; w < WEEKS; w++) {
+      const weekMonday = addDays(firstMonday, w * 7);
+      const col: { date: string | null; count: number; tasks: Task[] }[] = [];
+      for (let d = 0; d < 7; d++) {
+        const cellDate = addDays(weekMonday, d);
+        const iso = formatISO(cellDate);
+        if (iso > todayStr) { col.push({ date: null, count: 0, tasks: [] }); continue; }
+        const dayTasks = byDate.get(iso) ?? [];
+        const count = dayTasks.length;
+        if (count > maxCount) maxCount = count;
+        totalCount += count;
+        if (count > 0) active++;
+        if (count > 0 && (!busy || count > busy.count)) busy = { date: iso, count };
+        col.push({ date: iso, count, tasks: dayTasks });
+      }
+      // Month label when the month of this column's Monday changes.
+      const m = weekMonday.getMonth();
+      if (m !== prevMonth) {
+        labels.push({ col: w, label: MONTH_SHORT[m] });
+        prevMonth = m;
+      }
+      cols.push(col);
+    }
+    return { weeks: cols, monthLabels: labels, max: maxCount, total: totalCount, activeDays: active, busiest: busy };
+  }, [byDate]);
+
+  const verb = METRICS.find(m => m.key === metric)!.verb;
+
+  return (
+    <div className="heatmap">
+      <div className="heatmap-toolbar">
+        <div className="heatmap-metric-toggle">
+          {METRICS.map(m => (
+            <button
+              key={m.key}
+              className={`heatmap-metric-btn ${metric === m.key ? 'heatmap-metric-btn--active' : ''}`}
+              onClick={() => setMetric(m.key)}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+        <div className="heatmap-stats">
+          <span className="heatmap-stat"><strong>{total}</strong> {verb}</span>
+          <span className="heatmap-stat"><strong>{activeDays}</strong> active days</span>
+          {busiest && (
+            <span className="heatmap-stat heatmap-stat--muted">
+              peak {busiest.count} on {busiest.date.slice(5)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="heatmap-scroll">
+        <div className="heatmap-canvas">
+          <div className="heatmap-months">
+            {monthLabels.map(({ col, label }) => (
+              <span key={`${col}-${label}`} className="heatmap-month" style={{ gridColumnStart: col + 2 }}>
+                {label}
+              </span>
+            ))}
+          </div>
+
+          <div className="heatmap-body">
+            <div className="heatmap-weekdays">
+              <span />
+              <span>Mon</span>
+              <span />
+              <span>Wed</span>
+              <span />
+              <span>Fri</span>
+              <span />
+            </div>
+
+            <div className="heatmap-weeks">
+              {weeks.map((col, w) => (
+                <div key={w} className="heatmap-week">
+                  {col.map((cell, d) => {
+                    if (cell.date === null) return <span key={d} className="heatmap-cell heatmap-cell--empty" />;
+                    const level = levelFor(cell.count, max);
+                    return (
+                      <button
+                        key={d}
+                        className={`heatmap-cell heatmap-cell--l${level}`}
+                        title={`${cell.count} ${cell.count === 1 ? 'task' : 'tasks'} ${verb} · ${cell.date}`}
+                        onClick={() => onSelectDay?.(cell.date!, cell.tasks)}
+                        disabled={cell.count === 0}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="heatmap-legend">
+            <span className="heatmap-legend-label">Less</span>
+            {[0, 1, 2, 3, 4].map(l => (
+              <span key={l} className={`heatmap-cell heatmap-cell--l${l}`} />
+            ))}
+            <span className="heatmap-legend-label">More</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Visually-hidden overview so screen readers get the gist without
+          tabbing every active cell (mirrors RiceScatter's SR-only list). */}
+      <ol className="heatmap-sr-list" aria-label={`Daily ${verb} activity over the past 53 weeks`}>
+        {weeks.flat().filter(c => c.date && c.count > 0).map(c => (
+          <li key={c.date!}>{`${c.date}: ${c.count} ${c.count === 1 ? 'task' : 'tasks'} ${verb}`}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/KanbanBoard.tsx
+++ b/dashboard/src/components/tasks/KanbanBoard.tsx
@@ -11,6 +11,9 @@ import { TaskCreateModal } from './TaskCreateModal';
 import { TaskDetailPanel } from './TaskDetailPanel';
 import { EisenhowerMatrix } from './EisenhowerMatrix';
 import { RiceScatter } from './RiceScatter';
+import { TimelineGantt } from './TimelineGantt';
+import { TaskCalendar } from './TaskCalendar';
+import { ActivityHeatmap } from './ActivityHeatmap';
 import { TaskCard } from './TaskCard';
 import { VersionManager } from './VersionManager';
 import './KanbanBoard.css';
@@ -525,6 +528,21 @@ export function KanbanBoard() {
             />
           ))}
         </div>
+      ) : filters.viewMode === 'timeline' ? (
+        <TimelineGantt
+          tasks={filtered}
+          onTaskClick={(task) => setSelectedSlug(task.slug)}
+        />
+      ) : filters.viewMode === 'calendar' ? (
+        <TaskCalendar
+          tasks={filtered}
+          onTaskClick={(task) => setSelectedSlug(task.slug)}
+        />
+      ) : filters.viewMode === 'heatmap' ? (
+        <ActivityHeatmap
+          tasks={filtered}
+          onSelectDay={(_date, dayTasks) => { if (dayTasks.length > 0) setSelectedSlug(dayTasks[0].slug); }}
+        />
       ) : (
         <div className="kanban-columns">
           {renderColumns()}

--- a/dashboard/src/components/tasks/TaskCalendar.css
+++ b/dashboard/src/components/tasks/TaskCalendar.css
@@ -1,0 +1,254 @@
+.task-cal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ─── Toolbar ─── */
+.task-cal-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.task-cal-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.task-cal-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.task-cal-nav-btn:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+
+.task-cal-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  min-width: 160px;
+}
+
+.task-cal-today-btn {
+  padding: 5px var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-elevated);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.task-cal-today-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.task-cal-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.task-cal-meta-count {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+}
+
+.task-cal-meta-unscheduled {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-full);
+  padding: 2px 10px;
+}
+
+/* ─── Grid ─── */
+.task-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.task-cal-grid--head {
+  border: 1px solid var(--color-border);
+  border-bottom: none;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  overflow: hidden;
+  background: var(--color-bg-elevated);
+}
+
+.task-cal-weekday {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.task-cal-grid--body {
+  border: 1px solid var(--color-border);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  overflow: hidden;
+}
+
+/* ─── Cells ─── */
+.task-cal-cell {
+  min-height: 96px;
+  padding: var(--space-1);
+  border-right: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  background: var(--color-bg-elevated);
+  overflow: hidden;
+}
+
+/* Remove the seam on the last column / row */
+.task-cal-cell:nth-child(7n) {
+  border-right: none;
+}
+
+.task-cal-cell:nth-last-child(-n + 7) {
+  border-bottom: none;
+}
+
+.task-cal-cell--outside {
+  background: var(--color-bg-tertiary);
+}
+
+.task-cal-cell--outside .task-cal-cell-day {
+  color: var(--color-text-tertiary);
+  opacity: 0.6;
+}
+
+.task-cal-cell--today {
+  background: var(--color-accent-soft);
+}
+
+.task-cal-cell-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 4px 0;
+}
+
+.task-cal-cell-day {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.task-cal-cell--today .task-cal-cell-day {
+  background: var(--color-accent);
+  color: var(--color-text-on-brand);
+  border-radius: var(--radius-full);
+  min-width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+}
+
+.task-cal-cell-badge {
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.task-cal-cell-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+/* ─── Task chips ─── */
+.task-cal-chip {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: 2px 5px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--chip-color) 14%, transparent);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.task-cal-chip:hover {
+  background: color-mix(in srgb, var(--chip-color) 26%, transparent);
+}
+
+.task-cal-chip--overdue {
+  box-shadow: inset 2px 0 0 var(--color-error);
+}
+
+.task-cal-chip-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--chip-color);
+}
+
+.task-cal-chip-name {
+  font-size: 11px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-cal-more {
+  border: none;
+  background: transparent;
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  text-align: left;
+  padding: 1px 5px;
+}
+
+.task-cal-more:hover {
+  color: var(--color-accent);
+}
+
+@media (max-width: 720px) {
+  .task-cal-cell {
+    min-height: 72px;
+  }
+  .task-cal-chip-name {
+    display: none;
+  }
+}

--- a/dashboard/src/components/tasks/TaskCalendar.tsx
+++ b/dashboard/src/components/tasks/TaskCalendar.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react';
+import type { Task } from '../../hooks/useTasks';
+import {
+  STATUS_COLOR_VAR, MONTH_LONG, WEEKDAY_SHORT,
+  formatISO, todayISO, dateOf, isoWeekday,
+} from './calendar-utils';
+import './TaskCalendar.css';
+
+interface TaskCalendarProps {
+  tasks: Task[];
+  onTaskClick: (task: Task) => void;
+}
+
+interface DayCell {
+  date: string;
+  day: number;
+  isCurrentMonth: boolean;
+}
+
+const MAX_CHIPS = 3;
+
+export function TaskCalendar({ tasks, onTaskClick }: TaskCalendarProps) {
+  const now = new Date();
+  const [viewYear, setViewYear] = useState(now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(now.getMonth());
+
+  // Bucket tasks by their due date.
+  const { byDate, unscheduledCount } = useMemo(() => {
+    const map = new Map<string, Task[]>();
+    let unscheduled = 0;
+    for (const task of tasks) {
+      const due = dateOf(task.due_date);
+      if (!due) { unscheduled++; continue; }
+      const arr = map.get(due) ?? [];
+      arr.push(task);
+      map.set(due, arr);
+    }
+    return { byDate: map, unscheduledCount: unscheduled };
+  }, [tasks]);
+
+  const days = useMemo<DayCell[]>(() => {
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const startOffset = isoWeekday(new Date(viewYear, viewMonth, 1));
+    const cells: DayCell[] = [];
+
+    const prevMonthDays = new Date(viewYear, viewMonth, 0).getDate();
+    for (let i = startOffset - 1; i >= 0; i--) {
+      const d = prevMonthDays - i;
+      const m = viewMonth === 0 ? 11 : viewMonth - 1;
+      const y = viewMonth === 0 ? viewYear - 1 : viewYear;
+      cells.push({ date: formatISO(new Date(y, m, d)), day: d, isCurrentMonth: false });
+    }
+    for (let d = 1; d <= daysInMonth; d++) {
+      cells.push({ date: formatISO(new Date(viewYear, viewMonth, d)), day: d, isCurrentMonth: true });
+    }
+    const remaining = (cells.length <= 35 ? 35 : 42) - cells.length;
+    for (let d = 1; d <= remaining; d++) {
+      const m = viewMonth === 11 ? 0 : viewMonth + 1;
+      const y = viewMonth === 11 ? viewYear + 1 : viewYear;
+      cells.push({ date: formatISO(new Date(y, m, d)), day: d, isCurrentMonth: false });
+    }
+    return cells;
+  }, [viewYear, viewMonth]);
+
+  const monthScheduled = useMemo(() => {
+    let n = 0;
+    for (const cell of days) {
+      if (cell.isCurrentMonth) n += byDate.get(cell.date)?.length ?? 0;
+    }
+    return n;
+  }, [days, byDate]);
+
+  const today = todayISO();
+
+  const prevMonth = () => {
+    if (viewMonth === 0) { setViewMonth(11); setViewYear(y => y - 1); }
+    else setViewMonth(m => m - 1);
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) { setViewMonth(0); setViewYear(y => y + 1); }
+    else setViewMonth(m => m + 1);
+  };
+  const goToday = () => {
+    // Read the clock at click time — `now` is captured at render and would be
+    // stale if the tab sat open across midnight without re-rendering.
+    const n = new Date();
+    setViewYear(n.getFullYear());
+    setViewMonth(n.getMonth());
+  };
+
+  return (
+    <div className="task-cal">
+      <div className="task-cal-toolbar">
+        <div className="task-cal-nav">
+          <button className="task-cal-nav-btn" onClick={prevMonth} aria-label="Previous month">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M8.5 3L4.5 7L8.5 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <span className="task-cal-title">{MONTH_LONG[viewMonth]} {viewYear}</span>
+          <button className="task-cal-nav-btn" onClick={nextMonth} aria-label="Next month">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M5.5 3L9.5 7L5.5 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <button className="task-cal-today-btn" onClick={goToday}>Today</button>
+        </div>
+        <div className="task-cal-meta">
+          <span className="task-cal-meta-count">{monthScheduled} due this month</span>
+          {unscheduledCount > 0 && (
+            <span className="task-cal-meta-unscheduled">{unscheduledCount} unscheduled</span>
+          )}
+        </div>
+      </div>
+
+      <div className="task-cal-grid task-cal-grid--head">
+        {WEEKDAY_SHORT.map(d => (
+          <div key={d} className="task-cal-weekday">{d}</div>
+        ))}
+      </div>
+
+      <div className="task-cal-grid task-cal-grid--body">
+        {days.map(cell => {
+          const dayTasks = byDate.get(cell.date) ?? [];
+          const overflow = dayTasks.length - MAX_CHIPS;
+          return (
+            <div
+              key={cell.date}
+              className={[
+                'task-cal-cell',
+                !cell.isCurrentMonth && 'task-cal-cell--outside',
+                cell.date === today && 'task-cal-cell--today',
+              ].filter(Boolean).join(' ')}
+            >
+              <div className="task-cal-cell-head">
+                <span className="task-cal-cell-day">{cell.day}</span>
+                {dayTasks.length > 0 && <span className="task-cal-cell-badge">{dayTasks.length}</span>}
+              </div>
+              <div className="task-cal-cell-tasks">
+                {dayTasks.slice(0, MAX_CHIPS).map(task => {
+                  const overdue = task.status !== 'completed' && cell.date < today;
+                  return (
+                    <button
+                      key={task.slug}
+                      className={`task-cal-chip ${overdue ? 'task-cal-chip--overdue' : ''}`}
+                      style={{ '--chip-color': `var(${STATUS_COLOR_VAR[task.status]})` } as React.CSSProperties}
+                      onClick={() => onTaskClick(task)}
+                      title={`${task.name} · ${task.status.replace('_', ' ')}${overdue ? ' · overdue' : ''}`}
+                    >
+                      <span className="task-cal-chip-dot" />
+                      <span className="task-cal-chip-name">{task.name}</span>
+                    </button>
+                  );
+                })}
+                {overflow > 0 && (
+                  <button
+                    className="task-cal-more"
+                    onClick={() => onTaskClick(dayTasks[MAX_CHIPS])}
+                    title={dayTasks.slice(MAX_CHIPS).map(t => t.name).join('\n')}
+                  >
+                    +{overflow} more
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/TaskFilters.tsx
+++ b/dashboard/src/components/tasks/TaskFilters.tsx
@@ -7,7 +7,7 @@ import './TaskFilters.css';
 
 export type SortField = 'updated_at' | 'created_at' | 'priority' | 'urgency' | 'name' | 'rice';
 export type GroupBy = 'status' | 'priority' | 'urgency' | 'tags' | 'version' | 'none';
-export type ViewMode = 'kanban' | 'eisenhower' | 'scatter' | 'list';
+export type ViewMode = 'kanban' | 'eisenhower' | 'scatter' | 'list' | 'timeline' | 'calendar' | 'heatmap';
 export type DateField = 'created_at' | 'updated_at';
 
 export interface FilterState {
@@ -155,6 +155,44 @@ function ListIcon() {
   return (
     <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
       <path d="M2 3.5H12M2 7H12M2 10.5H12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function TimelineIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+      <rect x="1" y="2" width="8" height="2.6" rx="1.1" fill="currentColor"/>
+      <rect x="4" y="5.7" width="9" height="2.6" rx="1.1" fill="currentColor"/>
+      <rect x="2.5" y="9.4" width="6.5" height="2.6" rx="1.1" fill="currentColor"/>
+    </svg>
+  );
+}
+
+function CalendarViewIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+      <rect x="1.5" y="2.5" width="11" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2"/>
+      <path d="M1.5 5.5H12.5" stroke="currentColor" strokeWidth="1.2"/>
+      <path d="M4.5 1V3.5M9.5 1V3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+      <rect x="3.4" y="7" width="2" height="2" rx="0.4" fill="currentColor"/>
+      <rect x="6.4" y="7" width="2" height="2" rx="0.4" fill="currentColor"/>
+    </svg>
+  );
+}
+
+function HeatmapIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+      <rect x="1" y="1" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.35"/>
+      <rect x="5.5" y="1" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.7"/>
+      <rect x="10" y="1" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.5"/>
+      <rect x="1" y="5.5" width="3" height="3" rx="0.7" fill="currentColor"/>
+      <rect x="5.5" y="5.5" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.4"/>
+      <rect x="10" y="5.5" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.85"/>
+      <rect x="1" y="10" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.6"/>
+      <rect x="5.5" y="10" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.3"/>
+      <rect x="10" y="10" width="3" height="3" rx="0.7" fill="currentColor" opacity="0.5"/>
     </svg>
   );
 }
@@ -476,6 +514,33 @@ export function TaskFilters({
           title="List view"
         >
           <ListIcon />
+        </button>
+        <button
+          className={`filter-view-btn ${filters.viewMode === 'timeline' ? 'filter-view-btn--active' : ''}`}
+          onClick={() => onFilterChange('viewMode', 'timeline')}
+          title="Timeline (Gantt)"
+          aria-label="Timeline (Gantt) view"
+          aria-pressed={filters.viewMode === 'timeline'}
+        >
+          <TimelineIcon />
+        </button>
+        <button
+          className={`filter-view-btn ${filters.viewMode === 'calendar' ? 'filter-view-btn--active' : ''}`}
+          onClick={() => onFilterChange('viewMode', 'calendar')}
+          title="Calendar"
+          aria-label="Calendar view"
+          aria-pressed={filters.viewMode === 'calendar'}
+        >
+          <CalendarViewIcon />
+        </button>
+        <button
+          className={`filter-view-btn ${filters.viewMode === 'heatmap' ? 'filter-view-btn--active' : ''}`}
+          onClick={() => onFilterChange('viewMode', 'heatmap')}
+          title="Activity heatmap"
+          aria-label="Activity heatmap view"
+          aria-pressed={filters.viewMode === 'heatmap'}
+        >
+          <HeatmapIcon />
         </button>
       </div>
 

--- a/dashboard/src/components/tasks/TimelineGantt.css
+++ b/dashboard/src/components/tasks/TimelineGantt.css
@@ -1,0 +1,336 @@
+.gantt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ─── Legend ─── */
+.gantt-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.gantt-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-transform: capitalize;
+}
+
+.gantt-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.gantt-legend-spacer {
+  flex: 1;
+}
+
+.gantt-legend-count {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+}
+
+/* ─── Scroll frame ─── */
+.gantt-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+}
+
+.gantt-inner {
+  position: relative;
+  min-width: 100%;
+}
+
+/* ─── Header ─── */
+.gantt-header {
+  display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.gantt-corner {
+  flex: 0 0 auto;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+  position: sticky;
+  left: 0;
+  z-index: 4;
+}
+
+.gantt-track-head {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.gantt-tick {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.gantt-tick--week::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -10000px;
+  left: 0;
+  width: 1px;
+  background: var(--color-border);
+  opacity: 0.5;
+}
+
+.gantt-tick--major::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -10000px;
+  left: 0;
+  width: 1px;
+  background: var(--color-border);
+  opacity: 1;
+}
+
+.gantt-tick-label {
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  padding-left: 3px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.gantt-tick--major .gantt-tick-label {
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ─── Today marker ─── */
+.gantt-today-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  z-index: 5;
+}
+
+.gantt-today-flag {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  transform: translateX(-50%);
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-on-brand);
+  background: var(--color-accent);
+  border-radius: var(--radius-full);
+  padding: 1px 6px;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.gantt-today-rule {
+  position: absolute;
+  top: 30px;
+  bottom: 0;
+  width: 1px;
+  background: var(--color-accent);
+  opacity: 0.5;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ─── Body / rows ─── */
+.gantt-body {
+  position: relative;
+}
+
+.gantt-row {
+  display: flex;
+  align-items: stretch;
+  height: 34px;
+  border-bottom: 1px solid var(--color-border);
+  animation: gantt-row-in 260ms ease both;
+}
+
+.gantt-row:last-child {
+  border-bottom: none;
+}
+
+@keyframes gantt-row-in {
+  from { opacity: 0; transform: translateX(-6px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.gantt-row-label {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: none;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+  cursor: pointer;
+  text-align: left;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  transition: background var(--transition-fast);
+}
+
+.gantt-row-label:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.gantt-row-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.gantt-row-assignee {
+  font-size: 10px;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-full);
+  padding: 1px 6px;
+  white-space: nowrap;
+  max-width: 70px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gantt-row-track {
+  flex: 0 0 auto;
+  position: relative;
+}
+
+.gantt-bar {
+  position: absolute;
+  top: 7px;
+  height: 20px;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: filter var(--transition-fast), transform var(--transition-fast);
+}
+
+.gantt-bar:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+}
+
+.gantt-bar--done {
+  opacity: 0.65;
+}
+
+.gantt-bar--overdue {
+  outline: 2px solid var(--color-error);
+  outline-offset: 1px;
+}
+
+.gantt-bar-label {
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-on-brand);
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Empty state ─── */
+.gantt-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-12) var(--space-4);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.gantt-empty-title {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.gantt-empty-sub {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* ─── Unscheduled tray (shared shape with RICE unscored) ─── */
+.gantt-unscheduled {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+}
+
+.gantt-unscheduled-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.gantt-unscheduled-toggle:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.gantt-unscheduled-cards {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  overflow-x: auto;
+}
+
+.gantt-unscheduled-cards > * {
+  flex: 0 0 220px;
+}
+
+.gantt-chevron {
+  transition: transform var(--transition-fast);
+  color: var(--color-text-tertiary);
+}
+
+.gantt-chevron--open {
+  transform: rotate(180deg);
+}

--- a/dashboard/src/components/tasks/TimelineGantt.tsx
+++ b/dashboard/src/components/tasks/TimelineGantt.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from 'react';
+import type { Task } from '../../hooks/useTasks';
+import { TaskCard } from './TaskCard';
+import {
+  STATUS_COLOR_VAR, MONTH_SHORT,
+  formatISO, todayISO, parseISO, addDays, diffDays, taskSpan,
+} from './calendar-utils';
+import './TimelineGantt.css';
+
+interface TimelineGanttProps {
+  tasks: Task[];
+  onTaskClick: (task: Task) => void;
+}
+
+interface ScheduledRow {
+  task: Task;
+  start: string;
+  end: string;
+  overdue: boolean;
+}
+
+/** Pixels per day, chosen so a typical plan fits without horizontal scroll. */
+function dayWidthFor(totalDays: number): number {
+  if (totalDays <= 21) return 34;
+  if (totalDays <= 45) return 22;
+  if (totalDays <= 90) return 12;
+  if (totalDays <= 180) return 7;
+  return 4;
+}
+
+const LABEL_W = 220;
+
+export function TimelineGantt({ tasks, onTaskClick }: TimelineGanttProps) {
+  const [unscheduledOpen, setUnscheduledOpen] = useState(false);
+
+  const { scheduled, unscheduled } = useMemo(() => {
+    const sched: ScheduledRow[] = [];
+    const unsched: Task[] = [];
+    for (const task of tasks) {
+      const span = taskSpan(task);
+      if (span) sched.push({ task, ...span });
+      else unsched.push(task);
+    }
+    // Earliest start first; ties broken by the due date so bars cascade.
+    sched.sort((a, b) => (a.start === b.start ? a.end.localeCompare(b.end) : a.start.localeCompare(b.start)));
+    return { scheduled: sched, unscheduled: unsched };
+  }, [tasks]);
+
+  const range = useMemo(() => {
+    if (scheduled.length === 0) return null;
+    const today = todayISO();
+    let min = scheduled[0].start;
+    let max = scheduled[0].end;
+    for (const r of scheduled) {
+      if (r.start < min) min = r.start;
+      if (r.end > max) max = r.end;
+    }
+    // Always keep "today" in view so the marker has somewhere to land.
+    if (today < min) min = today;
+    if (today > max) max = today;
+    // Breathing room on both ends.
+    const start = formatISO(addDays(parseISO(min), -2));
+    const end = formatISO(addDays(parseISO(max), 3));
+    return { start, end, totalDays: diffDays(start, end) + 1 };
+  }, [scheduled]);
+
+  const ticks = useMemo(() => {
+    if (!range) return [];
+    const dayW = dayWidthFor(range.totalDays);
+    const labelEvery = dayW >= 22 ? 1 : dayW >= 12 ? 2 : dayW >= 7 ? 7 : 14;
+    const out: { offset: number; label: string | null; major: boolean; weekStart: boolean }[] = [];
+    for (let i = 0; i < range.totalDays; i++) {
+      const d = addDays(parseISO(range.start), i);
+      const dom = d.getDate();
+      const isMonthStart = dom === 1;
+      const isWeekStart = d.getDay() === 1; // Monday
+      let label: string | null = null;
+      if (isMonthStart) label = MONTH_SHORT[d.getMonth()];
+      else if (i % labelEvery === 0 && dayW >= 7) label = String(dom);
+      out.push({ offset: i, label, major: isMonthStart, weekStart: isWeekStart });
+    }
+    return out;
+  }, [range]);
+
+  if (scheduled.length === 0) {
+    return (
+      <div className="gantt">
+        <div className="gantt-empty">
+          <p className="gantt-empty-title">No scheduled tasks yet</p>
+          <p className="gantt-empty-sub">
+            Set a due date on a task to place it on the timeline.
+            {unscheduled.length > 0 && ` ${unscheduled.length} task${unscheduled.length === 1 ? '' : 's'} waiting below.`}
+          </p>
+        </div>
+        {unscheduled.length > 0 && (
+          <UnscheduledTray tasks={unscheduled} open={unscheduledOpen} onToggle={() => setUnscheduledOpen(v => !v)} onTaskClick={onTaskClick} />
+        )}
+      </div>
+    );
+  }
+
+  const dayW = dayWidthFor(range!.totalDays);
+  const trackW = range!.totalDays * dayW;
+  const todayOffset = (() => {
+    const t = todayISO();
+    if (t < range!.start || t > range!.end) return null;
+    return diffDays(range!.start, t);
+  })();
+
+  return (
+    <div className="gantt">
+      <div className="gantt-legend">
+        {(['todo', 'in_progress', 'in_review', 'completed'] as Task['status'][]).map(s => (
+          <span key={s} className="gantt-legend-item">
+            <span className="gantt-legend-swatch" style={{ background: `var(${STATUS_COLOR_VAR[s]})` }} />
+            {s.replace('_', ' ')}
+          </span>
+        ))}
+        <span className="gantt-legend-spacer" />
+        <span className="gantt-legend-count">{scheduled.length} scheduled</span>
+      </div>
+
+      <div className="gantt-scroll">
+        <div className="gantt-inner" style={{ width: LABEL_W + trackW }}>
+          {/* Header: month / day ticks */}
+          <div className="gantt-header" style={{ height: 30 }}>
+            <div className="gantt-corner" style={{ width: LABEL_W }} />
+            <div className="gantt-track-head" style={{ width: trackW }}>
+              {ticks.map(tk => (
+                <div
+                  key={tk.offset}
+                  className={`gantt-tick ${tk.major ? 'gantt-tick--major' : ''} ${tk.weekStart ? 'gantt-tick--week' : ''}`}
+                  style={{ left: tk.offset * dayW }}
+                >
+                  {tk.label && <span className="gantt-tick-label">{tk.label}</span>}
+                </div>
+              ))}
+              {todayOffset !== null && (
+                <div className="gantt-today-line" style={{ left: todayOffset * dayW + dayW / 2 }}>
+                  <span className="gantt-today-flag">today</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Rows */}
+          <div className="gantt-body">
+            {todayOffset !== null && (
+              <div
+                className="gantt-today-rule"
+                style={{ left: LABEL_W + todayOffset * dayW + dayW / 2 }}
+              />
+            )}
+            {scheduled.map(({ task, start, end, overdue }, i) => {
+              const offset = diffDays(range!.start, start);
+              const span = diffDays(start, end) + 1;
+              return (
+                <div className="gantt-row" key={task.slug} style={{ animationDelay: `${Math.min(i, 16) * 18}ms` }}>
+                  <button
+                    className="gantt-row-label"
+                    style={{ width: LABEL_W }}
+                    onClick={() => onTaskClick(task)}
+                    title={task.name}
+                  >
+                    <span className={`priority-dot priority-dot--${task.priority}`} />
+                    <span className="gantt-row-name">{task.name}</span>
+                    {task.assignee && <span className="gantt-row-assignee">{task.assignee}</span>}
+                  </button>
+                  <div className="gantt-row-track" style={{ width: trackW }}>
+                    <button
+                      className={`gantt-bar ${overdue ? 'gantt-bar--overdue' : ''} ${task.status === 'completed' ? 'gantt-bar--done' : ''}`}
+                      style={{
+                        left: offset * dayW,
+                        width: Math.max(span * dayW - 2, 6),
+                        background: `var(${STATUS_COLOR_VAR[task.status]})`,
+                      }}
+                      onClick={() => onTaskClick(task)}
+                      title={`${task.name}\n${start}${end !== start ? ` → ${end}` : ''}${overdue ? ' · overdue' : ''}`}
+                    >
+                      {span * dayW > 56 && <span className="gantt-bar-label">{task.name}</span>}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {unscheduled.length > 0 && (
+        <UnscheduledTray tasks={unscheduled} open={unscheduledOpen} onToggle={() => setUnscheduledOpen(v => !v)} onTaskClick={onTaskClick} />
+      )}
+    </div>
+  );
+}
+
+function UnscheduledTray({
+  tasks, open, onToggle, onTaskClick,
+}: {
+  tasks: Task[];
+  open: boolean;
+  onToggle: () => void;
+  onTaskClick: (task: Task) => void;
+}) {
+  return (
+    <div className={`gantt-unscheduled ${open ? 'gantt-unscheduled--open' : ''}`}>
+      <button type="button" className="gantt-unscheduled-toggle" onClick={onToggle} aria-expanded={open}>
+        <span>Unscheduled ({tasks.length})</span>
+        <svg className={`gantt-chevron ${open ? 'gantt-chevron--open' : ''}`} width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {open && (
+        <div className="gantt-unscheduled-cards">
+          {tasks.map(task => (
+            <TaskCard key={task.slug} task={task} onClick={() => onTaskClick(task)} onDragStart={() => { /* no drag */ }} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/calendar-utils.ts
+++ b/dashboard/src/components/tasks/calendar-utils.ts
@@ -1,0 +1,90 @@
+import type { Task } from '../../hooks/useTasks';
+
+/** Status → CSS color var, shared across the time-axis task views. */
+export const STATUS_COLOR_VAR: Record<Task['status'], string> = {
+  todo: '--color-status-todo',
+  in_progress: '--color-status-in-progress',
+  in_review: '--color-status-in-review',
+  completed: '--color-status-completed',
+};
+
+export const MONTH_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+export const MONTH_LONG = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/** Mon-first weekday labels (matches MiniCalendar). */
+export const WEEKDAY_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
+export function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Local-time ISO date (YYYY-MM-DD) for a Date — never UTC-shifts the day. */
+export function formatISO(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function todayISO(): string {
+  return formatISO(new Date());
+}
+
+/** Parse a YYYY-MM-DD (or longer ISO) string into a local-midnight Date. */
+export function parseISO(s: string): Date {
+  return new Date(s.slice(0, 10) + 'T00:00:00');
+}
+
+/** Date-part of any frontmatter timestamp (created_at/updated_at may carry time). */
+export function dateOf(ts: string | null | undefined): string | null {
+  if (!ts) return null;
+  const slice = ts.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(slice)) return null;
+  // The regex only checks digit shape, not calendar validity — reject things
+  // like "2026-13-45" so they can't become phantom keys that inflate stats.
+  return Number.isNaN(new Date(slice + 'T00:00:00').getTime()) ? null : slice;
+}
+
+export function addDays(d: Date, n: number): Date {
+  const c = new Date(d);
+  c.setDate(c.getDate() + n);
+  return c;
+}
+
+/** Whole days from a → b (b - a). Both treated as local midnight. */
+export function diffDays(aISO: string, bISO: string): number {
+  return Math.round((parseISO(bISO).getTime() - parseISO(aISO).getTime()) / 86_400_000);
+}
+
+/** Monday-first index (Mon=0 … Sun=6) for a JS getDay(). */
+export function isoWeekday(d: Date): number {
+  const day = d.getDay();
+  return day === 0 ? 6 : day - 1;
+}
+
+/**
+ * The [start, end] span a task occupies on the timeline.
+ *
+ * The task model carries a single `due_date` (no explicit start yet — that is a
+ * separate in-progress feature). Until a real `start_date` lands, we derive the
+ * span from what we have: the bar runs from the creation day up to the due day.
+ * When a `start_date` field is added to the model, prefer it here in one place.
+ *
+ * Returns null for unscheduled tasks (no due date) — callers tray them off.
+ */
+export function taskSpan(task: Task): { start: string; end: string; overdue: boolean } | null {
+  const due = dateOf(task.due_date);
+  if (!due) return null;
+  // Defensive: pick up a future `start_date` field if the model gains one.
+  const explicitStart = dateOf((task as { start_date?: string | null }).start_date);
+  const created = dateOf(task.created_at);
+  const candidate = explicitStart ?? created ?? due;
+  // Start can never be after the due date — clamp to a single-day marker.
+  const start = candidate <= due ? candidate : due;
+  const overdue = task.status !== 'completed' && due < todayISO();
+  return { start, end: due, overdue };
+}


### PR DESCRIPTION
## What

Adds three time-axis views to the task dashboard, switchable from the existing view toggle and driven by the **same filter set** as Kanban / Eisenhower / RICE (status, priority, urgency, tags, version, assignee, search).

| View | What it shows |
|------|---------------|
| **Timeline (Gantt)** | Status-colored bars spanning `created → due`, sticky task labels with priority dot + assignee, a **today** marker, overdue outline, adaptive day/week/month ticks, and a collapsible **Unscheduled** tray |
| **Calendar** | Monday-first month grid with tasks as chips on their due date, overdue + today highlighting, month nav, and due/unscheduled counts |
| **Activity heatmap** | GitHub-style 53-week grid with a **Created / Updated / Completed / Due** metric toggle, intensity buckets, an SR-only daily summary, and peak/active-day stats |

Closes the *"Task management views: timeline (Gantt), calendar, and activity heatmap"* feedback item — the dashboard previously had no time-based planning view.

## How

- New components under `dashboard/src/components/tasks/`: `TimelineGantt`, `TaskCalendar`, `ActivityHeatmap` (+ CSS).
- Shared date logic in `calendar-utils.ts` (local-time helpers + `taskSpan()`). `taskSpan()` is **forward-compatible** with the in-flight `start_date` feature via a defensive cast — it prefers `start_date` when the model gains it, falling back to `created_at` today.
- Wired into `KanbanBoard.tsx` (three render branches) and `TaskFilters.tsx` (three toggle buttons + `ViewMode` union, with `aria-label` + `aria-pressed`).

## Verification

- `tsc -b` ✅ and `vite build` ✅
- Live Playwright pass across all three views (seeded overdue/today/future tasks, **0 console errors**)
- Multi-reviewer pass (frontend + edge-case specialists) → **READY_TO_MERGE** after fixes: DST-safe date math, sparse-data heatmap scaling, calendar-valid `dateOf`, after-midnight `goToday` fix, and an SR-only overview list

## Scope

Frontend only — no backend/API/schema changes. The cross-project launcher version of these views is tracked separately and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)