### PR TITLE
fix(tests): raise recall-capture-stress timeouts 30s→90s (#74)

### DIFF
--- a/tests/unit/recall-capture-stress.test.ts
+++ b/tests/unit/recall-capture-stress.test.ts
@@ -199,7 +199,7 @@ describe('continuous-capture precision stress (STEP 1 measurement)', () => {
     // cannot and should not "fix" a real-doc-vs-real-doc reorder; the named
     // risk (captures out-ranking knowledge) is fully neutralised.
     expect(dropR3).toBeLessThanOrEqual(3.5);
-  }, 30_000);
+  }, 90_000);
 
   it('GUARD PROOF: a capture flood never knocks a real gold target out of the top-3', () => {
     // The named precision-decay risk is "mediocre auto-captures crowd real
@@ -250,5 +250,5 @@ describe('continuous-capture precision stress (STEP 1 measurement)', () => {
     // Load-bearing guarantee: at the worst-case flood, zero real top-3 knowledge
     // is crowded out by captures.
     expect(trueDisplacementsAt(200)).toEqual([]);
-  }, 30_000);
+  }, 90_000);
 });


### PR DESCRIPTION
## Summary

The two stress `it()` blocks in `tests/unit/recall-capture-stress.test.ts` carried inline **30s** timeouts. The test logic is correct, but on a loaded dev machine the BM25 capture-flood measurement takes ~50s and trips the 30s timeout — a spurious failure unrelated to any recall-engine change (the branch that surfaced it touches zero recall source).

Bump both inline timeouts to **90s** so a normally-loaded machine has comfortable margin. No other changes — test semantics are untouched.

## Changes
- `recall-capture-stress.test.ts`: `}, 30_000)` → `}, 90_000)` on both stress blocks (lines ~202 and ~253).

## Verification
- All 3 test **assertions** pass. (On a heavily-loaded machine an additional vitest worker-RPC heartbeat warning can appear independent of the per-test timeout; it does not occur on a normally-loaded machine where the run finishes in ~50s.)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)