### PR TITLE
fix(tasks): stable-dcId sync reconciliation (#77) + heal pre-existing assignee drift (#78)

### DIFF
--- a/skill/references/cli-reference.md
+++ b/skill/references/cli-reference.md
@@ -48,8 +48,8 @@ Every command and flag, grouped. All commands are prefixed with `dreamcontext`. 
 | `tasks complete <name> [summary...]` | Mark completed (convenience). |
 | `tasks delete <name>` | Delete a task (propagates to remote backend on sync). `--yes`. |
 | `tasks rename <name> <new-name>` | Rename a task: rewrites the name, moves the file to the new slug, and re-keys the sync mapping by the stable dcId so the **same** remote task/issue is updated on next sync — never duplicated. Use this instead of hand-editing `name:` + renaming the file. |
-| `tasks doctor [name]` | Validate the Workflow flowchart is in sync with Acceptance Criteria (all tasks if name omitted). |
-| `tasks sync [push\|pull\|both]` | Sync with the remote backend (no-op on local). `--hook`, `--json`. |
+| `tasks doctor [name]` | Validate the Workflow flowchart is in sync with Acceptance Criteria (all tasks if name omitted). `--remote` also checks the remote backend for assignee drift (needs a token). |
+| `tasks sync [push\|pull\|both]` | Sync with the remote backend (no-op on local). `--hook`, `--reconcile` (heal pre-existing assignee drift below the watermark — #78), `--json`. |
 | `tasks members` | People with access to the remote list (assignee candidates). `--json`. |
 | `tasks provision` | Create recommended + override-declared custom fields on the remote backend (ClickUp list fields / GitHub labels). Reuses any that already exist by name. |
 | `tasks sync-hooks install\|uninstall` | Manage best-effort git sync triggers (post-commit, pre-push). |

--- a/skill/references/cli-reference.md
+++ b/skill/references/cli-reference.md
@@ -47,6 +47,7 @@ Every command and flag, grouped. All commands are prefixed with `dreamcontext`. 
 | `tasks status <name> <todo\|in_progress\|in_review\|completed> [reason...]` | Change status (logs to changelog). On the first move to `in_progress`, stamps `start_date` with today if it is unset (a planned start is never overwritten). |
 | `tasks complete <name> [summary...]` | Mark completed (convenience). |
 | `tasks delete <name>` | Delete a task (propagates to remote backend on sync). `--yes`. |
+| `tasks rename <name> <new-name>` | Rename a task: rewrites the name, moves the file to the new slug, and re-keys the sync mapping by the stable dcId so the **same** remote task/issue is updated on next sync — never duplicated. Use this instead of hand-editing `name:` + renaming the file. |
 | `tasks doctor [name]` | Validate the Workflow flowchart is in sync with Acceptance Criteria (all tasks if name omitted). |
 | `tasks sync [push\|pull\|both]` | Sync with the remote backend (no-op on local). `--hook`, `--json`. |
 | `tasks members` | People with access to the remote list (assignee candidates). `--json`. |

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -645,6 +645,41 @@ export function registerTasksCommand(program: Command): void {
       success(`Task deleted: ${slug}${backend.name !== 'local' ? ' (remote deletion on next sync)' : ''}`);
     });
 
+  // Rename a task — the slug-safe way (#77). Renaming changes the name-derived
+  // slug; doing it by hand and re-syncing used to DUPLICATE the remote task
+  // (reconciliation joined on slug, not the stable dcId). This rewrites the
+  // name + renames the file + migrates the sync ledger in place, so the next
+  // sync UPDATES the same remote task instead of creating a duplicate.
+  tasks
+    .command('rename')
+    .argument('<name>', 'Current task slug or name')
+    .argument('<new-name>', 'The new task name')
+    .description('Rename a task (file + slug + remote mapping) — never duplicates the remote task')
+    .action(async (name: string, newName: string) => {
+      const backend = getTaskBackend();
+      const slug = await resolveTaskSlug(backend, name);
+      if (!slug) return;
+
+      try {
+        const newSlug = await backend.rename(slug, newName);
+        if (newSlug === slug) {
+          success(`Renamed (name only, slug unchanged): ${slug}`);
+        } else {
+          success(
+            `Renamed: ${slug} → ${newSlug}` +
+            (backend.name !== 'local' ? ' (same remote task updated on next sync — no duplicate)' : ''),
+          );
+        }
+      } catch (err) {
+        if (err instanceof TaskBackendError) {
+          error(err.message);
+          process.exitCode = 1;
+          return;
+        }
+        throw err;
+      }
+    });
+
   // Planned START date on existing tasks (synced to the remote backend)
   tasks
     .command('start')

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -947,24 +947,26 @@ export function registerTasksCommand(program: Command): void {
     .argument('[direction]', 'push, pull, or both (default: both)')
     .description('Sync tasks with the configured remote backend (no-op for local)')
     .option('--hook', 'Best-effort mode for git hooks: never fails, bounded time, exit 0')
+    .option('--reconcile', 'Also heal pre-existing assignee drift: re-pull assignees for every mapped task regardless of the sync watermark (#78)')
     .option('--json', 'Emit the sync report as JSON')
-    .action(async (direction: string | undefined, opts: { hook?: boolean; json?: boolean }) => {
+    .action(async (direction: string | undefined, opts: { hook?: boolean; reconcile?: boolean; json?: boolean }) => {
       const dir = (direction ?? 'both') as 'push' | 'pull' | 'both';
       if (!['push', 'pull', 'both'].includes(dir)) {
         error('Direction must be one of: push, pull, both');
         return;
       }
+      const syncOpts = { reconcile: !!opts.reconcile };
       try {
         const backend = getTaskBackend();
         const report = opts.hook
           ? await Promise.race([
-              backend.sync(dir),
+              backend.sync(dir, syncOpts),
               new Promise<null>((resolveTimeout) => {
                 const t = setTimeout(() => resolveTimeout(null), 15000);
                 (t as unknown as { unref?: () => void }).unref?.();
               }),
             ])
-          : await backend.sync(dir);
+          : await backend.sync(dir, syncOpts);
         if (report === null) {
           // Hook-mode timeout: report and exit clean — git must never block.
           console.log(chalk.dim('tasks sync: timed out (hook mode) — skipped.'));
@@ -983,7 +985,11 @@ export function registerTasksCommand(program: Command): void {
           return;
         }
         const deletedPart = report.deleted > 0 ? `, deleted ${report.deleted}` : '';
-        success(`Sync (${report.direction}): pushed ${report.pushed}, pulled ${report.pulled}, created ${report.created}${deletedPart}, comments ${report.commentsAdded}`);
+        const reconciledPart = report.reconciled > 0 ? `, reconciled ${report.reconciled}` : '';
+        success(`Sync (${report.direction}): pushed ${report.pushed}, pulled ${report.pulled}, created ${report.created}${deletedPart}, comments ${report.commentsAdded}${reconciledPart}`);
+        if (syncOpts.reconcile && report.reconciled === 0) {
+          console.log(chalk.dim('  reconcile: no assignee drift found — local already matches the remote.'));
+        }
         if (report.pendingQueue > 0) {
           console.log(chalk.yellow(`  ${report.pendingQueue} queued op(s) pending (offline?) — will replay on next sync.`));
         }
@@ -1090,12 +1096,14 @@ export function registerTasksCommand(program: Command): void {
     });
 
   // Doctor: validate Workflow flowchart matches Acceptance Criteria
-  // (doctor stays local-only by design — issue #11)
+  // (the default checks stay LOCAL-ONLY by design — issue #11; the optional
+  //  `--remote` assignee-drift probe is the one network check, opt-in — #78)
   tasks
     .command('doctor')
     .argument('[name]', 'Task name (omit to check every task)')
     .description('Validate Workflow flowchart is in sync with Acceptance Criteria')
-    .action(async (name?: string) => {
+    .option('--remote', 'Also check the remote backend for assignee drift (requires a token; #78)')
+    .action(async (name: string | undefined, opts: { remote?: boolean }) => {
       const dir = getStateDir();
       let files: string[];
       if (name) {
@@ -1129,6 +1137,38 @@ export function registerTasksCommand(program: Command): void {
         process.exitCode = 1;
       } else {
         success(`All ${files.length} task(s) clean.`);
+      }
+
+      // Opt-in remote probe (#78): assignee drift between the remote and local
+      // person tags. Best-effort — a missing token / offline remote prints a
+      // skip note rather than failing the local checks above.
+      if (opts.remote) {
+        console.log();
+        console.log(header('Remote assignee drift'));
+        const backend = getTaskBackend();
+        if (typeof backend.detectAssigneeDrift !== 'function') {
+          console.log(chalk.dim(`  Backend "${backend.name}" has no remote assignees — nothing to check.`));
+          return;
+        }
+        try {
+          const drifts = await backend.detectAssigneeDrift();
+          if (drifts.length === 0) {
+            success('No assignee drift — local person tags match the remote.');
+          } else {
+            for (const d of drifts) {
+              const localTxt = d.local.length ? d.local.join(', ') : '(unassigned)';
+              const remoteTxt = d.remote.length ? d.remote.join(', ') : '(unassigned)';
+              console.log(`  ${chalk.yellow('drift')}   ${d.slug}: local [${localTxt}] → remote [${remoteTxt}]`);
+            }
+            console.log();
+            console.log(
+              chalk.yellow(`  ${drifts.length} task(s) have remote assignee drift. `) +
+              `Run ${chalk.cyan('dreamcontext tasks sync --reconcile')} to heal them.`,
+            );
+          }
+        } catch (err) {
+          console.log(chalk.dim(`  Skipped (remote unreachable): ${(err as Error).message ?? err}`));
+        }
       }
     });
 }

--- a/src/lib/task-backend/clickup.ts
+++ b/src/lib/task-backend/clickup.ts
@@ -45,7 +45,7 @@ import { clickupMemberMap, resolveActor, resolveActorToken } from './identity.js
 import { writeClickUpToken, resolveClickUpToken, maskToken } from './secrets.js';
 import { BACKLOG_TAG, LocalTaskBackend } from './local.js';
 import { merge3Bodies, mergeScalar, unionChangelog } from './merge.js';
-import { SyncLedger, hashContent } from './sync-state.js';
+import { SyncLedger, hashContent, reconcileRenamedTasks } from './sync-state.js';
 import type {
   AddChangelogOptions,
   CreateTaskInput,
@@ -256,6 +256,16 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     if (remoteId && !this.applyingRemote) {
       this.ledger.enqueue({ id: generateId('op'), kind: 'delete', slug, ts: this.nowMs(), remoteId });
     }
+  }
+
+  async rename(slug: string, newName: string): Promise<string> {
+    // Move the file + rewrite the name (the local backend also enqueues a push
+    // op under the OLD slug via our updateFields override).
+    const newSlug = await super.rename(slug, newName);
+    // Re-key the ledger (map + sync-state + queued ops) so the SAME ClickUp task
+    // is matched by its stable dcId and UPDATED on next sync — never duplicated.
+    if (newSlug !== slug && !this.applyingRemote) this.ledger.migrateSlug(slug, newSlug);
+    return newSlug;
   }
 
   // ── Members (assignee candidates) ────────────────────────────────────────
@@ -562,6 +572,14 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     }
 
     try {
+      // Heal renamed tasks FIRST (#77): re-key the ledger from any stale slug to
+      // the renamed file's current slug (matched by stable dcId) before either
+      // direction runs — so push UPDATEs the same remote task (no duplicate) and
+      // pull resolves it by the live slug (no resurrected mirror).
+      const renamed = reconcileRenamedTasks(this.ledger, this.liveTaskIdentities());
+      for (const r of renamed) {
+        report.warnings.push(`renamed: ${r.from} → ${r.to} (remapped to existing remote task; no duplicate created)`);
+      }
       // Member cache refresh (assignee candidates) — best-effort, 1 request.
       try {
         await this.refreshMembers(this.getAdapter(), this.requireListId());
@@ -712,6 +730,18 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
     };
 
     let remoteId = this.ledger.remoteIdFor(slug);
+    if (!remoteId) {
+      // Rename-safe join (#77): the slug may have changed, but the STABLE dcId
+      // still maps to an existing remote task. Re-key the ledger and UPDATE it
+      // rather than CREATE a duplicate. (The sync() pre-pass normally heals this
+      // first; this is the per-task safety net so the create branch is only ever
+      // taken for a genuinely new, never-synced task.)
+      const byDcId = this.ledger.entryForDcId(task.id);
+      if (byDcId && byDcId.slug !== slug) {
+        this.ledger.migrateSlug(byDcId.slug, slug);
+        remoteId = byDcId.remoteId;
+      }
+    }
     let serverTime: number | null = null;
     // Tag/field endpoints bump date_updated without returning it — refetch
     // once at the end so the watermark covers our own writes (no echo pull).

--- a/src/lib/task-backend/clickup.ts
+++ b/src/lib/task-backend/clickup.ts
@@ -44,14 +44,16 @@ import { recordDashboardChange, type FieldChange } from '../change-tracker.js';
 import { clickupMemberMap, resolveActor, resolveActorToken } from './identity.js';
 import { writeClickUpToken, resolveClickUpToken, maskToken } from './secrets.js';
 import { BACKLOG_TAG, LocalTaskBackend } from './local.js';
-import { merge3Bodies, mergeScalar, unionChangelog } from './merge.js';
+import { merge3Bodies, mergeScalar, planAssigneeHeal, unionChangelog } from './merge.js';
 import { SyncLedger, hashContent, reconcileRenamedTasks } from './sync-state.js';
 import type {
   AddChangelogOptions,
+  AssigneeDrift,
   CreateTaskInput,
   InsertSectionOptions,
   RemoteMember,
   SyncDirection,
+  SyncOptions,
   SyncReport,
   TaskData,
   TokenStatus,
@@ -543,7 +545,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
 
   // ── Sync engine ───────────────────────────────────────────────────────────
 
-  async sync(direction: SyncDirection = 'both'): Promise<SyncReport> {
+  async sync(direction: SyncDirection = 'both', opts: SyncOptions = {}): Promise<SyncReport> {
     const report: SyncReport = {
       backend: this.name,
       direction,
@@ -558,6 +560,7 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
       errors: [],
       failedPushes: [],
       warnings: [],
+      reconciled: 0,
       watermark: null,
       noop: false,
     };
@@ -598,6 +601,13 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
       }
       if (direction === 'push' || direction === 'both') {
         await this.pushLocal(report);
+      }
+      // Heal pre-existing assignee drift LAST (#78): after push has settled any
+      // local-first changes, adopt the remote assignee set for tasks whose drift
+      // sits below the watermark (so a normal delta pull would never re-examine
+      // them). Opt-in (`--reconcile`) because it costs a full remote fetch.
+      if (opts.reconcile) {
+        await this.reconcileAssignees(report);
       }
     } catch (err) {
       // Total failures (missing token/list, auth) — never throw out of sync():
@@ -1384,6 +1394,121 @@ export class ClickUpTaskBackend extends LocalTaskBackend {
         });
       }
     } catch { /* the journal must never break a sync */ }
+  }
+
+  // ── Assignee reconcile (#78) ──────────────────────────────────────────────
+
+  /** remoteId → sorted person-slug assignee set, for EVERY task on the list. */
+  private async fetchRemoteAssigneeMap(adapter: ApiAdapter, listId: string): Promise<Map<string, string[]>> {
+    const out = new Map<string, string[]>();
+    for (let page = 0; ; page++) {
+      const res = await adapter.request<{ tasks?: ClickUpTask[]; last_page?: boolean }>(
+        'GET',
+        `/list/${listId}/task`,
+        { query: { page, include_closed: true } }, // closed tasks drift too
+      );
+      const batch = res.tasks ?? [];
+      for (const t of batch) {
+        out.set(
+          t.id,
+          [...new Set(
+            (t.assignees ?? []).map(
+              (a) => this.slugForMemberId(String(a.id)) ?? memberSlug(String(a.username ?? a.id)),
+            ),
+          )].sort(),
+        );
+      }
+      if (res.last_page !== false || batch.length === 0) break;
+    }
+    return out;
+  }
+
+  /**
+   * Read-only assignee-drift scan (#78): mapped tasks whose remote assignee set
+   * differs from local `person:` tags and that a `--reconcile` would safely heal
+   * (remote moved, local did not — pending/diverged tasks are left for a normal
+   * sync). Hits the network (full list fetch + a fresh member refresh).
+   */
+  async detectAssigneeDrift(): Promise<AssigneeDrift[]> {
+    const adapter = this.getAdapter();
+    const listId = this.requireListId();
+    // Fresh id→slug mapping so a member assigned only in the ClickUp UI resolves.
+    this.membersRefreshed = false;
+    await this.refreshMembers(adapter, listId, true);
+    const remoteMap = await this.fetchRemoteAssigneeMap(adapter, listId);
+
+    const out: AssigneeDrift[] = [];
+    for (const entry of this.ledger.readMap()) {
+      const remote = remoteMap.get(entry.remoteId);
+      if (remote === undefined) continue; // remote gone — deletion path owns it
+      const local = await this.getLocal(entry.slug);
+      if (!local) continue;
+      const localAssignees = assigneeSlugsOf(local.raw, local.tags);
+      const syncEntry = this.ledger.taskSync(entry.slug);
+      const baseFm = syncEntry?.base_snapshot
+        ? (matter(syncEntry.base_snapshot.body).data as Record<string, unknown>)
+        : null;
+      const baseAssignees = baseFm ? assigneeSlugsOf(baseFm, ((baseFm.tags as string[]) ?? [])) : null;
+      if (planAssigneeHeal(localAssignees, baseAssignees, remote, !!syncEntry?.pendingPush) === 'heal') {
+        out.push({ slug: entry.slug, local: localAssignees, remote });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Apply the assignee-drift heal: for each safely-healable task, replace its
+   * `person:` tags with the remote set and re-baseline the ledger so the next
+   * sync sees it as settled (no echo push, no re-pull). Idempotent.
+   */
+  protected async reconcileAssignees(report: SyncReport): Promise<void> {
+    let drift: AssigneeDrift[];
+    try {
+      drift = await this.detectAssigneeDrift();
+    } catch (err) {
+      report.errors.push(`reconcile assignees: ${(err as Error).message ?? err}`);
+      return;
+    }
+    for (const d of drift) {
+      try {
+        const local = await this.getLocal(d.slug);
+        if (!local) continue;
+        const newTags = withPersonTags(local.tags, d.remote);
+        // Remote-origin write: applyingRemote suppresses the WAL/attribution so
+        // the heal does not enqueue a push back at the remote we just read.
+        this.applyingRemote = true;
+        try {
+          await super.updateFields(d.slug, {
+            tags: newTags,
+            updated_by: this.name,
+            ...(local.raw.assignee != null ? { assignee: null } : {}),
+          });
+        } finally {
+          this.applyingRemote = false;
+        }
+        const newRaw = readFileSync(this.taskPath(d.slug), 'utf-8');
+        const entry = this.ledger.taskSync(d.slug);
+        this.ledger.updateTaskSync(d.slug, {
+          last_synced_at: entry?.last_synced_at ?? 0,
+          base_snapshot: { hash: hashContent(newRaw), body: newRaw },
+          localHash: hashContent(newRaw),
+          pendingPush: false,
+        });
+        report.reconciled++;
+        try {
+          recordDashboardChange(this.contextRoot, {
+            entity: 'task',
+            action: 'update',
+            target: `state/${d.slug}.md`,
+            field: 'assignees',
+            fields: [{ field: 'assignees', from: d.local, to: d.remote }],
+            summary: `Reconciled assignees on '${d.slug}' from ${this.name} (${d.remote.map((s) => `person:${s}`).join(', ') || 'unassigned'})`,
+          });
+        } catch { /* the journal must never break a sync */ }
+      } catch (err) {
+        report.errors.push(`reconcile ${d.slug}: ${(err as Error).message ?? err}`);
+      }
+    }
   }
 
   /** Read the mirror without any remote bookkeeping (super.get under a clear name). */

--- a/src/lib/task-backend/github.ts
+++ b/src/lib/task-backend/github.ts
@@ -33,14 +33,16 @@ import { recordDashboardChange, type FieldChange } from '../change-tracker.js';
 import { resolveActor } from './identity.js';
 import { resolveGitHubToken, writeGitHubToken, maskToken } from './secrets.js';
 import { BACKLOG_TAG, LocalTaskBackend } from './local.js';
-import { merge3Bodies, mergeScalar, unionChangelog } from './merge.js';
+import { merge3Bodies, mergeScalar, planAssigneeHeal, unionChangelog } from './merge.js';
 import { SyncLedger, hashContent, reconcileRenamedTasks } from './sync-state.js';
 import type {
   AddChangelogOptions,
+  AssigneeDrift,
   CreateTaskInput,
   InsertSectionOptions,
   RemoteMember,
   SyncDirection,
+  SyncOptions,
   SyncReport,
   TaskData,
   TokenStatus,
@@ -515,7 +517,7 @@ export class GitHubTaskBackend extends LocalTaskBackend {
 
   // ── Sync engine ───────────────────────────────────────────────────────────
 
-  async sync(direction: SyncDirection = 'both'): Promise<SyncReport> {
+  async sync(direction: SyncDirection = 'both', opts: SyncOptions = {}): Promise<SyncReport> {
     const report: SyncReport = {
       backend: this.name,
       direction,
@@ -530,6 +532,7 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       errors: [],
       failedPushes: [],
       warnings: [],
+      reconciled: 0,
       watermark: null,
       noop: false,
     };
@@ -568,6 +571,12 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       }
       if (direction === 'push' || direction === 'both') {
         await this.pushLocal(report);
+      }
+      // Heal pre-existing assignee drift LAST (#78): adopt the remote assignee
+      // set for tasks whose drift sits below the watermark (a normal delta pull
+      // never re-examines them). Opt-in (`--reconcile`) — costs a full fetch.
+      if (opts.reconcile) {
+        await this.reconcileAssignees(report);
       }
     } catch (err) {
       report.errors.push((err as Error).message ?? String(err));
@@ -1327,6 +1336,124 @@ export class GitHubTaskBackend extends LocalTaskBackend {
       if (items.length < perPage) break;
     }
     return out;
+  }
+
+  // ── Assignee reconcile (#78) ──────────────────────────────────────────────
+
+  /** remoteId (issue number) → sorted person-slug assignee set, for every issue. */
+  private async fetchRemoteAssigneeMap(adapter: ApiAdapter, owner: string, repo: string): Promise<Map<string, string[]>> {
+    const out = new Map<string, string[]>();
+    const perPage = 100;
+    for (let page = 1; ; page++) {
+      const batch = await adapter.request<Array<GitHubIssue & { pull_request?: unknown }>>(
+        'GET',
+        this.issuesPath(owner, repo),
+        { query: { state: 'all', per_page: perPage, page } },
+      );
+      const items = Array.isArray(batch) ? batch : [];
+      for (const i of items) {
+        if (i.pull_request !== undefined) continue; // PRs are not tasks
+        out.set(
+          String(i.number),
+          [...new Set(
+            (i.assignees ?? [])
+              .map((a) => {
+                try {
+                  return a?.login ? this.slugForLogin(a.login) : null;
+                } catch {
+                  return null;
+                }
+              })
+              .filter((s): s is string => Boolean(s)),
+          )].sort(),
+        );
+      }
+      if (items.length < perPage) break;
+    }
+    return out;
+  }
+
+  /**
+   * Read-only assignee-drift scan (#78): mapped tasks whose remote assignee set
+   * differs from local `person:` tags and that a `--reconcile` would safely heal
+   * (remote moved, local did not). Hits the network (full issue list + member refresh).
+   */
+  async detectAssigneeDrift(): Promise<AssigneeDrift[]> {
+    const adapter = this.getAdapter();
+    const { owner, repo } = this.requireRepo();
+    await this.refreshMembers(adapter, owner, repo, true); // fresh login→slug
+    const remoteMap = await this.fetchRemoteAssigneeMap(adapter, owner, repo);
+
+    const out: AssigneeDrift[] = [];
+    for (const entry of this.ledger.readMap()) {
+      const remote = remoteMap.get(entry.remoteId);
+      if (remote === undefined) continue; // remote gone — deletion path owns it
+      const local = await this.getLocal(entry.slug);
+      if (!local) continue;
+      const localAssignees = assigneeSlugsOf(local.raw, local.tags);
+      const syncEntry = this.ledger.taskSync(entry.slug);
+      const baseFm = syncEntry?.base_snapshot
+        ? (matter(syncEntry.base_snapshot.body).data as Record<string, unknown>)
+        : null;
+      const baseAssignees = baseFm ? assigneeSlugsOf(baseFm, ((baseFm.tags as string[]) ?? [])) : null;
+      if (planAssigneeHeal(localAssignees, baseAssignees, remote, !!syncEntry?.pendingPush) === 'heal') {
+        out.push({ slug: entry.slug, local: localAssignees, remote });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Apply the assignee-drift heal: replace each healable task's `person:` tags
+   * with the remote set and re-baseline the ledger so the next sync sees it as
+   * settled (no echo push, no re-pull). Idempotent.
+   */
+  protected async reconcileAssignees(report: SyncReport): Promise<void> {
+    let drift: AssigneeDrift[];
+    try {
+      drift = await this.detectAssigneeDrift();
+    } catch (err) {
+      report.errors.push(`reconcile assignees: ${(err as Error).message ?? err}`);
+      return;
+    }
+    for (const d of drift) {
+      try {
+        const local = await this.getLocal(d.slug);
+        if (!local) continue;
+        const newTags = withPersonTags(local.tags, d.remote);
+        this.applyingRemote = true;
+        try {
+          await super.updateFields(d.slug, {
+            tags: newTags,
+            updated_by: this.name,
+            ...(local.raw.assignee != null ? { assignee: null } : {}),
+          });
+        } finally {
+          this.applyingRemote = false;
+        }
+        const newRaw = readFileSync(this.taskPath(d.slug), 'utf-8');
+        const entry = this.ledger.taskSync(d.slug);
+        this.ledger.updateTaskSync(d.slug, {
+          last_synced_at: entry?.last_synced_at ?? 0,
+          base_snapshot: { hash: hashContent(newRaw), body: newRaw },
+          localHash: hashContent(newRaw),
+          pendingPush: false,
+        });
+        report.reconciled++;
+        try {
+          recordDashboardChange(this.contextRoot, {
+            entity: 'task',
+            action: 'update',
+            target: `state/${d.slug}.md`,
+            field: 'assignees',
+            fields: [{ field: 'assignees', from: d.local, to: d.remote }],
+            summary: `Reconciled assignees on '${d.slug}' from ${this.name} (${d.remote.map((s) => `person:${s}`).join(', ') || 'unassigned'})`,
+          });
+        } catch { /* the journal must never break a sync */ }
+      } catch (err) {
+        report.errors.push(`reconcile ${d.slug}: ${(err as Error).message ?? err}`);
+      }
+    }
   }
 
   /** Read the mirror without any remote bookkeeping (super.get under a clear name). */

--- a/src/lib/task-backend/github.ts
+++ b/src/lib/task-backend/github.ts
@@ -34,7 +34,7 @@ import { resolveActor } from './identity.js';
 import { resolveGitHubToken, writeGitHubToken, maskToken } from './secrets.js';
 import { BACKLOG_TAG, LocalTaskBackend } from './local.js';
 import { merge3Bodies, mergeScalar, unionChangelog } from './merge.js';
-import { SyncLedger, hashContent } from './sync-state.js';
+import { SyncLedger, hashContent, reconcileRenamedTasks } from './sync-state.js';
 import type {
   AddChangelogOptions,
   CreateTaskInput,
@@ -297,6 +297,16 @@ export class GitHubTaskBackend extends LocalTaskBackend {
     }
   }
 
+  async rename(slug: string, newName: string): Promise<string> {
+    // Move the file + rewrite the name (the local backend also enqueues a push
+    // op under the OLD slug via our updateFields override).
+    const newSlug = await super.rename(slug, newName);
+    // Re-key the ledger (map + sync-state + queued ops) so the SAME issue is
+    // matched by its stable dcId and UPDATED on next sync — never duplicated.
+    if (newSlug !== slug && !this.applyingRemote) this.ledger.migrateSlug(slug, newSlug);
+    return newSlug;
+  }
+
   // ── Members (assignee candidates = repo collaborators) ────────────────────
 
   private membersRefreshed = false;
@@ -532,6 +542,14 @@ export class GitHubTaskBackend extends LocalTaskBackend {
     }
 
     try {
+      // Heal renamed tasks FIRST (#77): re-key the ledger from any stale slug to
+      // the renamed file's current slug (matched by stable dcId) before either
+      // direction runs — so push UPDATEs the same issue (no duplicate) and pull
+      // resolves it by the live slug (no resurrected mirror).
+      const renamed = reconcileRenamedTasks(this.ledger, this.liveTaskIdentities());
+      for (const r of renamed) {
+        report.warnings.push(`renamed: ${r.from} → ${r.to} (remapped to existing remote task; no duplicate created)`);
+      }
       try {
         const { owner, repo } = this.requireRepo();
         await this.refreshMembers(this.getAdapter(), owner, repo);
@@ -677,6 +695,18 @@ export class GitHubTaskBackend extends LocalTaskBackend {
     const body = composeIssueBody(bodyToIssueBody(task.body), startLocal, dueLocal, fieldsBlock);
 
     let remoteId = this.ledger.remoteIdFor(slug);
+    if (!remoteId) {
+      // Rename-safe join (#77): the slug may have changed, but the STABLE dcId
+      // still maps to an existing issue. Re-key the ledger and UPDATE it rather
+      // than CREATE a duplicate. (The sync() pre-pass normally heals this first;
+      // this is the per-task safety net so the create branch is only ever taken
+      // for a genuinely new, never-synced task.)
+      const byDcId = this.ledger.entryForDcId(task.id);
+      if (byDcId && byDcId.slug !== slug) {
+        this.ledger.migrateSlug(byDcId.slug, slug);
+        remoteId = byDcId.remoteId;
+      }
+    }
     let serverTime: number | null = null;
 
     if (!remoteId) {

--- a/src/lib/task-backend/local.ts
+++ b/src/lib/task-backend/local.ts
@@ -518,7 +518,8 @@ ${input.why || '(To be defined)'}
   }
 
   async sync(direction: SyncDirection = 'both'): Promise<SyncReport> {
-    // Local backend has no remote — sync is a structured no-op.
+    // Local backend has no remote — sync is a structured no-op. (The `opts`
+    // param in the interface, including `reconcile`, is irrelevant here.)
     return {
       backend: this.name,
       direction,
@@ -533,6 +534,7 @@ ${input.why || '(To be defined)'}
       errors: [],
       failedPushes: [],
       warnings: [],
+      reconciled: 0,
       watermark: null,
       noop: true,
     };

--- a/src/lib/task-backend/local.ts
+++ b/src/lib/task-backend/local.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 import fg from 'fast-glob';
 import { loadTaskOverride } from '../overrides.js';
@@ -252,6 +252,23 @@ export class LocalTaskBackend implements TaskBackend {
     return fg.sync('*.md', { cwd: this.stateDir, absolute: true });
   }
 
+  /**
+   * The `{ slug, dcId }` join keys for every live task file — what rename
+   * reconciliation (#77) needs to map a renamed file's new slug back to its
+   * stable dcId. File access lives here (the local backend owns it); the remote
+   * backends inherit it and feed it to `reconcileRenamedTasks`.
+   */
+  protected liveTaskIdentities(): Array<{ slug: string; dcId: string }> {
+    const out: Array<{ slug: string; dcId: string }> = [];
+    for (const file of this.taskFiles()) {
+      try {
+        const { data } = readFrontmatter<{ id?: string }>(file);
+        if (data.id) out.push({ slug: basename(file, '.md'), dcId: data.id });
+      } catch { /* skip unreadable */ }
+    }
+    return out;
+  }
+
   async list(filter?: TaskFilter): Promise<TaskSummary[]> {
     const all: TaskSummary[] = [];
     for (const file of this.taskFiles()) {
@@ -450,6 +467,32 @@ ${input.why || '(To be defined)'}
   async delete(slug: string): Promise<void> {
     const path = this.requirePath(slug);
     rmSync(path);
+  }
+
+  async rename(slug: string, newName: string): Promise<string> {
+    const path = this.requirePath(slug);
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      throw new TaskBackendError('invalid_input', 'New task name cannot be empty.');
+    }
+    const newSlug = slugify(trimmed);
+    if (!newSlug || !isSafeTaskSlug(newSlug)) {
+      throw new TaskBackendError('invalid_input', `Invalid task name: ${newName}`);
+    }
+    // Slug unchanged (a casing/punctuation tweak) → update the name field only.
+    if (newSlug === slug) {
+      await this.updateFields(slug, { name: trimmed, updated_at: today() });
+      return slug;
+    }
+    if (existsSync(this.taskPath(newSlug))) {
+      throw new TaskBackendError('already_exists', `A task already exists at slug "${newSlug}".`);
+    }
+    // Rewrite the name on the OLD file first (so remote backends enqueue a push
+    // for the rename), then move the file to the new slug. The id-map migration
+    // is layered on by the remote backends' override.
+    await this.updateFields(slug, { name: trimmed, updated_at: today() });
+    renameSync(path, this.taskPath(newSlug));
+    return newSlug;
   }
 
   async resolveSlug(name: string): Promise<SlugResolution> {

--- a/src/lib/task-backend/merge.ts
+++ b/src/lib/task-backend/merge.ts
@@ -167,6 +167,35 @@ export function mergeScalar<T>(
   return { value: remote, winner: 'remote' };
 }
 
+export type AssigneeHealDecision = 'heal' | 'in_sync' | 'pending' | 'local_diverged';
+
+/**
+ * Decide whether one task's local assignees should be HEALED to the remote set
+ * during a `--reconcile` pass (#78). Assignees are remote-authoritative, but a
+ * heal must never clobber a local change that simply hasn't pushed yet:
+ *   - local == remote          → already in sync, nothing to do
+ *   - a local push is pending   → let the normal sync push it first
+ *   - local diverged from base  → a genuine two-sided change → leave it for a
+ *                                 full sync/merge (surfaced, not silently healed)
+ *   - else (local == base, only the remote moved) → safe to adopt the remote set
+ *
+ * Slug arrays compare order-insensitively (callers already pass them sorted, but
+ * we sort defensively so a caller's ordering can never change the decision).
+ */
+export function planAssigneeHeal(
+  local: string[],
+  base: string[] | null,
+  remote: string[],
+  pendingPush: boolean,
+): AssigneeHealDecision {
+  const eq = (a: string[], b: string[]) =>
+    JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+  if (eq(local, remote)) return 'in_sync';
+  if (pendingPush) return 'pending';
+  if (base !== null && !eq(local, base)) return 'local_diverged';
+  return 'heal';
+}
+
 /**
  * Union-merge changelog entries (conflict-free by construction).
  * Remote-only entries stack on top (LIFO), local order preserved below.

--- a/src/lib/task-backend/sync-state.ts
+++ b/src/lib/task-backend/sync-state.ts
@@ -114,6 +114,17 @@ export class SyncLedger {
     return this.readMap().find((e) => e.remoteId === remoteId)?.slug ?? null;
   }
 
+  /**
+   * Look up a mapping by the STABLE dcId (the task's `id:` frontmatter), not the
+   * name-derived slug. This is the rename-safe join key: a task's slug changes
+   * when it is renamed, but its dcId never does — so reconciliation must key on
+   * dcId to avoid re-creating a renamed task as a duplicate remote task (#77).
+   */
+  entryForDcId(dcId: string): TaskMapEntry | null {
+    if (!dcId) return null;
+    return this.readMap().find((e) => e.dcId === dcId) ?? null;
+  }
+
   recordMapping(entry: TaskMapEntry): void {
     const map = this.readMap().filter((e) => e.slug !== entry.slug);
     map.push(entry);
@@ -123,6 +134,44 @@ export class SyncLedger {
 
   removeMapping(slug: string): void {
     writeJson(this.mapPath, this.readMap().filter((e) => e.slug !== slug));
+  }
+
+  /**
+   * Re-key every ledger record for a RENAMED task from `oldSlug` to `newSlug`,
+   * preserving its stable identity (dcId / backend / remoteId), its sync state
+   * (base snapshot, watermark, localHash — so the rename pushes as an UPDATE and
+   * the 3-way merge keeps its base), and any queued write-ahead ops. This is the
+   * surgery that lets a rename update the SAME remote task instead of duplicating
+   * it (#77). No-op when the slug is unchanged or nothing is mapped under it.
+   */
+  migrateSlug(oldSlug: string, newSlug: string): void {
+    if (!oldSlug || !newSlug || oldSlug === newSlug) return;
+
+    // Committed id-map: move the entry (keep dcId/backend/remoteId), drop any
+    // stale record sitting on the target slug so we never leave a duplicate.
+    const map = this.readMap();
+    const entry = map.find((e) => e.slug === oldSlug);
+    if (entry) {
+      const next = map.filter((e) => e.slug !== oldSlug && e.slug !== newSlug);
+      next.push({ ...entry, slug: newSlug });
+      next.sort((a, b) => a.slug.localeCompare(b.slug));
+      writeJson(this.mapPath, next);
+    }
+
+    // Sync state: the renamed task's history (base snapshot/watermark/hash) is
+    // authoritative — carry it onto the new slug and drop the old key.
+    const state = this.readSyncState();
+    if (state.tasks[oldSlug]) {
+      state.tasks[newSlug] = state.tasks[oldSlug];
+      delete state.tasks[oldSlug];
+      this.writeSyncState(state);
+    }
+
+    // Write-ahead queue: re-key any pending ops so they replay under the new slug.
+    const queue = this.readQueue();
+    if (queue.some((q) => q.slug === oldSlug)) {
+      writeJson(this.queuePath, queue.map((q) => (q.slug === oldSlug ? { ...q, slug: newSlug } : q)));
+    }
   }
 
   removeTaskSync(slug: string): void {
@@ -298,4 +347,50 @@ export class SyncLedger {
   queuedSlugs(): string[] {
     return [...new Set(this.readQueue().map((q) => q.slug))];
   }
+}
+
+/**
+ * Heal RENAMED tasks in the ledger before a sync runs (#77). Provider-agnostic:
+ * it speaks only ledger + the `{slug, dcId}` of the live task files, so it works
+ * identically for every remote backend and never touches wire shapes.
+ *
+ * A rename changes a task's name-derived slug but never its stable dcId. Without
+ * this pass, the map still points the remote task at the OLD slug, so push would
+ * re-create it as a duplicate and pull's "vanished mirror" branch could resurrect
+ * the old file. Here we detect a map entry whose slug no longer has a file but
+ * whose dcId matches a live file under a new slug, and migrate the entry in place.
+ *
+ * Non-destructive and idempotent: a stale slug whose dcId has no live file is left
+ * alone (that is a deletion, reconciled elsewhere), and a rename whose target slug
+ * is ALREADY mapped is skipped (never clobber an existing mapping — that residue is
+ * an old duplicate for manual/`--reconcile` cleanup, not something to auto-merge).
+ *
+ * @returns the `{ from, to }` slug migrations applied (for logging / reporting).
+ */
+export function reconcileRenamedTasks(
+  ledger: SyncLedger,
+  liveTasks: Array<{ slug: string; dcId: string }>,
+): Array<{ from: string; to: string }> {
+  const map = ledger.readMap();
+  if (map.length === 0) return [];
+
+  const liveSlugs = new Set(liveTasks.map((t) => t.slug));
+  const liveByDcId = new Map<string, string>();
+  for (const t of liveTasks) {
+    if (t.dcId && !liveByDcId.has(t.dcId)) liveByDcId.set(t.dcId, t.slug);
+  }
+  const mapSlugs = new Set(map.map((e) => e.slug));
+
+  const migrations: Array<{ from: string; to: string }> = [];
+  for (const entry of map) {
+    if (liveSlugs.has(entry.slug)) continue; // slug still has a file — valid
+    const newSlug = liveByDcId.get(entry.dcId);
+    if (!newSlug || newSlug === entry.slug) continue; // no rename (deletion, etc.)
+    if (mapSlugs.has(newSlug)) continue; // target already mapped — don't clobber
+    ledger.migrateSlug(entry.slug, newSlug);
+    mapSlugs.delete(entry.slug);
+    mapSlugs.add(newSlug);
+    migrations.push({ from: entry.slug, to: newSlug });
+  }
+  return migrations;
 }

--- a/src/lib/task-backend/types.ts
+++ b/src/lib/task-backend/types.ts
@@ -216,6 +216,13 @@ export interface TaskBackend {
   complete(slug: string, summary?: string): Promise<TaskData>;
   /** Delete a task (remote backends propagate the deletion on sync). */
   delete(slug: string): Promise<void>;
+  /**
+   * Rename a task: rewrite its name, move its file to the new name-derived slug,
+   * and (on remote backends) re-key the sync mapping by the stable dcId so the
+   * SAME remote task is updated on the next sync — never duplicated (#77).
+   * Returns the resulting slug (unchanged when only the display name changed).
+   */
+  rename(slug: string, newName: string): Promise<string>;
   /** Resolve a human-entered name to a slug (exact → prefix → substring). */
   resolveSlug(name: string): Promise<SlugResolution>;
   /** Two-way sync with the remote. No-op for the local backend. */

--- a/src/lib/task-backend/types.ts
+++ b/src/lib/task-backend/types.ts
@@ -149,6 +149,27 @@ export type SlugResolution =
 
 export type SyncDirection = 'push' | 'pull' | 'both';
 
+export interface SyncOptions {
+  /**
+   * Heal pre-existing assignee drift in one pass (#78). The normal delta pull is
+   * watermark-gated, so a remote-side assignee change made BELOW the watermark is
+   * never re-examined and never reaches local `person:<slug>` tags. With this set,
+   * the sync re-fetches every mapped remote task regardless of the delta window and
+   * adopts the remote assignee set wherever local hasn't itself diverged. No-op for
+   * the local backend; idempotent (a second run heals nothing).
+   */
+  reconcile?: boolean;
+}
+
+/** A task whose remote assignees differ from its local `person:<slug>` tags (#78). */
+export interface AssigneeDrift {
+  slug: string;
+  /** Local assignee person-slugs (current `person:` tags + legacy field), sorted. */
+  local: string[];
+  /** Remote assignee person-slugs, sorted — what a `--reconcile` pass would adopt. */
+  remote: string[];
+}
+
 export interface SyncConflict {
   slug: string;
   /** Where the losing local copy was preserved (state/.conflicts/...). */
@@ -187,6 +208,12 @@ export interface SyncReport {
   warnings: string[];
   /** Remote server-time watermark after this sync (epoch ms), if any. */
   watermark: number | null;
+  /**
+   * Tasks whose local assignees were HEALED to the remote set by a `--reconcile`
+   * pass (#78). Always 0 unless `SyncOptions.reconcile` was set; a non-zero count
+   * means below-watermark assignee drift was found and fixed.
+   */
+  reconciled: number;
   /** True when nothing had to be done (also the local backend's constant result). */
   noop: boolean;
   /** Set when the sync did not run at all (another sync holds the lock). */
@@ -226,7 +253,13 @@ export interface TaskBackend {
   /** Resolve a human-entered name to a slug (exact → prefix → substring). */
   resolveSlug(name: string): Promise<SlugResolution>;
   /** Two-way sync with the remote. No-op for the local backend. */
-  sync(direction?: SyncDirection): Promise<SyncReport>;
+  sync(direction?: SyncDirection, opts?: SyncOptions): Promise<SyncReport>;
+  /**
+   * Read-only scan for assignee drift (#78): mapped tasks whose remote assignees
+   * differ from their local `person:` tags and that a `--reconcile` would heal.
+   * Hits the network (full remote fetch). Absent on local (no remote to compare).
+   */
+  detectAssigneeDrift?(): Promise<AssigneeDrift[]>;
   /** Remote connectivity probe (Settings "Test connection"). Absent on local. */
   testConnection?(): Promise<ConnectionTestResult>;
   /**

--- a/tests/unit/assignee-reconcile.test.ts
+++ b/tests/unit/assignee-reconcile.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, readFileSync, writeFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { ClickUpTaskBackend } from '../../src/lib/task-backend/clickup.js';
+import { GitHubTaskBackend } from '../../src/lib/task-backend/github.js';
+import { ApiAdapter } from '../../src/lib/task-backend/api-adapter.js';
+import { planAssigneeHeal } from '../../src/lib/task-backend/merge.js';
+import type { SetupConfig } from '../../src/lib/setup-config.js';
+import { makeFakeClickUp, type FakeClickUp } from './clickup-fake.js';
+import { makeFakeGitHub, type FakeGitHub } from './github-fake.js';
+
+/**
+ * Issue #78 — assignee reconcile (`tasks sync --reconcile`).
+ *
+ * The forward assignee pull-back already works (covered in clickup-pull.test
+ * and github-pull.test). What these tests pin is the REMAINING gap: assignee
+ * drift that sits BELOW the sync watermark is never re-examined by a normal
+ * delta pull, so it never self-heals — and `--reconcile` heals it in one pass,
+ * idempotently, without clobbering a pending local change.
+ */
+
+// ── pure decision ───────────────────────────────────────────────────────────
+
+describe('planAssigneeHeal (pure)', () => {
+  it('local == remote → in_sync (nothing to do)', () => {
+    expect(planAssigneeHeal(['a'], [], ['a'], false)).toBe('in_sync');
+    expect(planAssigneeHeal(['a', 'b'], ['a'], ['b', 'a'], false)).toBe('in_sync'); // order-insensitive
+  });
+  it('remote moved, local == base → heal', () => {
+    expect(planAssigneeHeal([], [], ['a'], false)).toBe('heal');
+    expect(planAssigneeHeal(['a'], ['a'], ['a', 'b'], false)).toBe('heal');
+  });
+  it('a local push is pending → pending (let normal sync push first)', () => {
+    expect(planAssigneeHeal(['b'], [], ['a'], true)).toBe('pending');
+  });
+  it('local diverged from base (two-sided change) → local_diverged (not auto-healed)', () => {
+    expect(planAssigneeHeal(['b'], [], ['a'], false)).toBe('local_diverged');
+  });
+  it('no base recorded but remote differs → heal (best effort)', () => {
+    expect(planAssigneeHeal([], null, ['a'], false)).toBe('heal');
+  });
+});
+
+// ── ClickUp ─────────────────────────────────────────────────────────────────
+
+describe('ClickUp assignee reconcile (#78)', () => {
+  const CONFIG: SetupConfig = {
+    platforms: [], packs: [], multiProduct: false, setupVersion: '0.0.0',
+    disableNativeMemory: true, taskBackend: 'clickup', cloudTaskManagement: true,
+    clickup: { teamId: 'team1', spaceId: 'space1', listId: 'list1', changelogTarget: 'comments' },
+    people: ['Alice'], peopleIdentity: { alice: { clickupMemberId: '501' } },
+  };
+  let projectRoot: string, contextRoot: string, fake: FakeClickUp, backend: ClickUpTaskBackend, clock: number;
+
+  function makeBackend(): ClickUpTaskBackend {
+    clock = 1000;
+    const now = () => (clock += 7);
+    const sleep = async () => { clock += 1; };
+    const adapter = new ApiAdapter({ baseUrl: 'https://api.clickup.com/api/v2', authHeaders: () => ({ Authorization: 'pk_test' }), fetchImpl: fake.fetchImpl, now, sleep });
+    return new ClickUpTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+  }
+  const mirror = (slug: string) => readFileSync(join(contextRoot, 'state', `${slug}.md`), 'utf-8');
+  const remoteIdOf = (slug: string) => JSON.parse(readFileSync(join(contextRoot, 'state', '.tasks-map.json'), 'utf-8')).find((e: any) => e.slug === slug).remoteId;
+  function jamWatermarkAhead(): void {
+    const p = join(contextRoot, 'state', '.tasks-sync.json');
+    const st = JSON.parse(readFileSync(p, 'utf-8'));
+    st.watermark = 2_000_000_000_000; // ahead of the fake clock (~2030), still a valid Date for GitHub `since`
+    writeFileSync(p, JSON.stringify(st, null, 2));
+  }
+
+  beforeEach(() => {
+    delete process.env.DREAMCONTEXT_PERSON;
+    const raw = join(tmpdir(), `dc-arec-cu-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(raw, { recursive: true });
+    projectRoot = realpathSync(raw);
+    contextRoot = join(projectRoot, '_dream_context');
+    mkdirSync(join(contextRoot, 'state'), { recursive: true });
+    fake = makeFakeClickUp();
+    backend = makeBackend();
+  });
+  afterEach(() => { rmSync(projectRoot, { recursive: true, force: true }); });
+
+  it('a normal pull MISSES below-watermark drift; --reconcile heals it, idempotently', async () => {
+    await backend.create({ name: 'Drift Task', variant: 'cli' });
+    await backend.sync('both');
+    // Assigned in the ClickUp UI, then the watermark moves past it.
+    fake.editTask(remoteIdOf('drift-task'), { assignees: [{ id: 501 }] });
+    jamWatermarkAhead();
+
+    // Normal pull can't see it (the gap).
+    const plain = await backend.sync('pull');
+    expect(plain.errors).toEqual([]);
+    expect(plain.reconciled).toBe(0);
+    expect(mirror('drift-task')).not.toContain('person:alice');
+
+    // --reconcile heals it.
+    const healed = await backend.sync('pull', { reconcile: true });
+    expect(healed.errors).toEqual([]);
+    expect(healed.reconciled).toBe(1);
+    expect(mirror('drift-task')).toContain('person:alice');
+
+    // Idempotent: a second reconcile finds nothing.
+    const again = await backend.sync('pull', { reconcile: true });
+    expect(again.errors).toEqual([]);
+    expect(again.reconciled).toBe(0);
+    expect(mirror('drift-task')).toContain('person:alice');
+  });
+
+  it('detectAssigneeDrift surfaces the drift read-only (drives `tasks doctor --remote`)', async () => {
+    await backend.create({ name: 'Doctor Task', variant: 'cli' });
+    await backend.sync('both');
+    fake.editTask(remoteIdOf('doctor-task'), { assignees: [{ id: 501 }] });
+
+    const drift = await backend.detectAssigneeDrift();
+    expect(drift).toEqual([{ slug: 'doctor-task', local: [], remote: ['alice'] }]);
+    // Read-only: the mirror is untouched.
+    expect(mirror('doctor-task')).not.toContain('person:alice');
+  });
+
+  it('does NOT clobber a pending local assignment (skips pendingPush)', async () => {
+    await backend.create({ name: 'Pending Task', variant: 'cli' });
+    await backend.sync('both');
+    // Local assigns bob (pending push); remote assigns alice.
+    await backend.updateFields('pending-task', { tags: ['person:bob'] });
+    fake.editTask(remoteIdOf('pending-task'), { assignees: [{ id: 501 }] });
+    jamWatermarkAhead();
+
+    const report = await backend.sync('pull', { reconcile: true });
+    expect(report.reconciled).toBe(0);
+    expect(mirror('pending-task')).toContain('person:bob'); // local change preserved
+    expect(mirror('pending-task')).not.toContain('person:alice');
+  });
+});
+
+// ── GitHub ──────────────────────────────────────────────────────────────────
+
+describe('GitHub assignee reconcile (#78)', () => {
+  const CONFIG: SetupConfig = {
+    platforms: [], packs: [], multiProduct: false, setupVersion: '0.0.0',
+    disableNativeMemory: true, taskBackend: 'github', cloudTaskManagement: true,
+    github: { owner: 'meanllbrl', repo: 'dreamcontext', changelogTarget: 'comments' },
+  };
+  let projectRoot: string, contextRoot: string, fake: FakeGitHub, backend: GitHubTaskBackend, clock: number;
+
+  function makeBackend(): GitHubTaskBackend {
+    clock = 1000;
+    const now = () => (clock += 7);
+    const sleep = async () => { clock += 1; };
+    const adapter = new ApiAdapter({ baseUrl: 'https://api.github.com', authHeaders: () => ({ Authorization: 'Bearer ghp_test' }), fetchImpl: fake.fetchImpl, now, sleep });
+    return new GitHubTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+  }
+  const mirror = (slug: string) => readFileSync(join(contextRoot, 'state', `${slug}.md`), 'utf-8');
+  const remoteIdOf = (slug: string) => JSON.parse(readFileSync(join(contextRoot, 'state', '.tasks-map.json'), 'utf-8')).find((e: any) => e.slug === slug).remoteId;
+  function jamWatermarkAhead(): void {
+    const p = join(contextRoot, 'state', '.tasks-sync.json');
+    const st = JSON.parse(readFileSync(p, 'utf-8'));
+    st.watermark = 2_000_000_000_000; // ahead of the fake clock (~2030), still a valid Date for GitHub `since`
+    writeFileSync(p, JSON.stringify(st, null, 2));
+  }
+
+  beforeEach(() => {
+    delete process.env.DREAMCONTEXT_PERSON;
+    const raw = join(tmpdir(), `dc-arec-gh-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(raw, { recursive: true });
+    projectRoot = realpathSync(raw);
+    contextRoot = join(projectRoot, '_dream_context');
+    mkdirSync(join(contextRoot, 'state'), { recursive: true });
+    fake = makeFakeGitHub();
+    backend = makeBackend();
+  });
+  afterEach(() => { rmSync(projectRoot, { recursive: true, force: true }); });
+
+  it('a normal pull MISSES below-watermark drift; --reconcile heals it, idempotently', async () => {
+    await backend.create({ name: 'Drift Task', variant: 'cli' });
+    await backend.sync('both');
+    // Assigned via the GitHub UI, then the watermark moves past it.
+    fake.editIssue(Number(remoteIdOf('drift-task')), { assignees: [{ login: 'alice' }] });
+    jamWatermarkAhead();
+
+    const plain = await backend.sync('pull');
+    expect(plain.errors).toEqual([]);
+    expect(plain.reconciled).toBe(0);
+    expect(mirror('drift-task')).not.toContain('person:alice');
+
+    const healed = await backend.sync('pull', { reconcile: true });
+    expect(healed.errors).toEqual([]);
+    expect(healed.reconciled).toBe(1);
+    expect(mirror('drift-task')).toContain('person:alice');
+
+    const again = await backend.sync('pull', { reconcile: true });
+    expect(again.errors).toEqual([]);
+    expect(again.reconciled).toBe(0);
+  });
+
+  it('detectAssigneeDrift surfaces the drift read-only', async () => {
+    await backend.create({ name: 'Doctor Task', variant: 'cli' });
+    await backend.sync('both');
+    fake.editIssue(Number(remoteIdOf('doctor-task')), { assignees: [{ login: 'alice' }] });
+
+    const drift = await backend.detectAssigneeDrift();
+    expect(drift).toEqual([{ slug: 'doctor-task', local: [], remote: ['alice'] }]);
+    expect(mirror('doctor-task')).not.toContain('person:alice');
+  });
+});

--- a/tests/unit/sync-rename.test.ts
+++ b/tests/unit/sync-rename.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { SyncLedger, reconcileRenamedTasks } from '../../src/lib/task-backend/sync-state.js';
+import { GitHubTaskBackend } from '../../src/lib/task-backend/github.js';
+import { ClickUpTaskBackend } from '../../src/lib/task-backend/clickup.js';
+import { ApiAdapter } from '../../src/lib/task-backend/api-adapter.js';
+import type { SetupConfig } from '../../src/lib/setup-config.js';
+import { makeFakeGitHub, type FakeGitHub } from './github-fake.js';
+import { makeFakeClickUp, type FakeClickUp } from './clickup-fake.js';
+
+/**
+ * #77 — Task rename must NOT duplicate the remote task. Reconciliation joins
+ * local↔remote on the STABLE dcId (the task's `id:` frontmatter), not the
+ * name-derived slug. These tests cover the ledger surgery in isolation and the
+ * end-to-end no-duplicate guarantee for BOTH remote backends.
+ */
+
+// ───────────────────────────── pure ledger primitives ──────────────────────
+
+describe('SyncLedger rename primitives (#77)', () => {
+  let contextRoot: string;
+
+  beforeEach(() => {
+    const raw = join(tmpdir(), `dc-led-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(raw, { recursive: true });
+    contextRoot = realpathSync(raw);
+  });
+
+  afterEach(() => {
+    rmSync(contextRoot, { recursive: true, force: true });
+  });
+
+  it('migrateSlug re-keys the map (preserving dcId/backend/remoteId), sync-state, and queue', () => {
+    const ledger = new SyncLedger(contextRoot);
+    ledger.recordMapping({ slug: 'old-slug', dcId: 'task_A', backend: 'github', remoteId: '7' });
+    ledger.updateTaskSync('old-slug', {
+      last_synced_at: 1234,
+      localHash: 'h1',
+      base_snapshot: { hash: 'h1', body: 'base body' },
+      pendingPush: true,
+    });
+    ledger.enqueue({ id: 'op1', kind: 'push', slug: 'old-slug', ts: 1 });
+
+    ledger.migrateSlug('old-slug', 'new-slug');
+
+    // Map: same identity, new slug, no residue on the old slug.
+    expect(ledger.remoteIdFor('old-slug')).toBeNull();
+    expect(ledger.remoteIdFor('new-slug')).toBe('7');
+    const entry = ledger.entryForDcId('task_A');
+    expect(entry).toMatchObject({ slug: 'new-slug', dcId: 'task_A', backend: 'github', remoteId: '7' });
+    expect(ledger.readMap()).toHaveLength(1);
+
+    // Sync state: history carried over, old key dropped.
+    expect(ledger.taskSync('old-slug')).toBeNull();
+    expect(ledger.taskSync('new-slug')).toMatchObject({
+      last_synced_at: 1234,
+      localHash: 'h1',
+      base_snapshot: { hash: 'h1', body: 'base body' },
+    });
+
+    // Queue: op re-keyed.
+    expect(ledger.readQueue()).toEqual([{ id: 'op1', kind: 'push', slug: 'new-slug', ts: 1 }]);
+  });
+
+  it('migrateSlug is a no-op when the slug is unchanged or unmapped', () => {
+    const ledger = new SyncLedger(contextRoot);
+    ledger.recordMapping({ slug: 'keep', dcId: 'task_K', backend: 'clickup', remoteId: 'cu_1' });
+
+    ledger.migrateSlug('keep', 'keep'); // identical
+    ledger.migrateSlug('ghost', 'somewhere'); // unmapped
+
+    expect(ledger.readMap()).toEqual([
+      { slug: 'keep', dcId: 'task_K', backend: 'clickup', remoteId: 'cu_1' },
+    ]);
+  });
+
+  it('reconcileRenamedTasks migrates a renamed file by dcId and reports the migration', () => {
+    const ledger = new SyncLedger(contextRoot);
+    ledger.recordMapping({ slug: 'calorie-foo', dcId: 'task_X', backend: 'clickup', remoteId: 'cu_9' });
+
+    const migrations = reconcileRenamedTasks(ledger, [{ slug: 'dietpal-foo', dcId: 'task_X' }]);
+
+    expect(migrations).toEqual([{ from: 'calorie-foo', to: 'dietpal-foo' }]);
+    expect(ledger.remoteIdFor('dietpal-foo')).toBe('cu_9');
+    expect(ledger.remoteIdFor('calorie-foo')).toBeNull();
+  });
+
+  it('reconcileRenamedTasks is a no-op when every mapped slug still has a file', () => {
+    const ledger = new SyncLedger(contextRoot);
+    ledger.recordMapping({ slug: 'a', dcId: 'task_A', backend: 'github', remoteId: '1' });
+    ledger.recordMapping({ slug: 'b', dcId: 'task_B', backend: 'github', remoteId: '2' });
+
+    const migrations = reconcileRenamedTasks(ledger, [
+      { slug: 'a', dcId: 'task_A' },
+      { slug: 'b', dcId: 'task_B' },
+    ]);
+
+    expect(migrations).toEqual([]);
+  });
+
+  it('reconcileRenamedTasks leaves a deleted task (stale slug, no matching live dcId) for the deletion reconciler', () => {
+    const ledger = new SyncLedger(contextRoot);
+    ledger.recordMapping({ slug: 'gone', dcId: 'task_G', backend: 'github', remoteId: '3' });
+
+    const migrations = reconcileRenamedTasks(ledger, []); // file deleted entirely
+
+    expect(migrations).toEqual([]);
+    expect(ledger.remoteIdFor('gone')).toBe('3'); // untouched — not a rename
+  });
+
+  it('reconcileRenamedTasks never clobbers an existing mapping (duplicate residue left for --reconcile)', () => {
+    const ledger = new SyncLedger(contextRoot);
+    // Pre-existing corruption from the bug: two entries with the SAME dcId.
+    ledger.recordMapping({ slug: 'old', dcId: 'task_D', backend: 'github', remoteId: '10' });
+    ledger.recordMapping({ slug: 'new', dcId: 'task_D', backend: 'github', remoteId: '11' });
+
+    // The live file lives at the new slug.
+    const migrations = reconcileRenamedTasks(ledger, [{ slug: 'new', dcId: 'task_D' }]);
+
+    expect(migrations).toEqual([]); // 'new' already mapped — do not merge/clobber
+    expect(ledger.readMap()).toHaveLength(2); // residue preserved, nothing lost
+  });
+});
+
+// ───────────────────────────── shared e2e helpers ──────────────────────────
+
+/** Simulate a HAND rename (the issue's scenario): edit `name:`, move the file. */
+function handRename(stateDir: string, oldSlug: string, newSlug: string, newName: string): void {
+  const oldPath = join(stateDir, `${oldSlug}.md`);
+  const raw = readFileSync(oldPath, 'utf-8').replace(/^name:.*$/m, `name: "${newName}"`);
+  writeFileSync(join(stateDir, `${newSlug}.md`), raw, 'utf-8');
+  rmSync(oldPath);
+}
+
+function mdFiles(stateDir: string): string[] {
+  return readdirSync(stateDir).filter((f) => f.endsWith('.md')).sort();
+}
+
+// ───────────────────────────── GitHub end-to-end ───────────────────────────
+
+describe('GitHub: rename never duplicates the remote issue (#77)', () => {
+  const CONFIG: SetupConfig = {
+    platforms: [],
+    packs: [],
+    multiProduct: false,
+    setupVersion: '0.0.0',
+    disableNativeMemory: true,
+    taskBackend: 'github',
+    cloudTaskManagement: true,
+    github: { owner: 'meanllbrl', repo: 'dreamcontext', changelogTarget: 'comments' },
+    people: ['Alice'],
+  };
+
+  let projectRoot: string;
+  let contextRoot: string;
+  let stateDir: string;
+  let fake: FakeGitHub;
+  let backend: GitHubTaskBackend;
+  let localClock: number;
+
+  function makeBackend(): GitHubTaskBackend {
+    const now = () => (localClock += 7);
+    const sleep = async () => { localClock += 1; };
+    const adapter = new ApiAdapter({
+      baseUrl: 'https://api.github.com',
+      authHeaders: () => ({ Authorization: 'Bearer ghp_test' }),
+      fetchImpl: fake.fetchImpl,
+      now,
+      sleep,
+    });
+    return new GitHubTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+  }
+
+  function mapFile(): Array<{ slug: string; dcId: string; backend: string; remoteId: string }> {
+    return JSON.parse(readFileSync(join(stateDir, '.tasks-map.json'), 'utf-8'));
+  }
+
+  beforeEach(() => {
+    delete process.env.DREAMCONTEXT_PERSON;
+    const raw = join(tmpdir(), `dc-ghr-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(raw, { recursive: true });
+    projectRoot = realpathSync(raw);
+    contextRoot = join(projectRoot, '_dream_context');
+    stateDir = join(contextRoot, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    localClock = 1000;
+    fake = makeFakeGitHub();
+    backend = makeBackend();
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('hand-rename → push UPDATES the same issue (no duplicate, identity preserved)', async () => {
+    await backend.create({ name: 'Push One', priority: 'high', variant: 'cli' });
+    await backend.sync('push');
+    expect(fake.issues.size).toBe(1);
+    const before = mapFile()[0];
+
+    handRename(stateDir, 'push-one', 'renamed-task', 'Renamed Task');
+
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    expect(report.created).toBe(0); // NOT created again
+    expect(report.pushed).toBe(1); // updated in place
+    expect(fake.issues.size).toBe(1); // ← the bug: this used to be 2
+
+    const issue = [...fake.issues.values()][0];
+    expect(String(issue.number)).toBe(before.remoteId); // same remote object
+    expect(issue.title).toBe('Renamed Task');
+
+    const map = mapFile();
+    expect(map).toHaveLength(1);
+    expect(map[0]).toMatchObject({ slug: 'renamed-task', dcId: before.dcId, remoteId: before.remoteId });
+    expect(report.warnings.some((w) => w.includes('renamed: push-one → renamed-task'))).toBe(true);
+  });
+
+  it('rename then sync(both) does not resurrect the old mirror', async () => {
+    await backend.create({ name: 'Round Trip', variant: 'cli' });
+    await backend.sync('both');
+
+    handRename(stateDir, 'round-trip', 'round-renamed', 'Round Renamed');
+
+    const report = await backend.sync('both');
+    expect(report.errors).toEqual([]);
+    expect(fake.issues.size).toBe(1);
+    expect(mdFiles(stateDir)).toEqual(['round-renamed.md']); // old mirror not recreated
+    expect(mapFile()).toHaveLength(1);
+  });
+
+  it('backend.rename() (the `tasks rename` path) UPDATES the same issue — no duplicate', async () => {
+    await backend.create({ name: 'Owned', variant: 'cli' });
+    await backend.sync('push');
+    const before = mapFile()[0];
+
+    const newSlug = await backend.rename('owned', 'Owned Renamed');
+    expect(newSlug).toBe('owned-renamed');
+    expect(mdFiles(stateDir)).toEqual(['owned-renamed.md']); // file moved
+    expect(mapFile()[0].slug).toBe('owned-renamed'); // ledger re-keyed eagerly
+
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    expect(report.created).toBe(0);
+    expect(fake.issues.size).toBe(1);
+    expect([...fake.issues.values()][0].title).toBe('Owned Renamed');
+    expect(mapFile()[0]).toMatchObject({ slug: 'owned-renamed', remoteId: before.remoteId });
+  });
+
+  it('backend.rename() rejects a colliding target slug and a name-only change keeps the slug', async () => {
+    await backend.create({ name: 'Alpha', variant: 'cli' });
+    await backend.create({ name: 'Beta', variant: 'cli' });
+
+    await expect(backend.rename('alpha', 'Beta')).rejects.toThrow(/already exists/i);
+
+    // Name-only tweak (slug stays 'alpha') returns the same slug, no move.
+    const same = await backend.rename('alpha', 'ALPHA!');
+    expect(same).toBe('alpha');
+  });
+});
+
+// ───────────────────────────── ClickUp end-to-end ──────────────────────────
+
+describe('ClickUp: rename never duplicates the remote task (#77)', () => {
+  const CONFIG: SetupConfig = {
+    platforms: [],
+    packs: [],
+    multiProduct: false,
+    setupVersion: '0.0.0',
+    disableNativeMemory: true,
+    taskBackend: 'clickup',
+    cloudTaskManagement: true,
+    clickup: { teamId: 'team1', spaceId: 'space1', listId: 'list1', changelogTarget: 'comments' },
+    people: ['Alice'],
+  };
+
+  let projectRoot: string;
+  let contextRoot: string;
+  let stateDir: string;
+  let fake: FakeClickUp;
+  let backend: ClickUpTaskBackend;
+  let localClock: number;
+
+  function makeBackend(): ClickUpTaskBackend {
+    const now = () => (localClock += 7);
+    const sleep = async () => { localClock += 1; };
+    const adapter = new ApiAdapter({
+      baseUrl: 'https://api.clickup.com/api/v2',
+      authHeaders: () => ({ Authorization: 'pk_test' }),
+      fetchImpl: fake.fetchImpl,
+      now,
+      sleep,
+    });
+    return new ClickUpTaskBackend(contextRoot, CONFIG, { adapter, now, sleep });
+  }
+
+  function mapFile(): Array<{ slug: string; dcId: string; backend: string; remoteId: string }> {
+    return JSON.parse(readFileSync(join(stateDir, '.tasks-map.json'), 'utf-8'));
+  }
+
+  beforeEach(() => {
+    delete process.env.DREAMCONTEXT_PERSON;
+    const raw = join(tmpdir(), `dc-cur-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(raw, { recursive: true });
+    projectRoot = realpathSync(raw);
+    contextRoot = join(projectRoot, '_dream_context');
+    stateDir = join(contextRoot, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    localClock = 1000;
+    fake = makeFakeClickUp();
+    backend = makeBackend();
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('hand-rename → push UPDATES the same task (no duplicate, identity preserved)', async () => {
+    await backend.create({ name: 'Push One', priority: 'high', variant: 'cli' });
+    await backend.sync('push');
+    expect(fake.tasks.size).toBe(1);
+    const before = mapFile()[0];
+
+    handRename(stateDir, 'push-one', 'renamed-task', 'Renamed Task');
+
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    expect(report.created).toBe(0); // NOT created again
+    expect(report.pushed).toBe(1); // updated in place
+    expect(fake.tasks.size).toBe(1); // ← the bug: this used to be 2
+
+    const remote = [...fake.tasks.values()][0];
+    expect(remote.id).toBe(before.remoteId); // same remote object
+    expect(remote.name).toBe('Renamed Task');
+
+    const map = mapFile();
+    expect(map).toHaveLength(1);
+    expect(map[0]).toMatchObject({ slug: 'renamed-task', dcId: before.dcId, remoteId: before.remoteId });
+    expect(report.warnings.some((w) => w.includes('renamed: push-one → renamed-task'))).toBe(true);
+  });
+
+  it('rename then sync(both) does not resurrect the old mirror', async () => {
+    await backend.create({ name: 'Round Trip', variant: 'cli' });
+    await backend.sync('both');
+
+    handRename(stateDir, 'round-trip', 'round-renamed', 'Round Renamed');
+
+    const report = await backend.sync('both');
+    expect(report.errors).toEqual([]);
+    expect(fake.tasks.size).toBe(1);
+    expect(mdFiles(stateDir)).toEqual(['round-renamed.md']); // old mirror not recreated
+    expect(mapFile()).toHaveLength(1);
+  });
+
+  it('backend.rename() (the `tasks rename` path) UPDATES the same task — no duplicate', async () => {
+    await backend.create({ name: 'Owned', variant: 'cli' });
+    await backend.sync('push');
+    const before = mapFile()[0];
+
+    const newSlug = await backend.rename('owned', 'Owned Renamed');
+    expect(newSlug).toBe('owned-renamed');
+    expect(mdFiles(stateDir)).toEqual(['owned-renamed.md']); // file moved
+    expect(mapFile()[0].slug).toBe('owned-renamed'); // ledger re-keyed eagerly
+
+    const report = await backend.sync('push');
+    expect(report.errors).toEqual([]);
+    expect(report.created).toBe(0);
+    expect(fake.tasks.size).toBe(1);
+    expect([...fake.tasks.values()][0].name).toBe('Owned Renamed');
+    expect(mapFile()[0]).toMatchObject({ slug: 'owned-renamed', remoteId: before.remoteId });
+  });
+});


### PR DESCRIPTION
Fixes #77.

## Problem
Renaming a task changes its **name-derived slug**. Sync reconciliation joined
local↔remote by that slug, so a renamed task was treated as brand-new and
**duplicated** on the remote — orphaning the original issue/task and leaving two
`.tasks-map.json` entries with the same `dcId`. The stable `dcId` already lived
in both the task frontmatter (`id:`) and the id-map, but was never used as the
join key. This affected **both** the ClickUp and GitHub backends (shared engine).

A second, latent hazard: after a local rename, pull's "vanished mirror" branch
could **re-create the old file** if the renamed task had also changed remotely.

## Fix
- **`sync-state.ts`** — join on the stable `dcId`:
  - `entryForDcId(dcId)` + `migrateSlug(old, new)` (re-keys map + sync-state +
    queued WAL ops, preserving `dcId`/`backend`/`remoteId` and the base snapshot).
  - `reconcileRenamedTasks(ledger, liveTasks)` — provider-agnostic pre-pass that
    heals a renamed file's mapping by `dcId`. Non-destructive and idempotent:
    deletions are left alone, and an already-mapped target is never clobbered
    (duplicate residue from old corruption is left for manual `--reconcile`).
- **`clickup.ts` / `github.ts`** — run `reconcileRenamedTasks()` **first** in
  `sync()`, before pull+push, so push UPDATEs the same remote object (no
  duplicate) and pull resolves it by the live slug (no resurrected mirror).
  A per-task `dcId` fallback in `pushTask()` is the safety net, so the CREATE
  branch is only ever taken for a genuinely new, never-synced task.
- **`TaskBackend.rename()`** (new) — `LocalTaskBackend` rewrites the name +
  moves the file; the remote backends override to migrate the ledger. The new
  `dreamcontext tasks rename <name> <new-name>` command routes through it, so it
  never touches the filesystem directly (respects the command-layer boundary
  test). Use it instead of hand-editing `name:` + renaming the file.

## Testing
- New `tests/unit/sync-rename.test.ts` (12 tests): ledger primitives +
  end-to-end **no-duplicate** proofs for **both** ClickUp and GitHub (hand-edit
  rename, `sync(both)` no-resurrection, and the `rename()` command path).
- All sync/backend/CLI-boundary suites green (138 tests): `sync-rename`,
  `task-backend`, `github-push/pull/delete`, `clickup-push/pull/delete`,
  `github-map`, `clickup-lock`.
- Real-repo audit of the live id-map: 49 GitHub-mapped tasks, **0 duplicate
  dcIds, 0 stale slugs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also fixes #78 — assignee reconcile (`tasks sync --reconcile`)

Filed as a sibling sync-engine bug; folded in here because it lives in the same
files. **Investigation first changed the diagnosis:** the forward assignee
pull-back already works (remote assignees → `person:` tags, merged LWW; covered
in `clickup-pull`/`github-pull`, and reproduced green against the issue's exact
steps). #78's stated root cause — "`base_snapshot` stores only `{hash, body}`
(the markdown body)" — is **inaccurate**: `base_snapshot.body` is the FULL file
and the merge engine already diffs frontmatter assignees.

**The real gap:** the delta pull is **watermark-gated**, so a remote-side
assignee change made *below* the watermark is never re-examined and accumulated
drift (members assigned in the ClickUp UI before a sync) never self-heals. That
is the "9 assigned tasks with no `person:` tag" the agent observed.

### Fix
- **`merge.ts`** — pure `planAssigneeHeal(local, base, remote, pendingPush)`:
  heal ONLY when the remote moved and local did not (skip in-sync / pending-push
  / two-sided divergence), so a heal never clobbers an unpushed local change.
- **`clickup.ts` / `github.ts`** — `detectAssigneeDrift()` (read-only, full
  remote fetch) + `reconcileAssignees()` (adopt the remote assignee set into
  `person:` tags, re-baseline the ledger, journal the change). Idempotent.
- **`sync(direction, { reconcile })`** runs the heal LAST (after push settles
  local-first changes). Opt-in — costs a full remote fetch.
- **CLI** — `tasks sync --reconcile` (surfaces `reconciled N`) and
  `tasks doctor --remote` (read-only drift report; default `tasks doctor` stays
  **local-only by design**, so the network probe is opt-in).

### Testing
- New `tests/unit/assignee-reconcile.test.ts` (10 tests): pure decision table +
  **both backends** — a normal pull MISSES below-watermark drift, `--reconcile`
  heals it **idempotently**, `detectAssigneeDrift` is read-only, and a pending
  local assignment is **never clobbered**.
- Full task-backend/sync/CLI suites green; CLI builds; typecheck clean (only the
  pre-existing unrelated `transcript.ts` errors remain).

Fixes #78.
