### PR TITLE
feat(desktop): readable in-app Agent terminal + prerequisite installer

### DIFF
--- a/_dream_context/core/CHANGELOG.json
+++ b/_dream_context/core/CHANGELOG.json
@@ -1,6 +1,32 @@
 [
   {
     "date": "2026-06-29",
+    "type": "feat",
+    "scope": "sleepy",
+    "description": "Add in-app prerequisite detection and installation to the Agent screen. GET /api/agent/capabilities now additionally reports claudeCli, nodePty, and npm availability, each probed via $SHELL -ilc so the detection path matches the PTY spawn's PATH (finds claude in ~/.local/bin, etc.). New POST /api/agent/install {claude|pty} and GET /api/agent/install/status endpoints mirror the Sleepy capture-run Map+poll pattern: the claude install target runs npm i -g @anthropic-ai/claude-code; the pty target installs node-pty into the CLI package directory, then chmods the spawn-helper and busts the probe cache. A Setup panel on the Agent screen renders any missing prerequisite with a one-click install button and re-checks on success. Start-agent is now gated on both node-pty and claude being present. All install endpoints are desktop-gated, loopback-only, and use a closed target whitelist.",
+    "breaking": false,
+    "summary": "In-app prerequisite installer: capabilities endpoint reports claudeCli/nodePty/npm; one-click install panel; Start-agent gated on both",
+    "references": [
+      "commit:351d14e",
+      "file:src/server/routes/agent-terminal.ts",
+      "file:src/server/index.ts",
+      "file:dashboard/src/components/sleepy/AgentSurface.tsx"
+    ]
+  },
+  {
+    "date": "2026-06-29",
+    "type": "fix",
+    "scope": "sleepy",
+    "description": "Fix unreadable Claude Code output in the embedded in-app Agent terminal on both light and dark themes. readXtermTheme() in AgentSurface.tsx was mapping ANSI black/white/brightBlack directly to design tokens, which inverted luminance in light mode and made dim grays too light in dark mode; minimumContrastRatio was set to 1, disabling xterm's contrast safety-net. Claude's TUI blocks (ANSI 7/8 background + default foreground) collapsed to same-luminance-on-same-luminance and were unreadable. Fix: set minimumContrastRatio to 4.5 and replaced the design-token mapping with a conventional per-theme grayscale ANSI ramp so ANSI dark/light colors follow each theme's luminance expectations correctly.",
+    "breaking": false,
+    "summary": "Fix Agent terminal unreadable text in both themes (minimumContrastRatio 4.5 + conventional ANSI grayscale ramp)",
+    "references": [
+      "commit:351d14e",
+      "file:dashboard/src/components/sleepy/AgentSurface.tsx"
+    ]
+  },
+  {
+    "date": "2026-06-29",
     "type": "chore",
     "scope": "release",
     "description": "Released v0.10.0 to both distribution channels. npm publish of 0.10.0 is live on the registry. The GitHub desktop-release CI workflow (macos-14, .github/workflows/desktop-release.yml) built and published the v0.10.0 GitHub Release with the ad-hoc deep-signed dreamcontext-beta_0.10.0_aarch64.app.tar.gz (29.3 MB) and accompanying .sha256 artifact. The workflow derives the app version from the git tag (VERSION=tag minus v prefix), so tauri.conf.json must stay in sync for the internal .app version to match. RELEASES.json v0.10.0 status set to released, date 2026-06-29. v0.11.0 opened as the new active planning milestone (desktop stale-dist fix, task-derived roadmap, excalidraw card-overflow fix, web read-only public surface).",

--- a/_dream_context/core/features/in-app-agent-terminal.md
+++ b/_dream_context/core/features/in-app-agent-terminal.md
@@ -1,0 +1,95 @@
+---
+id: "feat_nM4EnT8k"
+status: "in_review"
+created: "2026-06-28"
+updated: "2026-06-29"
+released_version: null
+tags:
+  - topic:desktop
+  - topic:agents
+  - layer:frontend
+  - layer:backend
+related_tasks:
+  - feat-desktop-in-app-conversational-agent-surface-bm25-search-claude-chat-embedded-terminal
+  - agent-terminal-readability-and-prereq-installer
+---
+
+## Why
+
+Developers using the dreamcontext desktop app need to run Claude Code interactively without leaving the app or opening a separate terminal window. The in-app Agent terminal embeds a full Claude Code TUI session directly in the Sleepy/Agent screen — full session parity (slash menu, skills, sub-agents, reasoning effort, real permission prompts) because it IS the client. In-app prerequisite detection and installation (node-pty, claude CLI) eliminate setup friction so the feature works out of the box.
+
+## User Stories
+
+- [x] As a developer, I can run Claude Code in an embedded terminal inside the dreamcontext desktop app so I do not need a separate terminal window.
+- [x] As a developer, I can navigate away from the Agent tab and return without losing my Claude Code session.
+- [x] As a developer, I can opt into bypassing Claude Code's permission prompts so I can let it operate autonomously (with a standing warning shown while armed).
+- [x] As a developer, I can split the view into side-by-side agent sessions to run parallel tasks.
+- [x] As a developer, I can read Claude Code's output clearly in both light and dark themes without eyestrain or same-luminance-on-same-luminance blocks.
+- [x] As a developer, I can install missing prerequisites (Claude CLI, node-pty) from within the app with one click so I never need to open a terminal just to unblock the Agent screen.
+- [ ] As a developer, I can use a read-only plan mode that shows Claude's intent without allowing file writes.
+
+## Acceptance Criteria
+
+- [x] WS bridge (`/api/agent/terminal`) spawns `$SHELL -ilc 'exec claude [--dangerously-skip-permissions]'` via node-pty; desktop-only (`DREAMCONTEXT_DESKTOP=1` gate) and loopback-only (strict `remoteAddress` check).
+- [x] Session persists via `display:none` hoist of `AgentSurface` above `App.tsx` page switch; torn down only on explicit Close/Restart or app quit.
+- [x] `AgentSurface.tsx` renders xterm.js with WebGL addon (`@xterm/addon-webgl`); automatic fallback to canvas on context-loss.
+- [x] Sometype Mono font loaded via `FontFaceSet.load()` and fully committed before `term.open()` and WebGL addon attachment (prevents glyph-atlas wrong-width on font-load-after-open).
+- [x] `bypassPermissions` default OFF; orange warning chip shown in the UI while armed.
+- [x] Drag-to-split: tab drag onto another tab or terminal body creates side-by-side layout; `⌘D` and `⊟` button also split.
+- [x] `readXtermTheme()` uses `minimumContrastRatio: 4.5` + per-theme conventional grayscale ANSI ramp (slot 0=darkest, slot 15=lightest); readable in both light and dark mode regardless of Claude's ANSI block-fill choices.
+- [x] `GET /api/agent/capabilities` returns `{ desktop, embeddedTerminal, openTerminal, nodePty, claudeCli, npm }`; `nodePty`/`claudeCli`/`npm` probed via `$SHELL -ilc` (interactive login shell, matching PTY spawn PATH).
+- [x] `POST /api/agent/install { target: 'claude'|'pty' }` starts a background install tracked in `installRuns` Map; `GET /api/agent/install/status?id=` polls `{ state, output }`.
+- [x] `pty` install target: `npm install node-pty@^1.1.0 --no-save` into CLI package root (walk up from `process.argv[1]`) + `ensurePtyHelperExecutable()` + bust memoized `ptyAvailable` cache.
+- [x] `claude` install target: `npm install -g @anthropic-ai/claude-code` in login shell.
+- [x] `Prereqs` component in `AgentSurface.tsx` lists missing prerequisites with one-click Install + live log tail + auto re-check on completion.
+- [x] Start-agent button gated on BOTH `embeddedTerminal` (node-pty present) AND `claudeCli` (claude on PATH); npm-absent shows guidance instead of failing silently.
+- [x] Install routes: desktop-gated, loopback-only, bad target → 400; registered in `src/server/index.ts` in `VAULT_AGNOSTIC_PREFIXES`.
+- [ ] Read-only plan mode (`--permission-mode plan`) available in the UI.
+
+## Constraints & Decisions
+<!-- LIFO: newest decision at top -->
+
+- **[2026-06-29] minimumContrastRatio 4.5 over palette fidelity.** Embedding someone else's TUI (Claude Code) requires yielding colour control to xterm's contrast engine. Setting `minimumContrastRatio: 1` "to keep the exact palette" causes unreadable block fills in both themes. Conventional grayscale ANSI ramp (0=darkest, 15=lightest) is the correct baseline; brand tokens belong in the non-ANSI theme colours only.
+- **[2026-06-29] Prerequisite installer targets are a CLOSED whitelist.** `claude` and `pty` only; any other value → 400. Desktop-gated AND loopback-only. Package names are internal literals, never user input (no injection).
+- **[2026-06-29] node-pty installed into CLI package root.** Walking up from `process.argv[1]` to find the nearest `package.json` ensures `import('node-pty')` resolves correctly from the bundled dist. Installing globally would not be visible to the server's module resolution.
+- **[2026-06-29] Capabilities probed via -ilc (interactive login shell).** `claude` is commonly added to PATH in `~/.zshrc` (e.g. `~/.local/bin`), which a non-interactive `-lc` shell does NOT source. Using `-ilc` for the probe matches the PTY spawn exactly so detection can never disagree with the real spawn.
+- **[2026-06-28] bypassPermissions opt-in, default OFF.** The terminal runs real `claude` with full file-write capability. The bypass is powerful and must be explicitly armed by the user.
+- **[2026-06-28] Session persistence via display:none, not re-mount.** `AgentSurface` must live above the `App.tsx` page switch; unmounting kills the PTY and the user loses their live session.
+- **[2026-06-28] Sometype Mono load-before-open.** The WebGL glyph atlas is committed at `term.open()` time; loading the font after results in incorrect cell metrics. `FontFaceSet.load()` + await before `term.open()` is the required sequence.
+
+## Technical Details
+
+Architecture, key files, and dev-workflow notes (including the npm-linked dev footgun with node-pty) are in `_dream_context/knowledge/desktop-beta-tauri-multivault.md` §"In-app Agent Terminal". Summary of key files:
+
+- `src/server/routes/agent-terminal.ts` — all agent routes: WS bridge + node-pty spawn, `GET /api/agent/capabilities`, `POST /api/agent/install`, `GET /api/agent/install/status`, `POST /api/agent/open-terminal` (osascript fallback).
+- `src/server/index.ts` — `attachAgentTerminal(server)` wired at bottom; install routes in `VAULT_AGNOSTIC_PREFIXES`.
+- `dashboard/src/components/sleepy/AgentSurface.tsx` — xterm.js, WebGL addon, font load, `readXtermTheme()`, `Prereqs` component, drag-to-split logic.
+- `dashboard/src/components/sleepy/AgentTerminal.css` — stylesheet (filename retained).
+- `dashboard/src/pages/SleepyPage.tsx` — Agent tab; `<AgentSurface />` hoisted above `App.tsx` page switch.
+
+## Notes
+
+- Desktop-only feature; never ships in the npm package. Gated on `DREAMCONTEXT_DESKTOP=1` (injected by the Rust shell).
+- `ensurePtyHelperExecutable()` runs at startup to restore `+x` on the prebuilt spawn-helper (tarball strips execute bit → `posix_spawnp failed`); idempotent.
+- Plan mode (`--permission-mode plan`) is always available via the external-terminal fallback (`POST /api/agent/open-terminal`); the in-app embedded plan mode is the remaining open AC.
+
+## Changelog
+<!-- LIFO: newest entry at top -->
+
+### 2026-06-29 - Readability fix + prerequisite installer shipped (commit 351d14e)
+- `readXtermTheme()` rewritten: `minimumContrastRatio: 4.5` + per-theme ANSI grayscale ramp — readable in both light and dark mode.
+- `GET /api/agent/capabilities` extended: `claudeCli`, `nodePty`, `npm` fields probed via `$SHELL -ilc`.
+- `POST /api/agent/install` + `GET /api/agent/install/status` — in-app prereq installer (Sleepy capture-run pattern).
+- `Prereqs` component in `AgentSurface.tsx` — setup panel with one-click install + live log tail + auto re-check.
+- Start-agent gated on BOTH node-pty AND claude CLI; npm-absent guidance shown.
+- Component renamed `AgentTerminal.tsx` → `AgentSurface.tsx`.
+- Status: in_review.
+
+### 2026-06-28 - Initial embedded terminal shipped
+- Full PTY terminal embedded in Sleepy/Agent screen: xterm.js + WebGL + node-pty WS bridge.
+- Session persistence via `display:none` hoist above `App.tsx` page switch.
+- `bypassPermissions` opt-in; drag-to-split; WebGL renderer + Sometype Mono font-load-before-open.
+- Status: in_progress → in_review (shipped; pending readability + prereq installer).
+
+### 2026-06-29 - Created
+- Feature PRD created.

--- a/_dream_context/knowledge/desktop-beta-tauri-multivault.md
+++ b/_dream_context/knowledge/desktop-beta-tauri-multivault.md
@@ -15,13 +15,14 @@ description: >-
   PanelEnabled opt-in default false; Learn/Ask/Sleep mode toggle; Sonnet enrichment
   with Markdown rendering; interactive-login-shell claude PATH fix; tracked
   enrichment status UI; dead-vault filtering; focus/blur UX), the in-app Agent
-  terminal (xterm.js + @xterm/addon-webgl + node-pty WS bridge; session persistence
-  via display:none hoist above App.tsx page switch; bypassPermissions opt-in;
-  drag-to-split; desktop-only DREAMCONTEXT_DESKTOP gate; dev-workflow note: only
+  terminal — AgentSurface.tsx (xterm.js + @xterm/addon-webgl + node-pty WS bridge;
+  session persistence via display:none hoist; bypassPermissions opt-in; drag-to-split;
+  readability fix: minimumContrastRatio 4.5 + per-theme ANSI ramp; in-app prereq
+  installer: GET /api/agent/capabilities + POST /api/agent/install; dev-workflow: only
   Rust/lib.rs changes need tauri build, dashboard changes just need npm run build +
-  app relaunch), find_global_cli -ilc fix SHIPPED v0.10.0 (empirical note: dev
-  machine had both -lc and -ilc resolve nvm CLI because global is npm-linked to repo,
-  so all three resolution paths pointed at same fresh dist), the Launcher per-project
+  app relaunch), find_global_cli -ilc fix SHIPPED v0.10.0 (note: global was a
+  separate installed copy until this session re-ran npm link; see dev footgun note),
+  the Launcher per-project
   status indicator (green/yellow/red, upgrade-vs-update distinction), the
   content-scoped drift nag, the ensure-dashboard app-installed auto-open suppression,
   the interactive federation graph (react-force-graph-2d, read-only violet edges,
@@ -229,16 +230,15 @@ ad-hoc signing already satisfies Apple Silicon's must-be-signed rule). Two parts
    `~/.zshrc` so nvm/mise/volta-managed CLIs are visible to the app even when
    launched from Finder or Spotlight. This fix shipped via `tauri build` +
    `dreamcontext app install` in v0.10.0.
-   **Empirical nuance (v0.10.0 dev machine)**: On the development machine BOTH
-   `-lc` and `-ilc` resolved the nvm `dreamcontext`, and the global CLI is
-   `npm link`-ed directly to the repo (`<nvm>/bin/dreamcontext →
-   ../lib/node_modules/dreamcontext/dist/index.js`). As a result all three CLI
-   resolution paths — `DREAMCONTEXT_CLI` override (set via launchctl to
-   `dist/index.js`), the global (npm-linked to the same `dist/`), and the
-   freshly-rebuilt bundled fallback — pointed at the same fresh dist during
-   testing. The stale-dist symptom was therefore NOT reproducible on the dev
-   machine; it manifests on user machines where the global CLI is a separate
-   installed copy that hasn't been updated yet.
+   **Empirical nuance (v0.10.0 dev machine — corrected 2026-06-29)**: At the time
+   of the v0.10.0 release the dev machine's global CLI was a **separate installed
+   copy** (`<nvm>/lib/node_modules/dreamcontext` — a real directory, not a symlink),
+   not `npm link`-ed to the repo. `npm link` was re-run in this session to restore
+   the linked-repo dev setup. Once re-linked, all three resolution paths —
+   `DREAMCONTEXT_CLI` override (set via launchctl to `dist/index.js`), the global
+   (npm-linked to the same `dist/`), and the freshly-rebuilt bundled fallback —
+   point at the same fresh dist. The stale-dist symptom (app serving an older dist)
+   manifests on user machines with a separately installed, stale global CLI.
    **Verified on dev**: a launched `.app` spawns
    `node <nvm>/bin/dreamcontext dashboard …` (the GLOBAL CLI), so server /
    dashboard / route / all `dist/` logic stays fresh via the existing CLI
@@ -638,14 +638,17 @@ A full interactive Claude Code terminal embedded in the Sleepy page of the dashb
 ### Architecture
 
 ```
-GET /api/agent/capabilities  →  { available: true }  (DREAMCONTEXT_DESKTOP gate)
-GET /api/agent/capabilities  →  { available: false } (npm/browser build)
+GET /api/agent/capabilities  →  { desktop, embeddedTerminal, openTerminal, nodePty, claudeCli, npm }
+  (DREAMCONTEXT_DESKTOP gate; nodePty/claudeCli/npm probed via $SHELL -ilc for PATH parity with PTY)
+
+POST /api/agent/install { target: 'claude'|'pty' }  →  { ok, runId }
+GET  /api/agent/install/status?id=<runId>           →  { state, output }
 
 WS /api/agent/terminal?vault=<name>&bypass=<bool>
   ← loopback-only (strict remoteAddress check)
   → node-pty: $SHELL -ilc 'exec claude [--dangerously-skip-permissions]'
        cwd = vault project root
-  ← AgentTerminal.tsx (xterm.js + @xterm/addon-webgl + @xterm/addon-fit)
+  ← AgentSurface.tsx (xterm.js + @xterm/addon-webgl + @xterm/addon-fit)
 ```
 
 ### Key decisions
@@ -656,15 +659,19 @@ WS /api/agent/terminal?vault=<name>&bypass=<bool>
 
 **bypassPermissions (default OFF):** The terminal runs real `claude` with full file-write capability. The bypass flag is opt-in; when armed, a standing orange warning chip is shown and the WS query param `bypass=true` passes `--dangerously-skip-permissions` to the claude spawn. Read-only Chat (Phase 3, `--permission-mode plan`) is always available and unaffected.
 
+**Readability fix — minimumContrastRatio 4.5 + per-theme ANSI ramp:** `readXtermTheme()` originally mapped the 16 ANSI slots straight to design tokens, which inverted luminance in light mode (ANSI black→light background colour, ANSI white→dark foreground colour) and made dim grays too light in dark mode. Combined with `minimumContrastRatio: 1` (contrast net deliberately OFF "to keep the palette exact"), Claude's TUI blocks that pair a default foreground with an ANSI 7/8 background fill collapsed to same-luminance-on-same-luminance → unreadable in both themes. Fix: `minimumContrastRatio: 4.5` (xterm auto-lifts any too-low-contrast foreground — mechanism-independent guarantee) + a conventional per-theme grayscale ANSI ramp (slot 0=darkest…slot 15=lightest, tuned per theme so block fills blend). Lesson: in an embedded TUI, readability > exact brand-colour fidelity; never set `minimumContrastRatio` to 1 when hosting ANSI output you don't control.
+
+**In-app prerequisite installer:** `GET /api/agent/capabilities` now reports `claudeCli`, `nodePty`, and `npm`, each probed via `$SHELL -ilc` matching the PTY spawn's PATH (`claude` commonly lives in `~/.local/bin` sourced only by `~/.zshrc`; a non-interactive `-lc` shell won't source it). `POST /api/agent/install { target: 'claude'|'pty' }` + `GET /api/agent/install/status?id=` mirror the Sleepy capture-run pattern: in-memory `installRuns` Map, 10-min TTL prune, 5-min watchdog, login-shell spawn. Targets: `claude` → `npm install -g @anthropic-ai/claude-code`; `pty` → `npm install node-pty@^1.1.0 --no-save` into the CLI's own package root (nearest ancestor `package.json` walking up from `process.argv[1]`, so node-pty resolves from the bundled dist exactly as `import('node-pty')` does), then `ensurePtyHelperExecutable()` (`chmod +x` all prebuilt spawn-helpers) and bust the memoized `ptyAvailable` cache so the next capabilities check reports ready without a relaunch. `AgentSurface.tsx` `Prereqs` component lists missing prerequisites with one-click Install + live log tail + auto re-check; Start-agent gated on BOTH `embeddedTerminal` AND `claudeCli`. Routes in `src/server/routes/agent-terminal.ts`, registered in `src/server/index.ts` and added to `VAULT_AGNOSTIC_PREFIXES`. Desktop-gated, loopback-only, closed target whitelist (bad target → 400).
+
 **Drag-to-split:** Dragging one agent tab onto another (or onto the terminal body) creates a side-by-side split layout. The drag-over handler gates `preventDefault()` on `dataTransfer.types` (available during dragover), not on React state (not settled on first hover). `⌘D` and the `⊟` button also split.
 
 ### Key files
 
-- `src/server/routes/agent-terminal.ts` — `attachAgentTerminal(server)`: WS upgrade + node-pty spawn; `GET /api/agent/capabilities`; `POST /api/agent/open-terminal` (osascript fallback for external terminal).
-- `src/server/index.ts` — `attachAgentTerminal(server)` wired at bottom.
-- `dashboard/src/components/sleepy/AgentTerminal.tsx` — xterm.js + `@xterm/addon-webgl` + `@xterm/addon-fit`; `readXtermTheme()` maps design tokens to xterm theme; dynamic Sometype Mono font load before `term.open()`; drag-to-split logic.
-- `dashboard/src/components/sleepy/AgentTerminal.css`.
-- `dashboard/src/pages/SleepyPage.tsx` — `mode: 'search' | 'ask' | 'agent'` tabs; `<AgentTerminal />` rendered in agent mode. **AgentTerminal hoisted above `App.tsx` page switch.**
+- `src/server/routes/agent-terminal.ts` — `attachAgentTerminal(server)`: WS upgrade + node-pty spawn; `GET /api/agent/capabilities` (now includes `claudeCli`/`nodePty`/`npm`); `POST /api/agent/install` / `GET /api/agent/install/status` (in-app prereq installer); `POST /api/agent/open-terminal` (osascript fallback for external terminal).
+- `src/server/index.ts` — `attachAgentTerminal(server)` wired at bottom; install routes registered in `VAULT_AGNOSTIC_PREFIXES`.
+- `dashboard/src/components/sleepy/AgentSurface.tsx` — xterm.js + `@xterm/addon-webgl` + `@xterm/addon-fit`; `readXtermTheme()` with `minimumContrastRatio: 4.5` + per-theme ANSI grayscale ramp; `Prereqs` component (Setup panel); dynamic Sometype Mono font load before `term.open()`; drag-to-split logic.
+- `dashboard/src/components/sleepy/AgentTerminal.css` (stylesheet; filename retained as-is).
+- `dashboard/src/pages/SleepyPage.tsx` — `mode: 'search' | 'ask' | 'agent'` tabs; `<AgentSurface />` rendered in agent mode. **AgentSurface hoisted above `App.tsx` page switch.**
 
 ### Desktop dev workflow note
 
@@ -678,7 +685,9 @@ Do NOT use `⌘R` (refresh): WKWebView's document cache retains the OLD bundle a
 
 **Last verified: 2026-06-29 (v0.10.0).** Version rename/delete dashboard feature was built (JS-only change), built via `npm run build`, and tested by ⌘Q + reopen — no Tauri rebuild required and the new routes were live immediately. The `-ilc` fix was baked in simultaneously via `tauri build` + `dreamcontext app install` as part of the v0.10.0 release.
 
-**Dev-machine empirical note (2026-06-29):** On the development machine the `DREAMCONTEXT_CLI` launchctl override was set to the repo's `dist/index.js`, AND the global CLI was `npm link`-ed to the same repo. So all three resolution paths (`DREAMCONTEXT_CLI` override, global, bundled fallback) pointed at the same fresh dist. The stale-dist symptom (app serving an older dist than expected) manifests on user machines with a separately installed/stale global CLI — not reproducible in the linked-repo dev setup.
+**Dev-machine empirical note (corrected 2026-06-29):** At the start of this session the dev machine's global CLI was a **separate installed copy** (`<nvm>/lib/node_modules/dreamcontext` — a real directory, not a symlink), NOT `npm link`-ed to the repo. `npm link` was re-run in this session to restore the linked-repo dev setup. **npm-linked dev footgun:** even when the global IS npm-linked to the repo, the embedded terminal silently downgrades to "Open in Terminal" unless (a) `node-pty` is installed in the repo's `node_modules` (it is an optional dep — a plain `npm install` can skip it) AND (b) its prebuilt spawn-helper has `+x` (the tarball ships `-rw-r--r--` → `posix_spawnp failed` at runtime). `ensurePtyHelperExecutable()` restores `+x` at runtime; the in-app installer's `pty` target handles the missing-module case from the UI. The stale-dist symptom (app serving an older dist) is a separate concern — manifests on user machines with a separately installed, stale global CLI.
+
+Feature PRD: `_dream_context/core/features/in-app-agent-terminal.md`.
 
 ## Status / deferred
 

--- a/dashboard/src/components/sleepy/AgentSurface.tsx
+++ b/dashboard/src/components/sleepy/AgentSurface.tsx
@@ -36,6 +36,10 @@ interface Capabilities {
   platform: string;
   embeddedTerminal: boolean;
   openTerminal: boolean;
+  // Prerequisite breakdown (drives the in-app Setup panel).
+  nodePty: boolean;
+  claudeCli: boolean;
+  npm: boolean;
 }
 
 type TermStatus = 'connecting' | 'open' | 'closed';
@@ -87,6 +91,18 @@ function readXtermTheme(): ITheme {
   const bg = g('--color-bg', '#14171f');
   const text = g('--color-text', '#f5f6fa');
   const accent = g('--color-accent', '#9d8cff');
+  // The 16 ANSI slots must keep conventional luminance ordering (0 = darkest →
+  // 15 = lightest) REGARDLESS of theme. The old mapping wired black/white/brightBlack
+  // straight to design tokens, which inverted them in light mode (black→#e9ebf0,
+  // white→#646464) and made the dim grays too light in dark mode — so when Claude's
+  // TUI fills a region with ANSI 7/8 as a background, the foreground collapsed to
+  // same-luminance-on-same-luminance (the unreadable pale blocks). The grayscale ramp
+  // is tuned per-theme so background fills BLEND with the surface; foreground
+  // readability on any pairing is then guaranteed by `minimumContrastRatio` below.
+  const isLight = currentTermTheme() === 'light';
+  const ramp = isLight
+    ? { black: '#292d34', brightBlack: '#646464', white: '#e9ebf0', brightWhite: '#ffffff' }
+    : { black: '#20242e', brightBlack: '#3b4151', white: '#c8ccd9', brightWhite: '#f5f6fa' };
   return {
     background: bg,
     foreground: text,
@@ -94,22 +110,22 @@ function readXtermTheme(): ITheme {
     cursorAccent: bg,
     selectionBackground: g('--color-accent-soft', 'rgba(157,140,255,0.30)'),
     selectionForeground: text,
-    black: g('--color-bg-tertiary', '#2a2f3d'),
+    black: ramp.black,
     red: g('--color-error', '#ff5a5f'),
     green: g('--color-success', '#4ade80'),
     yellow: g('--color-warning', '#ffae3b'),
     blue: '#5b9dff',
     magenta: accent,
     cyan: '#3bd6c6',
-    white: g('--color-text-secondary', '#c8ccd9'),
-    brightBlack: g('--color-text-tertiary', '#9aa0b3'),
+    white: ramp.white,
+    brightBlack: ramp.brightBlack,
     brightRed: '#ff7a7f',
     brightGreen: '#6ee7a0',
     brightYellow: '#ffc46b',
     brightBlue: '#8bbcff',
     brightMagenta: accent,
     brightCyan: '#6fe3d6',
-    brightWhite: text,
+    brightWhite: ramp.brightWhite,
   };
 }
 
@@ -178,7 +194,11 @@ function createSession(bypass: boolean, onStatus: () => void): Session {
     theme: readXtermTheme(),
     allowProposedApi: true,
     scrollback: 5000,
-    minimumContrastRatio: 1, // keep our themed ANSI palette exact
+    // AA contrast floor: xterm auto-lifts any foreground that falls too close to its
+    // actual cell background. Without this (was 1 = off), Claude's TUI blocks that pair
+    // a default foreground with an ANSI 7/8 background fill rendered as unreadable
+    // same-on-same text in BOTH themes. Readability beats exact brand-colour fidelity.
+    minimumContrastRatio: 4.5,
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
@@ -326,14 +346,13 @@ export function AgentSurface() {
   const started = tabs.length > 0;
   const activeTab = tabs.find(t => t.id === activeTabId) ?? null;
 
-  // ── Capabilities (fetched once; surface stays inert until the Agent tab opens) ─
-  useEffect(() => {
-    let alive = true;
-    api.get<Capabilities>('/agent/capabilities')
-      .then(c => { if (alive) setCaps(c); })
-      .catch(() => { if (alive) setCapsError(true); });
-    return () => { alive = false; };
+  // ── Capabilities (fetched on mount; re-fetched after an in-app install so a
+  //    freshly-installed prerequisite flips to ready without an app relaunch) ────
+  const refreshCaps = useCallback(async (): Promise<Capabilities | null> => {
+    try { const c = await api.get<Capabilities>('/agent/capabilities'); setCaps(c); return c; }
+    catch { setCapsError(true); return null; }
   }, []);
+  useEffect(() => { void refreshCaps(); }, [refreshCaps]);
 
   // ── Session/tab actions ──────────────────────────────────────────────────────
   const spawn = useCallback(() => {
@@ -715,20 +734,25 @@ export function AgentSurface() {
           (⌘D, or drag one tab onto another).
         </p>
         <BypassToggle bypass={bypass} setBypass={setBypass} />
-        <div style={{ display: 'flex', gap: '12px', marginTop: '22px', flexWrap: 'wrap', justifyContent: 'center' }}>
-          {caps.embeddedTerminal && (
-            <button onClick={startFirst} style={primaryBtn}>▸ Start agent in app</button>
-          )}
-          {caps.openTerminal && (
-            <button onClick={openExternal} style={caps.embeddedTerminal ? secondaryBtn : primaryBtn}>↗ Open in Terminal</button>
-          )}
-        </div>
-        {!caps.embeddedTerminal && caps.openTerminal && (
-          <p style={{ ...subStyle, fontSize: '12px', marginTop: '14px', color: 'var(--color-text-tertiary)' }}>
-            The embedded terminal needs the native <code>node-pty</code> module (absent in this build) —
-            launching your real terminal at the project path instead.
-          </p>
-        )}
+        {(() => {
+          // The embedded terminal is usable only when BOTH its renderer (node-pty)
+          // and the `claude` binary it spawns are present. Missing either → show the
+          // in-app Setup panel rather than silently spawning a shell that 404s claude.
+          const ready = caps.embeddedTerminal && caps.claudeCli;
+          return (
+            <>
+              <div style={{ display: 'flex', gap: '12px', marginTop: '22px', flexWrap: 'wrap', justifyContent: 'center' }}>
+                {ready && (
+                  <button onClick={startFirst} style={primaryBtn}>▸ Start agent in app</button>
+                )}
+                {caps.openTerminal && (
+                  <button onClick={openExternal} style={ready ? secondaryBtn : primaryBtn}>↗ Open in Terminal</button>
+                )}
+              </div>
+              {!ready && <Prereqs caps={caps} onRefresh={refreshCaps} />}
+            </>
+          );
+        })()}
       </Centered>
     );
   }
@@ -903,6 +927,90 @@ function BypassToggle({ bypass, setBypass }: { bypass: boolean; setBypass: (b: b
     </div>
   );
 }
+
+// ── Setup panel: one-click install of the embedded terminal's prerequisites ──────
+// Shown when `claude` and/or `node-pty` are missing. Each install runs server-side
+// in the user's login shell (so a Finder-launched app sees their real PATH) and is
+// polled to completion; a success re-checks capabilities so the row flips to ready.
+
+type InstallTarget = 'claude' | 'pty';
+
+function Prereqs({ caps, onRefresh }: { caps: Capabilities; onRefresh: () => Promise<Capabilities | null> }) {
+  const [busy, setBusy] = useState<InstallTarget | null>(null);
+  const [log, setLog] = useState('');
+  const [err, setErr] = useState('');
+
+  const runInstall = useCallback(async (target: InstallTarget) => {
+    setBusy(target); setErr(''); setLog('');
+    try {
+      const { runId } = await api.post<{ ok: boolean; runId: string }>('/agent/install', { target });
+      // Poll until the background install ends (the server watchdog caps it ~5 min).
+      for (let i = 0; i < 260; i++) {
+        await new Promise(r => setTimeout(r, 1300));
+        const s = await api.get<{ state: string; output: string }>(`/agent/install/status?id=${encodeURIComponent(runId)}`);
+        if (s.output) setLog(s.output);
+        if (s.state === 'done') { await onRefresh(); return; }
+        if (s.state === 'error') { setErr(s.output || 'Install failed.'); return; }
+        if (s.state === 'unknown') { setErr('The install run expired before it finished.'); return; }
+      }
+      setErr('Install is taking unusually long — check a real terminal.');
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Could not start the install.');
+    } finally {
+      setBusy(null);
+    }
+  }, [onRefresh]);
+
+  const rows: { target: InstallTarget; label: string; ok: boolean; desc: string }[] = [
+    { target: 'claude', label: 'Claude CLI', ok: caps.claudeCli, desc: 'Anthropic’s claude command — the agent that runs in the terminal.' },
+    { target: 'pty', label: 'Embedded terminal engine', ok: caps.nodePty, desc: 'The native node-pty module that renders Claude Code in-app.' },
+  ];
+  const canInstall = caps.npm;
+  const blocked = !canInstall || busy !== null;
+
+  return (
+    <div style={{ marginTop: '22px', width: '100%', maxWidth: '440px', textAlign: 'left' }}>
+      <p style={{ ...subStyle, fontSize: '13px', marginBottom: '12px', color: 'var(--color-text-tertiary)' }}>
+        Set up what the in-app terminal needs:
+      </p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {rows.map(row => (
+          <div key={row.target} style={prereqRow}>
+            <span style={{ fontSize: '15px', width: '18px', flexShrink: 0, textAlign: 'center' }}>{row.ok ? '✅' : '⬜'}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: '13.5px', fontWeight: 600, color: 'var(--color-text)' }}>{row.label}</div>
+              <div style={{ fontSize: '12px', color: 'var(--color-text-tertiary)', lineHeight: 1.4 }}>{row.desc}</div>
+            </div>
+            {row.ok
+              ? <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--color-success)', flexShrink: 0 }}>Ready</span>
+              : (
+                <button
+                  onClick={() => runInstall(row.target)}
+                  disabled={blocked}
+                  style={{ ...secondaryBtn, padding: '7px 14px', fontSize: '13px', flexShrink: 0, opacity: blocked ? 0.55 : 1, cursor: blocked ? 'not-allowed' : 'pointer' }}
+                >
+                  {busy === row.target ? '⏳ Installing…' : 'Install'}
+                </button>
+              )}
+          </div>
+        ))}
+      </div>
+
+      {!canInstall && (
+        <div style={{ ...bannerStyle, marginTop: '12px', background: 'rgba(255,174,59,0.1)', border: '1px solid rgba(255,174,59,0.32)', color: 'var(--color-text-secondary)' }}>
+          npm wasn’t found on your PATH, so these can’t be auto-installed. Install Node.js from <code>nodejs.org</code> (or via Homebrew), then reopen this screen.
+        </div>
+      )}
+      {busy && log && (
+        <pre style={installLog}>{log.split('\n').slice(-6).join('\n')}</pre>
+      )}
+      {err && <div style={{ ...bannerStyle, marginTop: '10px' }}>{err}</div>}
+    </div>
+  );
+}
+
+const prereqRow: CSSProperties = { display: 'flex', alignItems: 'center', gap: '10px', padding: '10px 12px', borderRadius: '10px', background: 'var(--color-bg-secondary)', border: '1px solid var(--color-border)' };
+const installLog: CSSProperties = { padding: '10px 12px', borderRadius: '8px', background: 'var(--color-bg-tertiary)', color: 'var(--color-text-secondary)', fontFamily: 'var(--font-mono)', fontSize: '11px', lineHeight: 1.45, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '120px', overflow: 'auto', margin: '10px 0 0' };
 
 function BypassPill({ bypass, setBypass }: { bypass: boolean; setBypass: (b: boolean) => void }) {
   return (

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,6 +50,8 @@ import {
 import {
   handleAgentCapabilities,
   handleOpenTerminal,
+  handleAgentInstall,
+  handleAgentInstallStatus,
   attachAgentTerminal,
 } from './routes/agent-terminal.js';
 import { handleConnectionsList, handleConnectionsCreate, handleConnectionsDelete } from './routes/connections.js';
@@ -180,6 +182,9 @@ function buildRouter(): Router {
   // not a router route.
   router.get('/api/agent/capabilities', handleAgentCapabilities);
   router.post('/api/agent/open-terminal', handleOpenTerminal);
+  // In-app prerequisite installer (Claude CLI / node-pty) — vault-agnostic.
+  router.post('/api/agent/install', handleAgentInstall);
+  router.get('/api/agent/install/status', handleAgentInstallStatus);
 
   // Vaults + federation connections (issue #25 P2)
   router.get('/api/vaults', handleVaultsGet);
@@ -231,7 +236,7 @@ function buildRouter(): Router {
 }
 
 /** API path prefixes that do NOT need a vault — they work in launcher mode. */
-const VAULT_AGNOSTIC_PREFIXES = ['/api/health', '/api/vaults', '/api/launcher', '/api/sleepy', '/api/agent/capabilities'];
+const VAULT_AGNOSTIC_PREFIXES = ['/api/health', '/api/vaults', '/api/launcher', '/api/sleepy', '/api/agent/capabilities', '/api/agent/install'];
 
 function isVaultAgnostic(pathname: string): boolean {
   return VAULT_AGNOSTIC_PREFIXES.some(

--- a/src/server/routes/agent-terminal.ts
+++ b/src/server/routes/agent-terminal.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Server } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { existsSync, readdirSync, statSync, chmodSync } from 'node:fs';
@@ -73,6 +74,31 @@ async function hasNodePty(): Promise<boolean> {
   return ptyAvailable;
 }
 
+/** Bust the memoized node-pty probe so the next capabilities check re-imports
+ *  (e.g. right after the in-app installer materialised node-pty on disk). */
+function resetPtyCache(): void { ptyAvailable = null; }
+
+/**
+ * Is a command resolvable on the user's PATH, as the embedded terminal will see
+ * it? We probe through the SAME interactive-login shell (`-ilc`) the PTY spawn
+ * uses, so detection can't disagree with the real spawn — `claude` is commonly
+ * added to PATH in `~/.zshrc` (e.g. `~/.local/bin`), which only `-i` sources.
+ * `cmd` is an internal whitelist literal, never user input (no injection).
+ */
+function detectOnPath(cmd: 'claude' | 'npm', timeoutMs = 8000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const shell = process.env.SHELL || '/bin/zsh';
+    let out = '';
+    let settled = false;
+    const done = (v: boolean) => { if (!settled) { settled = true; clearTimeout(timer); resolve(v); } };
+    const child = spawn(shell, ['-ilc', `command -v ${cmd}`], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const timer = setTimeout(() => { try { child.kill(); } catch { /* gone */ } done(false); }, timeoutMs);
+    child.stdout?.on('data', (c: Buffer) => { out += c.toString('utf-8'); });
+    child.on('error', () => done(false));
+    child.on('close', () => done(out.trim().length > 0));
+  });
+}
+
 // ─── Vault / path helpers ───────────────────────────────────────────────────
 
 function projectRootOf(contextRoot: string): string {
@@ -101,13 +127,24 @@ export async function handleAgentCapabilities(
   res: ServerResponse,
 ): Promise<void> {
   const desktop = isDesktop();
+  // Probe the three prerequisites in parallel (only when desktop — they cost a
+  // login-shell spawn each). `nodePty` gates the embedded renderer; `claudeCli`
+  // gates whether the spawned shell can actually find `claude`; `npm` tells the
+  // UI whether the in-app installer can even run.
+  const [nodePty, claudeCli, npm] = desktop
+    ? await Promise.all([hasNodePty(), detectOnPath('claude'), detectOnPath('npm')])
+    : [false, false, false];
   sendJson(res, 200, {
     desktop,
     platform: process.platform,
     // Embedded terminal needs the desktop shell AND the native node-pty module.
-    embeddedTerminal: desktop && process.platform !== 'win32' && (await hasNodePty()),
+    embeddedTerminal: desktop && process.platform !== 'win32' && nodePty,
     // Launching the user's real terminal is macOS-only (osascript) today.
     openTerminal: desktop && process.platform === 'darwin',
+    // Prerequisite breakdown for the in-app Setup panel.
+    nodePty,
+    claudeCli,
+    npm,
   });
 }
 
@@ -162,6 +199,167 @@ export async function handleOpenTerminal(
   } catch (err) {
     sendError(res, 500, 'spawn_failed', err instanceof Error ? err.message : 'Could not open Terminal.');
   }
+}
+
+// ─── In-app prerequisite installer ────────────────────────────────────────────
+//
+// When the embedded terminal's prerequisites are missing — the `claude` CLI or the
+// native `node-pty` module — the Setup panel offers a one-click install instead of
+// only falling back to an external terminal. Installs run in the user's LOGIN shell
+// (so a Finder-launched app sees their real nvm/brew PATH) and are tracked like the
+// Sleepy capture runs: POST starts it + returns an id, the UI polls status.
+//
+// Trust model: identical to `ensure-cli.ts` / `open-terminal` — desktop-gated, and
+// the package names are FIXED internal literals, never user input. The only body
+// field is `target`, validated against a closed whitelist.
+
+type InstallTarget = 'claude' | 'pty';
+
+interface InstallRun {
+  state: 'running' | 'done' | 'error';
+  target: InstallTarget;
+  /** Combined stdout+stderr tail — shown live, and as the detail on failure. */
+  output: string;
+  startedAt: number;
+  endedAt?: number;
+}
+
+const installRuns = new Map<string, InstallRun>();
+const INSTALL_RUN_TTL_MS = 10 * 60 * 1000;
+const INSTALL_RUNS_MAX = 20;
+const INSTALL_WATCHDOG_MS = 5 * 60 * 1000; // kill a wedged npm after 5 min
+
+function pruneInstallRuns(): void {
+  const now = Date.now();
+  for (const [id, run] of installRuns) {
+    if (run.endedAt && now - run.endedAt > INSTALL_RUN_TTL_MS) installRuns.delete(id);
+  }
+  while (installRuns.size > INSTALL_RUNS_MAX) {
+    const oldest = installRuns.keys().next().value;
+    if (oldest === undefined) break;
+    installRuns.delete(oldest);
+  }
+}
+
+/**
+ * The package root of the running CLI (nearest ancestor with a package.json),
+ * walking up from the entry module. `node-pty` is installed HERE so it resolves
+ * from the bundled `dist/index.js` exactly as the runtime `import('node-pty')`
+ * does (node walks up to `<root>/node_modules`). Returns null if not found.
+ */
+function cliPackageRoot(): string | null {
+  let dir = process.argv[1] ? dirname(process.argv[1]) : '';
+  if (!dir) return null;
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, 'package.json'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Build the shell command + cwd for a target. Returns null if it can't be run here. */
+function installPlan(target: InstallTarget): { script: string; cwd?: string } | null {
+  if (target === 'claude') {
+    // Anthropic's official Claude Code distribution.
+    return { script: 'npm install -g @anthropic-ai/claude-code' };
+  }
+  // node-pty: install into the CLI's own package so the server can import it. Pinned
+  // to the declared range; `--no-save` leaves the package manifest untouched.
+  const root = cliPackageRoot();
+  if (!root) return null;
+  return { script: 'npm install node-pty@^1.1.0 --no-save', cwd: root };
+}
+
+/**
+ * POST /api/agent/install  { target: 'claude' | 'pty' }
+ * Starts a background install and returns `{ ok, runId }`. Poll status to track it.
+ */
+export async function handleAgentInstall(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (!isDesktop()) {
+    sendError(res, 403, 'desktop_only', 'The in-app installer is only available in the desktop app.');
+    return;
+  }
+
+  let target: unknown;
+  try {
+    const chunks: Buffer[] = [];
+    for await (const c of req) chunks.push(c as Buffer);
+    target = chunks.length ? (JSON.parse(Buffer.concat(chunks).toString('utf-8')) as { target?: unknown }).target : undefined;
+  } catch { /* invalid body → 400 below */ }
+
+  if (target !== 'claude' && target !== 'pty') {
+    sendError(res, 400, 'bad_target', "Body must be { target: 'claude' | 'pty' }.");
+    return;
+  }
+  const plan = installPlan(target);
+  if (!plan) {
+    sendError(res, 500, 'no_install_path', "Couldn't locate the CLI package to install node-pty into.");
+    return;
+  }
+
+  pruneInstallRuns();
+  const runId = randomUUID();
+  const run: InstallRun = { state: 'running', target, output: '', startedAt: Date.now() };
+  installRuns.set(runId, run);
+
+  try {
+    const shell = process.env.SHELL || '/bin/zsh';
+    const child = spawn(shell, ['-ilc', plan.script], {
+      cwd: plan.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const append = (chunk: Buffer) => { run.output = (run.output + chunk.toString('utf-8')).slice(-8000); };
+    child.stdout?.on('data', append);
+    child.stderr?.on('data', append);
+    const watchdog = setTimeout(() => {
+      try { child.kill(); } catch { /* gone */ }
+      if (run.state === 'running') { run.state = 'error'; run.output += '\n[timed out after 5 min]'; run.endedAt = Date.now(); }
+    }, INSTALL_WATCHDOG_MS);
+    child.on('error', (err) => {
+      clearTimeout(watchdog);
+      if (run.state !== 'running') return;
+      run.state = 'error';
+      run.output = `Couldn't start install: ${err.message}. Run manually: ${plan.script}`;
+      run.endedAt = Date.now();
+    });
+    child.on('close', (code) => {
+      clearTimeout(watchdog);
+      if (run.state !== 'running') return;
+      if (code === 0) {
+        // node-pty just landed: restore the spawn-helper +x bit and bust the probe
+        // cache so the very next capabilities check reports the terminal as ready.
+        if (target === 'pty') { ensurePtyHelperExecutable(); resetPtyCache(); }
+        run.state = 'done';
+      } else {
+        run.state = 'error';
+        if (!run.output.trim()) run.output = `Install exited with code ${code}. Run manually: ${plan.script}`;
+      }
+      run.endedAt = Date.now();
+    });
+  } catch (err) {
+    run.state = 'error';
+    run.output = `Couldn't start install: ${err instanceof Error ? err.message : 'spawn failed'}`;
+    run.endedAt = Date.now();
+  }
+
+  sendJson(res, 200, { ok: true, runId });
+}
+
+/** GET /api/agent/install/status?id=<runId> — poll a background install. */
+export async function handleAgentInstallStatus(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const url = new URL(req.url || '/', `http://${req.headers.host}`);
+  const id = url.searchParams.get('id') ?? '';
+  const run = id ? installRuns.get(id) : undefined;
+  if (!run) { sendJson(res, 200, { state: 'unknown', output: '' }); return; }
+  sendJson(res, 200, { state: run.state, target: run.target, output: run.output.trim() });
 }
 
 // ─── Embedded terminal (WebSocket ↔ node-pty) ─────────────────────────────────


### PR DESCRIPTION
Two fixes to the embedded Claude Code terminal on the Sleepy/Agent screen.

## 1. Readability — Claude's text was unreadable in both light & dark mode

**Root cause:** `readXtermTheme()` mapped xterm's 16 ANSI slots straight to design tokens, which **inverted luminance in light mode** (`black`→`#e9ebf0`, `white`→`#646464`) and made dim grays too light in dark mode — and `minimumContrastRatio` was set to `1`, i.e. xterm's contrast safety-net was **off**. So when Claude's TUI fills a region with an ANSI 7/8 background and writes default-colored text on it, the cell collapsed to same-luminance-on-same-luminance → invisible text (the pale block in dark mode, the washed-out blank in light mode).

**Fix:**
- `minimumContrastRatio: 1 → 4.5` — xterm now auto-lifts any foreground too close to its actual cell background. Mechanism-independent guarantee of readability in both themes.
- Conventional, per-theme grayscale ANSI ramp (0 = darkest … 15 = lightest) so background fills *blend* with the surface instead of becoming wrong-luminance blocks.

## 2. In-app prerequisite installer on the Agent screen

When the embedded terminal's prerequisites are missing, the screen now offers a one-click install instead of only falling back to "Open in Terminal".

- `GET /api/agent/capabilities` also reports `claudeCli` / `nodePty` / `npm`, each probed through `$SHELL -ilc` so detection **matches the PTY spawn's PATH** (finds `claude` in `~/.local/bin`, which only an interactive login shell sources).
- New `POST /api/agent/install { target: 'claude' | 'pty' }` + `GET /api/agent/install/status?id=` mirror the Sleepy capture-run pattern (in-memory run Map + TTL prune + 5-min watchdog).
  - `claude` → `npm install -g @anthropic-ai/claude-code`
  - `pty` → `npm install node-pty@^1.1.0 --no-save` into the CLI's own package dir, then `chmod +x` the spawn-helper and bust the probe cache (so it flips to ready without an app relaunch).
- A **Setup panel** (`Prereqs` in `AgentSurface.tsx`) lists each missing prerequisite with an Install button, live log tail, and auto re-check on success. "Start agent in app" is now gated on **both** `node-pty` **and** `claude` (previously only node-pty, so it could spawn a shell that can't find `claude`). `npm`-absent shows guidance instead of failing.
- **Security:** desktop-gated, loopback-served, package names are fixed internal literals (no user input), `target` validated against a closed whitelist.

## Testing
- `npm run build` green (dashboard `tsc -b` + vite + CLI tsup).
- Endpoints verified live (launcher mode, desktop gate on): capabilities returns the new fields; `install/status` unknown id → `{state:unknown}`; bad target → `400 bad_target`.
- To verify visually: ⌘Q + reopen the desktop app, open an Agent tab. On a machine that already has `claude` + `node-pty` you get the working embedded terminal; the Setup panel appears only when a prerequisite is missing.

## Notes
- Drive-by ops finding: `node-pty` is an **optional** dependency and was absent from the repo's `node_modules`, which silently downgrades the embedded terminal once the dev global CLI is `npm link`-ed to the repo. The new `pty` installer fixes this from the UI; `ensurePtyHelperExecutable()` handles the spawn-helper `+x` at runtime.
- Includes a RemSleep consolidation commit: CHANGELOG entries, knowledge corrections (stale `AgentTerminal.tsx` → `AgentSurface.tsx`, the npm-link/node-pty footgun), and a new `core/features/in-app-agent-terminal.md` PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)