### PR TITLE
fix(dashboard): distinct label for GitHub discovered-repo picker (#76)

### DIFF
--- a/dashboard/src/context/I18nContext.tsx
+++ b/dashboard/src/context/I18nContext.tsx
@@ -117,6 +117,7 @@ const translations: Record<string, Record<string, string>> = {
     'settings.cloud_tasks.github.hint': 'Tasks sync to a GitHub repository\'s Issues; a gitignored local mirror keeps recall, snapshots, and the dashboard working unchanged.',
     'settings.cloud_tasks.github.owner': 'Owner',
     'settings.cloud_tasks.github.repo': 'Repository',
+    'settings.cloud_tasks.github.repo_picker': 'Discovered repository',
     'settings.cloud_tasks.github.pick': 'Pick the repository to sync to…',
     'settings.cloud_tasks.github.search': 'Search repositories…',
     'settings.cloud_tasks.github.token_hint': 'The token is saved to a gitignored secrets file (never in this config). You can also set it from the CLI with `dreamcontext config github-token`. Needs `repo` scope (classic) or Issues read/write + Metadata (fine-grained).',

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -534,7 +534,7 @@ export function SettingsPage() {
                 <>
                   {(containers ?? []).length > 0 && (
                     <div className="settings-field-row">
-                      <label>{t('settings.cloud_tasks.github.repo')}</label>
+                      <label>{t('settings.cloud_tasks.github.repo_picker')}</label>
                       <SearchableSelect
                         value={githubOwner && githubRepo ? `${githubOwner}/${githubRepo}` : null}
                         options={(containers ?? []).map(c => ({ value: c.path, label: c.path }))}


### PR DESCRIPTION
## Summary

The GitHub task-backend section of dashboard Settings showed **two fields both labeled "Repository"** — the discovered-repo picker (`SearchableSelect` over detected containers) and the manual repo-name input shared the `settings.cloud_tasks.github.repo` i18n key, so users couldn't tell them apart.

Add a distinct `settings.cloud_tasks.github.repo_picker` key (**"Discovered repository"**) and point the picker's label at it. The manual input keeps **"Repository"**.

## Changes
- `I18nContext.tsx`: add `settings.cloud_tasks.github.repo_picker` = "Discovered repository".
- `SettingsPage.tsx`: discovered-repo picker label now uses `…github.repo_picker` instead of `…github.repo`.

## Verification
- `tsc -b` (dashboard) green.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)