### PR TITLE
fix(tasks): resolve assignees to real members; never silently drop unmapped ones

### DIFF
--- a/dashboard/src/components/tasks/TaskDetailPanel.css
+++ b/dashboard/src/components/tasks/TaskDetailPanel.css
@@ -727,6 +727,35 @@
   border-radius: var(--radius-sm, 4px);
 }
 
+/* Assigned to a slug that matches no real member on a remote backend — it will
+   not sync (ClickUp would default the assignee to the API-token owner). Visually
+   distinct from a real, syncing assignee so the two are never confused. */
+.assignee-chip--unmapped {
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+  outline: 1px dashed var(--color-error);
+  outline-offset: -1px;
+}
+
+.assignee-chip__warn {
+  font-size: var(--font-size-xs, 11px);
+  line-height: 1;
+}
+
+/* Screen-reader-only: conveys the "won't sync" warning to assistive tech, since
+   the ⚠ icon is aria-hidden and a title tooltip isn't reliably announced. */
+.assignee-chip__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .assignee-chip__remove {
   background: none;
   border: none;

--- a/dashboard/src/components/tasks/TaskDetailPanel.tsx
+++ b/dashboard/src/components/tasks/TaskDetailPanel.tsx
@@ -3,7 +3,7 @@ import { marked } from 'marked';
 import mermaid from 'mermaid';
 import panzoom from 'panzoom';
 import type { Task, RiceFields, RiceInput } from '../../hooks/useTasks';
-import { useUpdateTask, useAddTaskChangelog, useDeleteTask, useTaskMembers, useFeatureOptions } from '../../hooks/useTasks';
+import { useUpdateTask, useAddTaskChangelog, useDeleteTask, useTaskMembers, useFeatureOptions, useSyncStatus } from '../../hooks/useTasks';
 import { SearchableSelect } from './SearchableSelect';
 import { usePlanningVersions } from '../../hooks/useVersions';
 import { useI18n } from '../../context/I18nContext';
@@ -364,6 +364,14 @@ export function TaskDetailPanel({ task, onClose, initialRiceExpanded }: TaskDeta
   const addChangelog = useAddTaskChangelog();
   const deleteTask = useDeleteTask();
   const { data: members } = useTaskMembers();
+  const { data: syncStatus } = useSyncStatus();
+  // On a remote backend (ClickUp/GitHub) an assignee MUST resolve to a real
+  // member to round-trip — so the picker offers ONLY members (no free-text) and
+  // any already-assigned slug that isn't a member is flagged "won't sync".
+  // While sync-status is still loading (`undefined`), default to the SAFE state
+  // (treat as remote): never open free-text during the load window, or a fast
+  // user could mint an unsyncable slug — the exact bug this guards against.
+  const remoteBacked = syncStatus === undefined ? true : syncStatus.backend !== 'local';
   const { data: featureOptions } = useFeatureOptions();
   const { data: versions } = usePlanningVersions();
   const [changelogEntry, setChangelogEntry] = useState('');
@@ -922,9 +930,18 @@ export function TaskDetailPanel({ task, onClose, initialRiceExpanded }: TaskDeta
                   <div className="assignee-chips">
                     {effectiveAssignees.map(slug => {
                       const m = (members ?? []).find(x => x.slug === slug);
+                      // On a remote backend, a slug that matches no real member
+                      // won't sync — flag it so it's not mistaken for assigned.
+                      const unmapped = remoteBacked && !m;
                       return (
-                        <span key={slug} className="assignee-chip">
+                        <span
+                          key={slug}
+                          className={`assignee-chip${unmapped ? ' assignee-chip--unmapped' : ''}`}
+                          title={unmapped ? `"${slug}" is not a member of this backend — it won't sync. Remove it and pick a real member.` : undefined}
+                        >
                           {m?.name ?? slug}
+                          {unmapped && <span className="assignee-chip__warn" aria-hidden="true">⚠</span>}
+                          {unmapped && <span className="assignee-chip__sr">(not a member — won't sync)</span>}
                           <button
                             type="button"
                             className="assignee-chip__remove"
@@ -946,7 +963,9 @@ export function TaskDetailPanel({ task, onClose, initialRiceExpanded }: TaskDeta
                   placeholder={effectiveAssignees.length > 0 ? 'Add assignee…' : 'Unassigned'}
                   searchPlaceholder="Search people…"
                   clearLabel="Unassigned"
-                  allowCustom
+                  // Free-text only on a local backend; a remote backend accepts
+                  // members only (typing a non-member slug is the bug we're fixing).
+                  allowCustom={!remoteBacked}
                   onChange={v => { if (v) addAssignee(v); }}
                 />
               </div>

--- a/src/cli/commands/sleep.ts
+++ b/src/cli/commands/sleep.ts
@@ -398,6 +398,13 @@ export function registerSleepCommand(program: Command): void {
             warn(`Task sync: completed with ${report.errors.length} non-fatal error(s):`);
             for (const e of report.errors) warn(`  ${e}`);
           }
+          // Data-quality warnings (e.g. an unmapped assignee left unassigned).
+          // The task synced, but assignment silently failing is exactly the
+          // class of bug we refuse to bury — surface every one.
+          if (report.warnings.length > 0) {
+            warn(`Task sync: ${report.warnings.length} assignment warning(s):`);
+            for (const w of report.warnings) warn(`  ${w}`);
+          }
         }
       } catch (err) {
         // The sync engine itself threw (auth/lock/transport) — best-effort by

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -7,7 +7,8 @@ import { readSection, extractMermaidNodes, nodeStatus, countCheckboxes } from '.
 import { prepareSectionInsert, SECTION_MAP } from '../../lib/section-insert.js';
 import { promptInput } from '../../lib/prompt.js';
 import { slugify, today } from '../../lib/id.js';
-import { success, error, header } from '../../lib/format.js';
+import { success, error, header, warn } from '../../lib/format.js';
+import { matchMember } from '../../lib/task-backend/member-match.js';
 import { readSetupConfig, isMultiPerson } from '../../lib/setup-config.js';
 import { getActivePlanningVersion } from '../../lib/active-version.js';
 import { mergeRice, validateRiceInput, type RiceFields, type RiceInput } from '../../lib/rice.js';
@@ -35,6 +36,47 @@ function getStateDir(): string {
 /** Commander collector for repeatable string options (e.g. `--tag a --tag b`). */
 function collectOption(value: string, previous: string[]): string[] {
   return previous.concat(value);
+}
+
+/**
+ * Resolve a human-entered person reference to a CANONICAL, member-backed slug
+ * for a `person:<slug>` tag. On a remote backend whose members are known, the
+ * input is fuzzy-matched against the real roster so we never mint an unmappable
+ * slug — an unmapped slug is silently dropped on push and the remote then
+ * defaults the assignee to the API-token owner. On a local backend (or when members are
+ * unavailable) it falls back to a plain slugify with no warning, since free-text
+ * assignment is harmless there.
+ *
+ * Returns `{ abort: true }` on an ambiguous match (a message is printed and the
+ * caller must stop rather than guess an assignee).
+ */
+async function resolvePersonSlug(
+  backend: TaskBackend,
+  input: string,
+): Promise<{ slug: string } | { abort: true }> {
+  const fallback = slugify(input);
+  if (!backend.listMembers) return { slug: fallback };
+  let members;
+  try {
+    members = await backend.listMembers();
+  } catch {
+    return { slug: fallback }; // offline — keep intent; the push-side warning catches it
+  }
+  if (members.length === 0) return { slug: fallback };
+
+  const match = matchMember(input, members);
+  if (match.kind === 'exact' || match.kind === 'fuzzy') {
+    if (match.member.slug !== fallback) {
+      console.log(chalk.dim(`  → assignee "${input}" resolved to ${match.member.slug} (${match.member.name}).`));
+    }
+    return { slug: match.member.slug };
+  }
+  if (match.kind === 'ambiguous') {
+    error(`Ambiguous assignee "${input}" — matches ${match.matches.map((m) => m.slug).join(', ')}. Be more specific.`);
+    return { abort: true };
+  }
+  warn(`"${input}" matches no member on the "${backend.name}" backend — recording person:${fallback}, but it will NOT sync until they are a member (see \`dreamcontext tasks members\`).`);
+  return { slug: fallback };
 }
 
 /** Render one task as a colorized human-readable line. */
@@ -240,7 +282,9 @@ export function registerTasksCommand(program: Command): void {
       if (opts.person && opts.person.trim()) {
         const projectRoot = dirname(ensureContextRoot());
         if (isMultiPerson(readSetupConfig(projectRoot))) {
-          const personTag = `person:${slugify(opts.person)}`;
+          const resolved = await resolvePersonSlug(backend, opts.person);
+          if ('abort' in resolved) return;
+          const personTag = `person:${resolved.slug}`;
           if (!tags.includes(personTag)) tags.push(personTag);
         }
       }
@@ -445,14 +489,32 @@ export function registerTasksCommand(program: Command): void {
         const drop = new Set(given.map((t) => t.toLowerCase()));
         next = task.tags.filter((t) => !drop.has(t.toLowerCase()));
       } else {
-        next = [...task.tags];
+        // Canonicalize person:<slug> assignments to a real member slug so we
+        // never record an unmappable assignee (silently dropped on push, which
+        // makes the remote default the assignee to the API-token owner).
+        const addTags: string[] = [];
         for (const t of given) {
+          if (t.startsWith('person:')) {
+            const raw = t.slice('person:'.length).trim();
+            if (!raw) {
+              error('Empty assignee: `person:` needs a slug, e.g. `person:emrecan-tetik` (see `dreamcontext tasks members`).');
+              return;
+            }
+            const resolved = await resolvePersonSlug(backend, raw);
+            if ('abort' in resolved) return;
+            addTags.push(`person:${resolved.slug}`);
+          } else {
+            addTags.push(t);
+          }
+        }
+        next = [...task.tags];
+        for (const t of addTags) {
           if (!next.some((x) => x.toLowerCase() === t.toLowerCase())) next.push(t);
         }
         // A person tag is an assignment — only one person tag at a time.
         const persons = next.filter((t) => t.startsWith('person:'));
         if (persons.length > 1) {
-          const keep = given.filter((t) => t.startsWith('person:')).pop() ?? persons[persons.length - 1];
+          const keep = addTags.filter((t) => t.startsWith('person:')).pop() ?? persons[persons.length - 1];
           next = next.filter((t) => !t.startsWith('person:') || t === keep);
         }
       }
@@ -641,6 +703,9 @@ export function registerTasksCommand(program: Command): void {
         }
         for (const e of report.errors) {
           console.log(chalk.red(`  error: ${e}`));
+        }
+        for (const w of report.warnings) {
+          console.log(chalk.yellow(`  warning: ${w}`));
         }
       } catch (err) {
         if (opts.hook) {

--- a/src/lib/task-backend/clickup.ts
+++ b/src/lib/task-backend/clickup.ts
@@ -474,6 +474,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
       pendingQueue: 0,
       errors: [],
       failedPushes: [],
+      warnings: [],
       watermark: null,
       noop: false,
     };
@@ -582,11 +583,24 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     const newEntries = currentEntries.filter((e) => !baseNorm.has(normalizeEntry(e)));
 
     // assignees: every person:<slug> tag (plus the legacy assignee field),
-    // mapped to ClickUp member ids. Unknown slugs drop out silently.
-    const assigneeIds = assigneeSlugsOf(task.raw, task.tags)
-      .map((s) => this.memberIdFor(s))
-      .filter((id): id is string => id !== null)
-      .map(Number);
+    // mapped to ClickUp member ids. A slug that maps to NO member is NOT
+    // silently dropped — it is surfaced as a warning (otherwise an all-unmapped
+    // create sends an empty assignee set and ClickUp defaults the assignee to
+    // the API-token owner, with no signal to the user).
+    const assigneeIds: number[] = [];
+    const unmappedAssignees: string[] = [];
+    for (const s of assigneeSlugsOf(task.raw, task.tags)) {
+      const id = this.memberIdFor(s);
+      if (id !== null) assigneeIds.push(Number(id));
+      else unmappedAssignees.push(s);
+    }
+    if (unmappedAssignees.length > 0) {
+      report.warnings.push(
+        `push ${slug}: assignee ${unmappedAssignees.map((s) => `person:${s}`).join(', ')} ` +
+        `maps to no ClickUp member — left unassigned (add them to the list, or map with ` +
+        `\`dreamcontext config clickup-member <slug> <id>\`).`,
+      );
+    }
 
     // Map the status against the list's actual status set; an unmappable
     // status is OMITTED (the remote keeps its value) instead of 400-ing.

--- a/src/lib/task-backend/github.ts
+++ b/src/lib/task-backend/github.ts
@@ -436,6 +436,7 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       pendingQueue: 0,
       errors: [],
       failedPushes: [],
+      warnings: [],
       watermark: null,
       noop: false,
     };
@@ -536,11 +537,24 @@ export class GitHubTaskBackend extends LocalTaskBackend {
     const newEntries = currentEntries.filter((e) => !baseNorm.has(normalizeEntry(e)));
 
     // assignees: every person:<slug> tag (plus the legacy field), resolved to
-    // GitHub logins via the collaborator cache. Unknown slugs drop out silently
-    // (GitHub also ignores unknown assignees on write — never a 4xx abort).
-    const assignees = assigneeSlugsOf(task.raw, task.tags)
-      .map((s) => this.loginForSlug(s))
-      .filter((login): login is string => login !== null);
+    // GitHub logins via the collaborator cache. A slug that resolves to NO
+    // collaborator is surfaced as a warning rather than silently dropped (GitHub
+    // ignores unknown assignees on write — never a 4xx abort, but the user must
+    // still be told the assignment did not land).
+    const assignees: string[] = [];
+    const unmappedAssignees: string[] = [];
+    for (const s of assigneeSlugsOf(task.raw, task.tags)) {
+      const login = this.loginForSlug(s);
+      if (login !== null) assignees.push(login);
+      else unmappedAssignees.push(s);
+    }
+    if (unmappedAssignees.length > 0) {
+      report.warnings.push(
+        `push ${slug}: assignee ${unmappedAssignees.map((s) => `person:${s}`).join(', ')} ` +
+        `is not a collaborator on this repo — left unassigned (invite them, or use a ` +
+        `\`person:<slug>\` matching their GitHub login).`,
+      );
+    }
 
     // The FULL computed label set (PATCH labels REPLACES the whole set on
     // GitHub, so we always send everything the map derives for this task — a

--- a/src/lib/task-backend/local.ts
+++ b/src/lib/task-backend/local.ts
@@ -448,6 +448,7 @@ ${input.why || '(To be defined)'}
       pendingQueue: 0,
       errors: [],
       failedPushes: [],
+      warnings: [],
       watermark: null,
       noop: true,
     };

--- a/src/lib/task-backend/member-match.ts
+++ b/src/lib/task-backend/member-match.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolve a human-entered person reference to a CANONICAL remote member —
+ * pure, no I/O, unit-testable in isolation.
+ *
+ * The slug taxonomy for assignees is full-name based (e.g. "Aylin Yilmaz" →
+ * `aylin-yilmaz`). Users, however, type short first names ("Emrecan", "aylin").
+ * Left unresolved, those mint `person:emrecan` tags that map to no remote member
+ * and get silently dropped on push (and the remote then defaults the assignee to
+ * the API-token owner). This matcher maps the typed input onto the real member
+ * roster so only member-backed slugs are ever recorded — the root-cause fix for
+ * both the silent-drop and the non-member-picker bugs.
+ *
+ * Only members carrying a real remote id (`id !== ''`) are assignable
+ * candidates; roster/task-derived stubs (id '') are excluded.
+ */
+
+import { slugify } from '../id.js';
+import { foldAscii } from './clickup-map.js';
+import type { RemoteMember } from './types.js';
+
+export type MemberMatch =
+  | { kind: 'exact'; member: RemoteMember }
+  | { kind: 'fuzzy'; member: RemoteMember }
+  | { kind: 'ambiguous'; matches: RemoteMember[] }
+  | { kind: 'none' };
+
+/** Canonical comparison key: ascii-folded, slugified (matches `memberSlug`). */
+function key(s: string): string {
+  return slugify(foldAscii(s));
+}
+
+/** True when `q` is a whole name-segment of `slug` (so "emrecan" hits "emrecan-tetik"). */
+function matchesSegment(slug: string, q: string): boolean {
+  return slug === q || slug.startsWith(`${q}-`) || slug.split('-').includes(q);
+}
+
+/**
+ * Match `input` against the assignable (real-id) members.
+ * - exact slug → `exact`
+ * - one member whose slug/name contains the input as a name segment → `fuzzy`
+ * - several such members → `ambiguous` (caller must not guess)
+ * - none → `none`
+ */
+export function matchMember(input: string, members: RemoteMember[]): MemberMatch {
+  const q = key(input);
+  if (!q) return { kind: 'none' };
+
+  // Only members with a real remote id can actually be assigned.
+  const real = members.filter((m) => m.id !== '');
+
+  const exact = real.find((m) => m.slug === q);
+  if (exact) return { kind: 'exact', member: exact };
+
+  const matches = real.filter(
+    (m) => matchesSegment(m.slug, q) || matchesSegment(key(m.name), q),
+  );
+  if (matches.length === 1) return { kind: 'fuzzy', member: matches[0] };
+  if (matches.length > 1) return { kind: 'ambiguous', matches };
+  return { kind: 'none' };
+}

--- a/src/lib/task-backend/types.ts
+++ b/src/lib/task-backend/types.ts
@@ -163,6 +163,14 @@ export interface SyncReport {
    * surface it loudly rather than report success.
    */
   failedPushes: string[];
+  /**
+   * Non-fatal data-quality warnings surfaced by a sync (e.g. a `person:<slug>`
+   * assignee tag that resolves to no remote member, so it was left unassigned
+   * rather than silently falling back to the API-token owner). The task itself
+   * still synced — distinct from `errors`/`failedPushes` — but the user must be
+   * told, never silently dropped. Callers surface these loudly.
+   */
+  warnings: string[];
   /** Remote server-time watermark after this sync (epoch ms), if any. */
   watermark: number | null;
   /** True when nothing had to be done (also the local backend's constant result). */

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -231,6 +231,15 @@ async function taskAssigneeMembers(backend: TaskBackend): Promise<RemoteMember[]
  * GET /api/tasks/members — assignee candidates. Merges remote members (when a
  * remote backend exposes them) with the local project roster, keyed by slug so
  * a person appears once. Remote entries win (they carry a real member id).
+ *
+ * On a REMOTE backend whose member roster is known, only member-backed
+ * candidates are returned: roster/task-derived stubs (id '') that match no real
+ * member are dropped. Offering them is the bug — picking one mints a
+ * `person:<slug>` tag that resolves to no member and is silently dropped on
+ * push (the remote then defaults the assignee to the API-token owner). On a
+ * LOCAL backend (or a remote one whose members are momentarily unavailable) the
+ * stubs are kept, because there free-text assignment is harmless and the
+ * alternative is an empty, seemingly-broken picker.
  */
 export async function handleTasksMembers(
   _req: IncomingMessage,
@@ -255,7 +264,15 @@ export async function handleTasksMembers(
     if (!bySlug.has(m.slug)) bySlug.set(m.slug, m);
   }
   for (const m of remote) bySlug.set(m.slug, m); // remote wins (real member id)
-  sendJson(res, 200, { members: [...bySlug.values()] });
+
+  let members = [...bySlug.values()];
+  // Remote backend WITH a known member roster → assignees must round-trip to a
+  // real member, so non-member stubs (id '') are not offered. Gate on a
+  // non-empty `remote` so a transient empty fetch doesn't blank the picker.
+  if (backend.listMembers && remote.length > 0) {
+    members = members.filter((m) => m.id !== '');
+  }
+  sendJson(res, 200, { members });
 }
 
 /**

--- a/tests/unit/clickup-push.test.ts
+++ b/tests/unit/clickup-push.test.ts
@@ -187,6 +187,37 @@ describe('clickup PUSH (M3, mocked transport)', () => {
     expect(remote.assignees.map((a) => a.id)).toEqual([501]);
   });
 
+  it('an unmapped person:<slug> is surfaced as a warning, never silently dropped', async () => {
+    await backend.create({ name: 'Mixed Assign', variant: 'cli' });
+    // person:alice maps (config → 501); person:bob maps to nothing.
+    await backend.updateFields('mixed-assign', {
+      tags: ['person:alice', 'person:bob'],
+      updated_at: '2026-06-12',
+    });
+    const report = await backend.sync('push');
+
+    // The mappable assignee still lands on the remote…
+    const remote = [...fake.tasks.values()][0];
+    expect(remote.assignees.map((a) => a.id)).toEqual([501]);
+    // …and the unmappable one is REPORTED (not silently dropped).
+    expect(report.warnings.some((w) => w.includes('person:bob'))).toBe(true);
+  });
+
+  it('an all-unmapped assignee set creates with NO assignees + a warning (no token-owner fallback hidden)', async () => {
+    await backend.create({ name: 'Lost Assign', variant: 'cli' });
+    await backend.updateFields('lost-assign', {
+      tags: ['person:nobody'],
+      updated_at: '2026-06-12',
+    });
+    const report = await backend.sync('push');
+
+    // ClickUp gets an empty assignee set — the wrong-but-visible state — and the
+    // warning makes the dropped assignment loud instead of silent.
+    const remote = [...fake.tasks.values()][0];
+    expect(remote.assignees).toEqual([]);
+    expect(report.warnings.some((w) => w.includes('person:nobody'))).toBe(true);
+  });
+
   it('created_by/updated_by are recorded on mutations (attribution)', async () => {
     await backend.create({ name: 'Attributed', variant: 'cli' });
     const task = await backend.get('attributed');

--- a/tests/unit/member-match.test.ts
+++ b/tests/unit/member-match.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { matchMember } from '../../src/lib/task-backend/member-match.js';
+import type { RemoteMember } from '../../src/lib/task-backend/index.js';
+
+/**
+ * The matcher is the root-cause fix for "unmapped person:<slug> tags": a user
+ * types a short first name ("Emrecan"), and we must resolve it to the canonical
+ * full-name member slug ("emrecan-tetik") rather than mint an unmappable slug
+ * that the push path silently drops (defaulting the ClickUp assignee to the
+ * API-token owner).
+ */
+
+const MEMBERS: RemoteMember[] = [
+  { slug: 'emrecan-tetik', id: '101', name: 'Emrecan Tetik' },
+  { slug: 'aylin-yilmaz', id: '102', name: 'Aylin Yilmaz' },
+  { slug: 'mehmet-nuraydin', id: '103', name: 'Mehmet Nuraydın' },
+  { slug: 'ahmet-yilmaz', id: '104', name: 'Ahmet Yilmaz' },
+];
+
+describe('matchMember', () => {
+  it('exact slug → exact', () => {
+    const m = matchMember('emrecan-tetik', MEMBERS);
+    expect(m.kind).toBe('exact');
+    expect(m.kind === 'exact' && m.member.id).toBe('101');
+  });
+
+  it('first name → the one member it prefixes (fuzzy)', () => {
+    const m = matchMember('Emrecan', MEMBERS);
+    expect(m.kind).toBe('fuzzy');
+    expect(m.kind === 'fuzzy' && m.member.slug).toBe('emrecan-tetik');
+  });
+
+  it('ascii-folds Turkish input before matching', () => {
+    // "mehmet" must reach "Mehmet Nuraydın" (dotless ı in the surname).
+    const m = matchMember('mehmet', MEMBERS);
+    expect(m.kind).toBe('fuzzy');
+    expect(m.kind === 'fuzzy' && m.member.slug).toBe('mehmet-nuraydin');
+  });
+
+  it('a surname segment shared by two members → ambiguous (never guess)', () => {
+    const m = matchMember('Yilmaz', MEMBERS);
+    expect(m.kind).toBe('ambiguous');
+    expect(m.kind === 'ambiguous' && m.matches.map((x) => x.slug).sort()).toEqual([
+      'ahmet-yilmaz',
+      'aylin-yilmaz',
+    ]);
+  });
+
+  it('no match → none', () => {
+    expect(matchMember('nobody', MEMBERS).kind).toBe('none');
+  });
+
+  it('empty / whitespace input → none', () => {
+    expect(matchMember('   ', MEMBERS).kind).toBe('none');
+  });
+
+  it('stub members (no remote id) are never assignable candidates', () => {
+    const stubs: RemoteMember[] = [{ slug: 'emrecan', id: '', name: 'Emrecan' }];
+    // Even an exact-slug hit is rejected when the member carries no real id.
+    expect(matchMember('emrecan', stubs).kind).toBe('none');
+  });
+});

--- a/tests/unit/tasks-members-route.test.ts
+++ b/tests/unit/tasks-members-route.test.ts
@@ -6,6 +6,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { handleTasksMembers } from '../../src/server/routes/tasks.js';
 import { writeSetupConfig } from '../../src/lib/setup-config.js';
 import type { RemoteMember } from '../../src/lib/task-backend/index.js';
+import { SyncLedger } from '../../src/lib/task-backend/index.js';
 
 /**
  * GET /api/tasks/members on a LOCAL project must surface the roster (config
@@ -99,5 +100,68 @@ describe('GET /api/tasks/members (roster fallback)', () => {
     expect(slugs).toEqual(['alan-turing', 'grace-hopper']);
     const grace = body().members.find((m) => m.slug === 'grace-hopper');
     expect(grace?.name).toBe('Grace Hopper');
+  });
+});
+
+describe('GET /api/tasks/members (remote backend gates non-members)', () => {
+  // No real ClickUp token anywhere → listMembers() falls back to the cached
+  // member set (which we seed below) instead of hitting the network.
+  beforeEach(() => {
+    delete process.env.CLICKUP_TOKEN;
+    delete process.env.CLICKUP_API_KEY;
+  });
+
+  it('drops roster/task-derived stubs that match no real member, keeping only member-backed candidates', async () => {
+    // Remote (ClickUp) backend configured. The roster contains a non-member
+    // ("emrecan") AND a real member ("aylin-yilmaz"); a task already carries an
+    // unmappable person:bektas tag. Only the real, member-backed slug may be
+    // offered — picking a stub would mint an unmappable assignee.
+    writeSetupConfig(tmpDir, {
+      platforms: ['claude'],
+      packs: [],
+      multiProduct: false,
+      setupVersion: '1',
+      disableNativeMemory: false,
+      taskBackend: 'clickup',
+      clickup: { teamId: 't', spaceId: 's', listId: 'list1' },
+      people: ['emrecan', 'aylin-yilmaz'],
+    } as never);
+
+    writeFileSync(
+      join(contextRoot, 'state', 'handoff.md'),
+      [
+        '---',
+        'id: task_xyz',
+        'name: Handoff',
+        'status: todo',
+        'priority: medium',
+        'urgency: medium',
+        'tags:',
+        '  - person:bektas',
+        '---',
+        '',
+        '## Notes',
+        '',
+      ].join('\n'),
+    );
+
+    // Seed the cached member roster (real remote ids) — listMembers() returns
+    // this when the live refresh fails (no token → no network).
+    const ledger = new SyncLedger(contextRoot);
+    ledger.writeMembers({
+      'aylin-yilmaz': { id: '102', name: 'Aylin Yilmaz' },
+      'alper-caymaz': { id: '105', name: 'Alper Caymaz' },
+    });
+
+    const { res, status, body } = makeRes();
+    await handleTasksMembers(req, res, {}, contextRoot);
+
+    expect(status()).toBe(200);
+    const members = body().members;
+    // Only the two real members survive; emrecan (roster stub) and bektas
+    // (task-derived stub) are filtered out.
+    expect(members.map((m) => m.slug).sort()).toEqual(['alper-caymaz', 'aylin-yilmaz']);
+    // And every offered candidate carries a real remote id.
+    expect(members.every((m) => m.id !== '')).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Two ClickUp/GitHub task-sync assignee bugs, two ends of one pipe:

1. **Unmapped `person:<slug>` tags silently drop the assignee** — they fell out of the push set with no signal, so the remote defaulted the assignee to the **API-token owner**.
2. **The assignee picker offered non-member free-text slugs** — picking one minted exactly such an unmappable tag.

Root cause: the picker and CLI minted `person:<slug>` tags that resolved to no member, and the push path dropped them silently.

## Fix

**Stop minting unmappable slugs (the root cause)**
- New pure matcher `member-match.ts` — fuzzy-resolves a typed name/first-name (e.g. `Emrecan`) to the canonical member slug (`emrecan-tetik`), ascii/Turkish-folded; returns `ambiguous` rather than guessing.
- CLI `tasks create --person` and `tasks tag person:<slug>` route through it on a remote backend: exact/fuzzy → canonical slug; ambiguous → abort with candidates; no-match → loud warning. Local backend unchanged (free-text harmless, no network).
- Dashboard picker: free-text disabled on a remote backend (members-only; the loading state defaults to the safe/remote behaviour so the window can't be exploited); already-assigned non-member chips are flagged "won't sync" with screen-reader text. The `GET /api/tasks/members` route drops non-member stubs when a remote roster is known.

**Never drop an assignee silently (the safety net)**
- `pushTask` (clickup.ts + github.ts) splits resolved vs unmapped slugs and records each unmapped one in a new structural `SyncReport.warnings[]`, surfaced loudly in `sleep done` and `tasks sync`. The task still pushes — the assignment failure is now visible, not buried.

## Notes
- Provider-neutrality preserved: the generic CLI/route/types layers name no provider (the existing guard test stays green).
- A `/multi-review` pass (security + frontend + edge-cases) ran on this change; security PASS, and the surfaced frontend/edge findings (loading-window default, CSS token usage, a11y text, empty `person:` guard) are folded in.

## Testing
- Both packages typecheck (only pre-existing, unrelated `transcript.ts` errors remain).
- 93 task-backend unit tests pass, including new coverage in `member-match.test.ts`, `clickup-push.test.ts` (unmapped-assignee → warning), and `tasks-members-route.test.ts` (remote-backend member gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)