### PR TITLE
feat(desktop): one window holds every open project as a live chip strip

### DIFF
--- a/_dream_context/knowledge/features/project-tabs-one-window-multi-vault.md
+++ b/_dream_context/knowledge/features/project-tabs-one-window-multi-vault.md
@@ -1,0 +1,141 @@
+---
+id: "feat_nLvaWOhX"
+type: "feature"
+name: "project-tabs-one-window-multi-vault"
+description: "Transform desktop from one OS window per project to one window with a chip strip where every open project stays live with per-instance isolation"
+pinned: false
+date: "2026-08-10"
+status: "in_review"
+created: "2026-08-10"
+updated: "2026-08-10"
+released_version: null
+product: desktop
+tags:
+  - topic:desktop
+  - architecture
+  - layer:frontend
+  - topic:agents
+related_tasks:
+  - one-window-holds-every-open-project-as-a-live-chip-strip
+---
+
+## Why
+
+**Problem:** dreamcontext desktop used the "one OS window per project" model (inherited from v0.8 beta multi-window architecture). Switching between projects meant hunting windows. When a background project's agent asked a question, it was invisible until you found that window. This friction made multi-project workflows painful.
+
+**Constraint:** A background project with a live chat cannot be unmounted — its PTY is bound to a live WebSocket, so unmounting kills the conversation. Any solution must keep every open project LIVE.
+
+**Solution:** Transform the desktop app into one window with a center-aligned chip strip where every open project stays live in the same window, isolated by per-instance state. A background chip's badge shows its active chat count and jumps when an agent asks, firing a native banner even when the window is focused.
+
+**Who benefits:** Anyone working across multiple dreamcontext projects (team members with multiple clients, personal + work vaults, multi-product portfolios).
+
+## User Stories
+
+- [x] As a user, I want to open multiple projects in one window as a chip strip so that I don't have to hunt between OS windows
+- [x] As a user, I want background projects to stay live (WebSocket connections maintained) so that long-running agent tasks continue when I switch away
+- [x] As a user, I want to see when a background project's agent asks a question (chip badge shows active chat count, chip jumps once, native banner fires) so that I don't miss questions
+- [x] As a user, I want the terminal to stay correctly fitted after switching projects so that TUI output isn't clipped or wrapped
+- [x] As a user, I want per-project isolation for settings and permissions so that enabling bypass mode in one project doesn't affect others
+- [x] As a user, I want the system to enforce a ceiling (6 live instances) and evict idle projects to cold chips so that the window doesn't degrade under load
+- [ ] As a user, I want multi-window to remain an escape hatch (Shift-click to open in new window) so that I can spread projects across displays
+
+## Acceptance Criteria
+
+### Automated (9/9 PASS at in_review)
+- [x] `npx tsc --noEmit` at repo root: exit 0, zero diagnostics
+- [x] `cd dashboard && npx tsc --noEmit`: exit 0, zero diagnostics
+- [x] `npm test` green: 0 failed, 0 skipped
+- [x] NEW unit test `tests/unit/agent-status-project-rollup.test.ts` green (11 tests: rollupProject worst-of ordering, saved/ended/shell excluded from live, `alive` field regression lock)
+- [x] NEW unit test `tests/unit/scoped-storage.test.ts` green (17 tests: scoped-key shape, legacy→scoped migration, second vault gets fallback, keepLegacy preserves legacy key)
+- [x] `npm run build` exits 0 and produces dashboard bundle
+- [x] `grep -rn 'getActiveVault()' dashboard/src` matches ONLY inside `dashboard/src/api/client.ts` (module-global activeVault dead except deprecated pair)
+- [x] Only sanctioned `window.dispatchEvent` sites remain: dreamcontext-zoom, AGENT_SETTINGS_EVENT, ANNOUNCEMENTS_READ_EVENT, dead AUTO_CHECKPOINT_EVENT
+- [x] RED LINE: `grep -rn 'isActive' dashboard/src/components/sleepy/{agentSession.ts,chatSession.ts}` returns zero matches — WebSockets never tied to visibility
+
+### Runtime (6/9 proven at in_review, 3 unproven)
+- [x] Register two vaults, open both as chips: both render in centered strip, both instances live with their own data
+- [ ] Start chat in A, switch to B: A's chat keeps streaming, WebSocket never closed, B's page data loads independently
+- [x] A's chat asks while on B: A's chip dot red, bounces once, badge shows active chat count, native banner fires even though window focused
+- [ ] Return to A: term.cols/rows match visible grid, no clipped/wrapped TUI, scrollback intact (M-x1 measurement)
+- [ ] Close one chip: only that project's sessions end, other project still streaming, no orphaned claude process
+- [ ] Open same project twice (via +, via CMD-P, from second window): in-window focuses existing chip, from another window that window focused
+- [ ] Open 7th tab: if any instance has `rollup.live === 0` oldest torn down to cold chip; if all busy tab refused with stated reason. Instance with no published rollup never evicted
+- [x] Add 3rd chip then close one with cursor over strip: adding re-centers; pointer inside strip freezes layout on close; leaving re-centers; overflow left-aligned + scrollable
+- [x] Quit and relaunch: exactly ONE project returns (launcher's ?vault=), no tab list persisted
+
+## Constraints & Decisions
+<!-- LIFO: newest decision at top -->
+
+### Hard Constraints (red lines)
+- **Live chats NEVER unmounted.** PTY bound to live WebSocket; unmounting kills conversation. Hiding is `display:none` + `inert`, nothing else.
+- **WebSockets NEVER tied to `isActive`.** Only page-data `refetchInterval` pauses; agent surface's own polling continues in background so a background goal-skill run's badge doesn't freeze.
+- **No tab persistence.** Every launch opens exactly ONE project (launcher's `?vault=`). Deliberate simplicity.
+- **Ceiling of 6 live instances.** At ceiling, oldest instance with `rollup.live === 0` torn down to cold chip (sessions disposed, remounted on click). If all busy, new tab refused with stated reason.
+- **Same project never open twice** (in this window or another). Focus existing chip/window instead.
+
+### Closed Decisions
+- **Per-vault isolation:** `chatPermissionMode` (permission gate), `autoCheckpointOnOpen` (git behavior), `githubSyncSeen` (brain enable CTA), `activePage` (navigation), `chat.mediaBoxes` (path collisions) all scoped. `sidebarCollapsed` hoisted to chrome. Theme/zoom/announcements stay global.
+- **Attention throttle per source.** Map keyed by vault name gates banner + Dock bounce separately; global floor for chime (one AudioContext, one voice correct).
+- **Chip activity probe.** `setChipActiveProbe((vault) => vault === activeRef.current)` registered by WindowChrome so attention system knows which chip is visible.
+- **No escape to new window from chip strip itself** — only via Shift-click in ProjectSwitcher or right-click context menu (cut on YAGNI).
+- **Eviction gate is `alive`, not `live`.** `ProjectRollup.live` excludes shells (it's the chat badge count); a project with only a running shell (dev server) must not report `live:0` and be evictable mid-process. `ProjectRollup.alive` counts any row with a live PTY/WebSocket, shells included.
+
+### Review Findings
+- **M7 (T8):** `fitVisible()` must early-return on `!isActive` — two other paths call it while hidden, and fitting a `display:none` xterm degrades to no-op only by luck (position:absolute;inset:0 → height auto → NaN → FitAddon bails).
+- **M8 (T11):** `markSleepPending`/`clearSleepPending` gained `vault` — a global key meant clicking "Run sleep" in A put B's tracker into "Waiting to sleep..." and disabled its menu item.
+- **M9 (T18/T19/T20, CRITICAL):** `ProjectRollup.live` was the eviction test but excludes shells → project with only a running shell reported `live:0`, was evicted, PTY killed mid-process. Fixed by adding `ProjectRollup.alive` as sole eviction gate, regression-locked.
+
+## Technical Details
+
+### Architecture
+- **ProjectInstance** (`dashboard/src/ProjectInstance.tsx`): one mounted React app per vault, each with its own `instanceQueryClient` (React Query cache isolation), `VaultContext`, scoped localStorage, and event bus.
+- **WindowChrome** (`dashboard/src/components/layout/WindowChrome.tsx`): the shell that owns the instance lifecycle, chip registry (`OpenProject[]`), ceiling enforcement (`MAX_LIVE_INSTANCES=6`), eviction (oldest `rollup.alive === 0`), and window registry heartbeat.
+- **ProjectTabs** (`dashboard/src/components/layout/ProjectTabs.tsx` + `.css`): the center-aligned chip strip. Rule 1 (freeze): `pointerenter` snapshots leading gap + each chip's width, so a chip closed while frozen leaves a ghost and neighbors don't slide under cursor. Rule 2 (fall left): `margin-inline:auto` collapses to 0 when content exceeds container, so CSS and overflow flag can't disagree.
+- **Per-vault ApiClient** (`dashboard/src/api/client.ts`): was module-level singleton `api`, now a class. Module-global `api` survives for capture/perch windows (separate OS windows, legitimately single-vault). Migrated ~28 hooks + 12 components off `getActiveVault()`.
+
+### State Isolation
+- **VaultContext** (`dashboard/src/context/VaultContext.tsx`): `{vault, bus: EventTarget, instanceId}`. `useVault()` never throws (launcher safe); `useApi()` reads vault from context, returns per-instance `ApiClient`.
+- **Scoped storage** (`dashboard/src/lib/scopedStorage.ts`): `scopedKey(vault, key)` → `dc:${vault}:${key}`. Migration: on first read, `getItem(key)` copies to scoped key for that vault. `keepLegacy: true` preserves bare key (e.g., `autoCheckpointOnOpen` — unset default is ON, so inheritance would silently enable git auto-commit everywhere).
+- **Instance QueryClient** (`dashboard/src/lib/instanceQueryClient.ts`): default `refetchInterval: false` (paused when backgrounded). Three hooks override explicitly: `useAgentSessionStats` (5s), `useAgentGoalLive` (2s), `useAgentCouncilLive` (2s) — session-stats/goal/council polling survives backgrounding so badge stays current.
+
+### Event Bus Migration
+Ten events moved from `window` to instance bus: `navigate`, `agent-open-page`, `delegate`, `run-sleep-agent`, `sleep-pending`, `brain-resolve`, `automation-run-chat`, `claude-signin`, `chatPermissionMode` consumption. Four correctly stayed global: `dreamcontext-zoom`, `AGENT_SETTINGS_EVENT`, `ANNOUNCEMENTS_READ_EVENT`, dead `AUTO_CHECKPOINT_EVENT`.
+
+### Cross-Instance Coordination
+- **Window registry** (`dashboard/src/lib/windowRegistry.ts`): `localStorage['dc.windows.v1']` heartbeat (5s), 15s staleness GC. `findWindowForVault(vault)` → label or null (registry-only, skips this window's own row). `resolveLiveWindowForVault(vault)` corroborates against `WebviewWindow.getAll()` (registry ∩ actual windows).
+- **Desktop bridge** (`dashboard/src/lib/desktop.ts`): `focusWindow(label)`, `goToProject` seam (module-level `setGoToProjectHandler(fn|null)` registered by WindowChrome, falls back to `openVaultWindow` when nothing registered — launcher window byte-identical).
+- **Checklist submit** (`dashboard/src/lib/checklistBridge.ts`): corroborated label (registry ∩ `WebviewWindow.getAll()`), returns `false` when it can't — fail-closed, no derived labels.
+
+### Attention System
+- **Per-source throttle** (`dashboard/src/lib/attention.ts`): `lastRaiseBySource: Map<string, number>` keyed on vault name gates banner + Dock bounce separately. Separate module `lastChime` keeps global 1500ms floor for `playAskChime()` (one AudioContext).
+- **Chip active probe:** `setChipActiveProbe((vault) => vault === activeRef.current)` — closes over ref, not value, registered mount-only by WindowChrome. Guard: `isWatchingThisWindow() && (chipActiveProbe?.(source) ?? true)` — short-circuits true for empty source (source-less alarm can't be attributed to any chip).
+
+### Lab Route Ownership
+- **labRoute.ts** (`dashboard/src/components/lab/funnel/labRoute.ts`, 232 lines): routing moved to the bus. `setLabRouteWritable(on: boolean, bus: EventTarget)` claims/releases address bar ownership. Ownership held as **bus, not boolean** — stale release from outgoing instance can't unseat incoming one. Release parks `pathname+search` in `WeakMap` keyed by bus, resets path to `/` (query kept) so reload can't resurrect one vault's funnel under another. Re-activation flushes parked route with `replaceState` (not `pushState` — returning to chip isn't Back-button step). `LabPage` owns toggle; background instances read parked route, never live URL.
+
+### Overlay ID Namespacing
+- **useOverlayId** (`dashboard/src/lib/useOverlayId.ts`): `` `${instanceId}::${local}` `` via `useVault()`. Five literal-id sites converted: `command-palette`, `chat-history`, `announcements-modal`, `insight-detail-panel`, `automation-detail-panel`. `popAllWithPrefix(prefix)` for future chip-deactivate call.
+
+### XTerm Re-Drive
+- **agentSession.ts** (`dashboard/src/components/sleepy/agentSession.ts`): `ensureOpen` gained `{focus?: boolean}`. New activation effect keyed `[isActive, fitVisible]` with rAF. RO gate tightened to `!expanded || !isActive`. Unmount-only teardown disposing `sessions.current`. `fitVisible()` early-returns on `!isActive` (M7 fix).
+
+### ProjectRollup
+- **agentStatus.ts** (`dashboard/src/components/sleepy/agentStatus.ts`): `rollupProject(rows): ProjectRollup` → `{worst: SessionStatusKind; live: number; waiting: number; alive: number}`. `alive` counts rows where `info.kind ∉ {'saved','ended'}` (shells included); `live` excludes shells (chat badge count). Eviction gate reads `rollup.alive === 0`, never `live`.
+
+### Verification
+- **scripts/verify/project-tabs.mjs**: runtime verification script (6/6 green against real server with isolated scratch HOME and `DREAMCONTEXT_DESKTOP=1`). Proven: vault window boots, one ProjectInstance mounts, chip renders, instance neither hidden nor inert, `.project-instance[hidden]` computes `display:none`, reload returns one project.
+
+### Wave-by-Wave Rollout
+20 tasks across 4 waves, dependency map mechanically audited (0 collisions). Wave 1 (contracts, behavior-neutral) → Wave 2 (instance shell, still one chip) → Wave 3 (global collisions, riskiest) → Wave 4 (badge + window bridge). Full plan: `_dream_context/workspace/project-tabs/plan-validated-v1.md` (838 lines).
+
+## Notes
+
+- **Multi-window escape hatch** (Shift-click) lands in a follow-up task — deliberately scoped out of this PRD to ship the core first.
+- **Runtime validation partial:** 3 of 9 runtime criteria unproven at `in_review` (B2, M-x1 terminal fitting after 5 switches, B5/B6/B7 multi-chip lifecycle). Automated validation 9/9 PASS provides strong confidence.
+- **Supersedes knowledge/desktop-beta-tauri-multivault.md** — that doc explicitly stated "multi-vault == multi-window, one shared Node server. No in-window switcher" — this PRD documents the replacement model.
+
+## Changelog
+<!-- LIFO: newest entry at top -->
+
+### 2026-08-10 - Created at in_review
+- Feature PRD created after Waves 2–4 landed (all 20 tasks done). Automated validation 9/9 PASS; runtime 6/9 proven. Status `in_review` reflects partial runtime validation — human should close remaining 3 criteria against a second registered vault + live shell session.

--- a/_dream_context/knowledge/patterns/wave-by-wave-rollout.md
+++ b/_dream_context/knowledge/patterns/wave-by-wave-rollout.md
@@ -1,0 +1,84 @@
+---
+id: knowledge_wave_by_wave_rollout
+name: wave-by-wave-rollout
+description: >-
+  When landing a large, cross-cutting change: partition the work into sequential
+  waves where each wave lands contract+behavior-neutral FIRST (the new shape
+  compiles and tests green, but acts byte-for-byte like the old one), then the
+  NEXT wave flips behavior once the contract is proven stable. Measured gates
+  between waves (tsc + tests + explicit red-line checks) catch breaking changes
+  early when blast radius is still narrow, and a late-wave failure rolls back to
+  a known-good state without tearing out foundational waves.
+type: knowledge
+tags:
+  - kind:pattern
+  - architecture
+  - topic:build
+pinned: false
+created: '2026-08-10'
+---
+
+# wave-by-wave-rollout
+
+## Why this exists
+
+Large architectural changes that touch 50+ files across multiple subsystems fail late and expensively when implemented as one atomic diff. A late-breaking defect 3 days into implementation forces either (a) tearing out foundational changes to isolate the bug, or (b) shipping the defect because unwinding is too costly. Wave-by-wave rollout partitions the work into sequential phases where each wave lands its contract + scaffolding FIRST (compiles green, tests green, acts byte-identical to the old code), then the NEXT wave flips behavior once the contract is proven stable. Measured gates between waves catch breaking changes early when blast radius is narrow, and a failure rolls back to a known-good checkpoint without losing the whole build.
+
+## The pattern
+
+1. **Partition into waves** — each wave is a semantically complete contract change (e.g., "introduce ApiClient class + useApi hook", "migrate 28 hooks off the singleton api") with a clear behavioral boundary. Waves run sequentially; no wave starts until the previous one passes its gate.
+
+2. **Contract-first, behavior-next** — Wave N lands the new shape (types, function signatures, scaffolding) in a way that compiles and tests green but acts BYTE-FOR-BYTE like the old code (e.g., the new `ApiClient` class wraps the old singleton `api`, so every call site still hits the same code path). Wave N+1 flips behavior (e.g., per-instance `ApiClient` instead of singleton).
+
+3. **Measured gates** — after each wave, run the full gate on a quiet machine: `tsc --noEmit` (both root and dashboard if applicable), `npm test`, and explicit red-line checks (e.g., `grep -rn 'forbiddenPattern'` returns zero). The gate MUST pass before the next wave starts. A failure is caught with N files changed, not 150.
+
+4. **Wave-completion evidence** — each wave logs its completion (commit SHA or session ID) and its gate result (automated checks + any manual verification). The orchestrator or review panel knows which waves are done and which are still risky.
+
+5. **Rollback-safe** — if Wave 4 fails its gate, the work rolls back to Wave 3's known-good state (revert Wave 4's changes only), diagnose, fix, and retry. The foundation (Waves 1-3) stays intact.
+
+## When to use it
+
+- Changes touching ≥50 files across ≥3 subsystems
+- Architectural refactors where the contract change and the behavior change are separable
+- Multi-reviewer builds where early waves need sign-off before later waves proceed
+- Any change where "ship it all or revert it all" is unacceptable risk
+
+## When NOT to use it
+
+- Small, focused changes (≤10 files, one subsystem) — the overhead exceeds the benefit
+- Behavior-only changes where the contract is already stable (e.g., fixing a calculation bug)
+- Throwaway prototypes or spikes — the rigor is wasted on exploratory work
+
+## Two occurrences (qualifying this as a pattern)
+
+### Occurrence 1: automations HITL architecture (2026-08-04, 5 waves)
+
+Task `automations-hitl-a-run-can-stop-and-ask-and-the-verdict-comes-back-from-wherever-you-are`. Final diff: +5021/-123 lines across 32 files.
+
+- **Wave 1** (contract root): review predicates, card-registry, approval hash grew to EIGHT fields including `review: ReviewMode`, `RUN_STATUSES` gained `awaiting-review`, types extended — but `review` reads leniently toward `off` and `off` is byte-for-byte pre-feature behavior. Zero behavior change. Gate: tsc + tests green.
+- **Wave 2** (propose verb): `propose` verb with sidecar-guarded process-group probe, three resume preambles, `resumeWithVerdict` spawn, steer→learn distillation. Gate: same.
+- **Wave 3** (runner serial gate): `awaiting-review` refusal, `backfillCardSession`, `kind: 'output'` staging, tick/show/snapshot reporting. Gate: same.
+- **Wave 4** (Telegram adapter): machine-local `~/.dreamcontext/telegram.json`, long-poll `getUpdates`, inline-keyboard verdicts. Gate: same.
+- **Wave 5** (UI surfaces): dashboard review queue, card UI, run-chat steering, clickable notification, CLI verbs. Gate: same + multi-reviewer panel (caught a Critical serialization bug before merge).
+
+### Occurrence 2: project-tabs (2026-08-09, 4 waves = 8 sub-waves)
+
+Task `one-window-holds-every-open-project-as-a-live-chip-strip`. 20 tasks partitioned into 4 waves with max 3 concurrent per wave, mechanically audited for zero file collisions.
+
+- **Wave 1 (Faz 0)**: contracts, `scopedStorage`, `ApiClient` class, `VaultContext`, tests. Behavior-neutral — the new `ApiClient` wraps the old singleton `api`. Gate: dashboard tsc CLEAN, `npm test` green, `grep 'getActiveVault'` returns only `api/client.ts`.
+- **Wave 2 (Faz 1)**: instance shell, `ProjectInstance`, `WindowChrome`, `ProjectTabs`, xterm re-drive + unmount teardown. Still one chip, but the infrastructure is live. Gate: dashboard tsc CLEAN, `npm run build` exit 0, red-line check (`grep 'isActive'` in agentSession/chatSession returns ZERO).
+- **Wave 3 (Faz 2)**: global collisions — Shell, localStorage scoping, permission split, window registry. The riskiest wave, gated hardest.
+- **Wave 4 (Faz 3)**: badge + window bridge, rollup sink, duplicate-open guard.
+
+Each wave had its own gate (A1-A9 acceptance criteria), and the orchestrator measured them on a quiet machine rather than trusting implementer reports.
+
+**Lessons from the full run (Waves 2-4, 2026-08-09 → 2026-08-10):**
+- **Ownership gaps repeat.** The dependency map derived file ownership from IMPORT graphs, missing CALL SITES. Five instances of the same gap: T11's event producers had six call sites (BrainSyncControl, SystemDependencies, DelegateComposer, authorTaskAgent, AuthorTaskComposer, AutomationDetailPanel) not in T11's lane. Each required a resume when the orchestrator caught the typecheck failure. **Lesson:** derive ownership from the full call tree, not just imports. When changing a signature, `grep -rn` for the function name and claim every call site.
+- **Parallel implementers won't cross territories, even for repo-wide errors.** T15 found T11/T12 typecheck errors mid-work and correctly STOPPED rather than editing files outside its lane. This kept the single-writer discipline but meant errors accumulated until wave-gate measurement. **Lesson:** the orchestrator MUST run the gate after each batch within a wave, not only at wave boundaries.
+- **Resume is cheaper than re-fork.** Five resume passes (T11r, T12r, T18r, T19r, T20r) each took <10 minutes and closed gaps the orchestrator found. Re-forking from scratch would have re-explained the entire plan. **Lesson:** when a task stops on an ownership gap, extend its lane in the map and resume it with the delta, not a full re-brief.
+- **A number computed for display must never be reused as a safety predicate.** M9 (CRITICAL): `ProjectRollup.live` excluded shells because it's the chat badge count, but the eviction test read `rollup.live === 0` — so a project with only a running shell (dev server) reported `live:0`, was evicted, and had its PTY killed mid-process. Fixed by adding `ProjectRollup.alive` (any live PTY/WebSocket, shells included) as the sole eviction gate. **Lesson:** display rules drift as UX evolves (e.g., "don't count shells in the badge"); safety predicates must be independent and named for their actual gate (aliveness, not liveness).
+
+## Related patterns
+
+- **feature-integration-pattern** — what to do AFTER a feature lands (wire it into all nine surfaces)
+- **byte-surgical-section-editing** — the same "preserve everything you're not changing" discipline, applied to file edits instead of build phases

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-global-shortcut": "^2.3.2",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@types/dompurify": "^3.0.5",
         "@types/three": "^0.184.1",
         "@xterm/addon-fit": "^0.10.0",
@@ -2261,6 +2262,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,6 +13,7 @@
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-global-shortcut": "^2.3.2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@types/dompurify": "^3.0.5",
     "@types/three": "^0.184.1",
     "@xterm/addon-fit": "^0.10.0",

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,156 +1,28 @@
 import { Component, useEffect, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { setActiveVault } from './api/client';
-import { useServerHealth } from './hooks/useServerHealth';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createInstanceQueryClient } from './lib/instanceQueryClient';
 import { LauncherPage } from './pages/LauncherPage';
 import { CaptureBar } from './pages/CaptureBar';
 import { SleepyPerch } from './components/sleepy/SleepyPerch';
 import { applySleepyHotkey, readSleepyConfig, initSleepyFromServer, SLEEPY_CONFIG_KEY } from './lib/sleepy';
 import { ThemeProvider } from './context/ThemeContext';
 import { I18nProvider } from './context/I18nContext';
-import { ProjectProvider } from './context/ProjectContext';
-import { Shell, type ShellNavigation } from './components/layout/Shell';
 import { UpgradeRelaunchBanner } from './components/layout/UpgradeRelaunchBanner';
 import { ProjectSwitcher } from './components/search/ProjectSwitcher';
-import { AgentSurface } from './components/sleepy/AgentSurface';
-import { TasksPage } from './pages/TasksPage';
-import { RoadmapPage } from './pages/RoadmapPage';
-import { HypothesesPage } from './pages/HypothesesPage';
-import { LabPage } from './pages/LabPage';
-import { AutomationsPage } from './pages/AutomationsPage';
-import { SleepPage } from './pages/SleepPage';
-import { CorePage } from './pages/CorePage';
-import { KnowledgePage } from './pages/KnowledgePage';
-import { BrainPage, type BrainNavigatePage } from './pages/BrainPage';
-import { CouncilPage } from './pages/CouncilPage';
-import { SettingsPage } from './pages/SettingsPage';
-import { PacksPage } from './pages/PacksPage';
-import { AboutPage } from './pages/AboutPage';
-import { TaxonomyPage } from './pages/TaxonomyPage';
-import { AnnouncementsPage } from './pages/AnnouncementsPage';
-import { AnnouncementsModal } from './components/layout/AnnouncementsModal';
+import { WindowChrome } from './components/layout/WindowChrome';
 import { ChecklistWindow } from './components/checklist/ChecklistWindow';
-import type { Page } from './components/layout/Sidebar';
 import './styles/global.css';
 
 /**
- * Version handshake against the running server process. This bundle is served
- * fresh from disk, but a long-lived server keeps its route table in memory —
- * after an upgrade it serves THIS (new) bundle with an OLD API and newer routes
- * 404 ("No route: POST /api/tasks/token"). An exact version match is the only
- * check that can't drift; the old REQUIRED_CAPABILITIES list rotted the moment
- * a route shipped without an entry. A server with no `version` field predates
- * the handshake entirely and is stale by definition. Servers ≥ this fix also
- * self-exit on upgrade (lifecycle.ts), so this banner mainly covers pre-fix
- * servers and the ≤30s window before the drift watch fires.
- */
-function StaleServerBanner() {
-  const { health, serverCurrent } = useServerHealth();
-  if (!health || serverCurrent) return null;
-  return (
-    <div className="stale-server-banner">
-      ⚠ The dashboard server is running an older build (
-      {health.version ?? 'unknown'} vs {__DC_VERSION__}) — some actions will fail.
-      Restart it: <code>dreamcontext dashboard</code>
-    </div>
-  );
-}
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5000,
-      retry: 1,
-      refetchOnWindowFocus: true,
-      // Live-update while the app stays open (sleep debt, tasks, knowledge all
-      // go stale as the agent works). Polls only when the tab is visible, and
-      // react-query's structural sharing skips re-renders when nothing changed,
-      // so this is cheap against the local server. The Header also exposes a
-      // manual refresh button for an immediate pull.
-      refetchInterval: 15_000,
-      refetchIntervalInBackground: false,
-    },
-    mutations: {
-      retry: 0,
-    },
-  },
-});
-
-/**
- * The listener half of the agent surface's "open this in the app" bridge.
+ * The window-level query cache: the launcher's project list, the server version handshake,
+ * the upgrade banner. All of it is per-SERVER or per-machine, never per-vault, so it is the
+ * one cache a window can share. Each open project gets its OWN client inside its
+ * `ProjectInstance` — see `lib/instanceQueryClient.ts` for why that separation matters.
  *
- * `AgentSurface` is mounted OUTSIDE `Shell` (so its PTY/scrollback survives navigation), which
- * leaves it with no handle on Shell's navigation state — it fires a
- * `dreamcontext-agent-open-page` window event instead. Until this existed nothing listened,
- * so the chat's "Open in app ↗" collapsed the overlay onto whatever page happened to be
- * underneath. This closes that loop, and is what makes the transcript's `task`/`knowledge`/
- * `core` action buttons actually land on the item.
- *
- * Rendered inside Shell's children, so it has `nav`; renders nothing.
+ * One client for both branches below because they are mutually exclusive: a window is either
+ * the launcher or a vault window, never both.
  */
-function AgentPageNavBridge({ nav }: { nav: ShellNavigation }) {
-  useEffect(() => {
-    const onOpen = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { page?: unknown; id?: unknown } | undefined;
-      const page = detail?.page;
-      if (page !== 'tasks' && page !== 'knowledge' && page !== 'core') return;
-      nav.navigate(page, typeof detail?.id === 'string' && detail.id ? detail.id : null);
-    };
-    window.addEventListener('dreamcontext-agent-open-page', onOpen);
-    return () => window.removeEventListener('dreamcontext-agent-open-page', onOpen);
-  }, [nav]);
-  return null;
-}
-
-function PageRouter({ nav }: { nav: ShellNavigation }) {
-  const handleBrainNavigate = (target: BrainNavigatePage, nodeId: string) => {
-    const pageMap: Record<BrainNavigatePage, Page> = {
-      tasks: 'tasks',
-      knowledge: 'knowledge',
-      core: 'core',
-    };
-    nav.navigate(pageMap[target], nodeId);
-  };
-
-  // A navigation focus target (set by the ⌘K palette and the Brain map). The
-  // `nonce` bumps on every navigate() so destination pages re-open the item even
-  // when it's the same page or the same id. Without this, pages render their
-  // default state and the navigated-to doc never opens.
-  const focus = { id: nav.focusId, nonce: nav.nonce };
-
-  switch (nav.page) {
-    case 'brain':
-      return <BrainPage onNavigate={handleBrainNavigate} />;
-    case 'tasks':
-      return <TasksPage focus={focus} />;
-    case 'roadmap':
-      return <RoadmapPage onNavigate={(page, id) => nav.navigate(page, id ?? null)} focus={focus} />;
-    case 'hypotheses':
-      return <HypothesesPage focus={focus} />;
-    case 'lab':
-      return <LabPage focus={focus} />;
-    case 'automations':
-      return <AutomationsPage />;
-    case 'sleep':
-      return <SleepPage />;
-    case 'core':
-      return <CorePage onNavigateTaxonomy={() => nav.navigate('taxonomy', null)} focus={focus} />;
-    case 'knowledge':
-      return <KnowledgePage focus={focus} />;
-    case 'council':
-      return <CouncilPage />;
-    case 'settings':
-      return <SettingsPage focus={focus} />;
-    case 'packs':
-      return <PacksPage />;
-    case 'taxonomy':
-      return <TaxonomyPage />;
-    case 'about':
-      return <AboutPage />;
-    case 'announcements':
-      return <AnnouncementsPage focus={focus} />;
-  }
-}
+const windowQueryClient = createInstanceQueryClient();
 
 interface ErrorBoundaryState {
   error: Error | null;
@@ -178,18 +50,20 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
 }
 
 /**
- * Read the `?vault=` URL param ONCE at module load and pin it as the active
- * vault before any query fires. Absent → launcher mode (render LauncherPage);
- * present → the normal vault Shell with every request carrying the vault header.
+ * Read the `?vault=` URL param ONCE at module load. Absent → launcher mode (render
+ * LauncherPage); present → the window's FIRST CHIP.
+ *
+ * It no longer pins anything globally. A window used to be one project, so the vault could be
+ * a module-level fact that every request read back out of the API client; now a window holds
+ * several live projects at once and that global would be shared state between unrelated ones.
+ * The vault travels down the tree per instance instead (`VaultProvider` → `useApi()`), and
+ * this param only decides which project the window opens WITH.
  */
 const params = new URLSearchParams(window.location.search);
 const initialVault = params.get('vault');
 const captureMode = params.get('capture') === '1';
 const perchMode = params.get('perch') === '1';
 const checklistId = params.get('checklist');
-if (initialVault) {
-  setActiveVault(initialVault);
-}
 
 /**
  * Owns the Sleepy global hotkey from the persistent launcher window. Registers on
@@ -251,7 +125,7 @@ export function App() {
   if (!initialVault) {
     return (
       <ErrorBoundary>
-        <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={windowQueryClient}>
           <ThemeProvider>
             <I18nProvider>
               <UpgradeRelaunchBanner />
@@ -265,32 +139,25 @@ export function App() {
     );
   }
 
+  /*
+   * A vault window. Everything that used to be rendered here directly — Shell, the page
+   * router, the agent surface — now belongs to a ProjectInstance, and this window may hold
+   * more than one of them. `WindowChrome` owns the chip strip and mounts them.
+   *
+   * Theme and locale sit ABOVE the chrome because they are properties of the window, not of
+   * any project in it: `ThemeProvider` writes `data-theme` onto <html> (one document, one
+   * palette), and the chrome's own `UpgradeRelaunchBanner` reads translations, so it needs a
+   * locale in scope before any instance exists.
+   */
   return (
     <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <ProjectProvider>
-          <ThemeProvider>
-            <I18nProvider>
-              <UpgradeRelaunchBanner />
-              <StaleServerBanner />
-              <Shell>
-                {(nav) => (
-                  <>
-                    <PageRouter nav={nav} />
-                    <AgentPageNavBridge nav={nav} />
-                    <AnnouncementsModal onOpenPage={(id) => nav.navigate('announcements', id ?? null)} />
-                  </>
-                )}
-              </Shell>
-              {/* Mounted ONCE, outside the page switch: the global Agent floater (a
-                  bottom-right FAB that expands to a fullscreen overlay) keeps its
-                  PTY/scrollback alive across navigation and collapse/expand. */}
-              <AgentSurface />
-              <ProjectSwitcher />
-            </I18nProvider>
-          </ThemeProvider>
-        </ProjectProvider>
-      </QueryClientProvider>
+      <ThemeProvider>
+        <QueryClientProvider client={windowQueryClient}>
+          <I18nProvider>
+            <WindowChrome initialVault={initialVault} />
+          </I18nProvider>
+        </QueryClientProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 }

--- a/dashboard/src/ProjectInstance.css
+++ b/dashboard/src/ProjectInstance.css
@@ -1,0 +1,20 @@
+/*
+ * The hiding contract for a background project — one rule, and it has to be unconditional.
+ *
+ * `hidden` is not a strong guarantee: the browser implements it as a UA stylesheet
+ * `display: none`, which ANY author rule that sets `display` on the same element silently
+ * beats. A layout rule meant for the visible instance that forgets to exclude `[hidden]`
+ * would therefore stack every open project on top of the others — and worse than the visual
+ * mess, a subtree that still computes to a real `display` keeps a live geometry: xterm
+ * re-fits itself to a size nobody is looking at, and `inert` is left as the only thing
+ * standing between a hidden project and the user's keystrokes.
+ *
+ * So the state is asserted here, with `!important`, and nothing in this file gives
+ * `.project-instance` a `display` of its own that could apply while hidden — the visible
+ * instance's layout belongs to the chrome that lays instances out (`ProjectTabs.css`'s
+ * `.window-chrome-body > *:not([hidden])`), which is exactly the shape that stays compatible
+ * with this rule.
+ */
+.project-instance[hidden] {
+  display: none !important;
+}

--- a/dashboard/src/ProjectInstance.tsx
+++ b/dashboard/src/ProjectInstance.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef } from 'react';
+import { QueryClientProvider, type QueryClient } from '@tanstack/react-query';
+import { VaultProvider, useInstanceEvent } from './context/VaultContext';
+import { ProjectProvider } from './context/ProjectContext';
+import { I18nProvider } from './context/I18nContext';
+import { createInstanceQueryClient, setInstanceActive } from './lib/instanceQueryClient';
+import { Shell, type ShellNavigation } from './components/layout/Shell';
+import { AnnouncementsModal } from './components/layout/AnnouncementsModal';
+import { AgentSurface, PROJECT_ROLLUP_EVENT } from './components/sleepy/AgentSurface';
+import type { ProjectRollup } from './components/sleepy/agentStatus';
+import { TasksPage } from './pages/TasksPage';
+import { RoadmapPage } from './pages/RoadmapPage';
+import { HypothesesPage } from './pages/HypothesesPage';
+import { LabPage } from './pages/LabPage';
+import { AutomationsPage } from './pages/AutomationsPage';
+import { SleepPage } from './pages/SleepPage';
+import { CorePage } from './pages/CorePage';
+import { KnowledgePage } from './pages/KnowledgePage';
+import { BrainPage, type BrainNavigatePage } from './pages/BrainPage';
+import { CouncilPage } from './pages/CouncilPage';
+import { SettingsPage } from './pages/SettingsPage';
+import { PacksPage } from './pages/PacksPage';
+import { AboutPage } from './pages/AboutPage';
+import { TaxonomyPage } from './pages/TaxonomyPage';
+import { AnnouncementsPage } from './pages/AnnouncementsPage';
+import type { Page } from './components/layout/Sidebar';
+import './ProjectInstance.css';
+
+/**
+ * ONE live project, mounted inside a window that may be holding several.
+ *
+ * This is the unit that used to be an entire OS window. Everything a project owns now hangs
+ * off this subtree instead of off module scope: its API client's vault, its query cache, its
+ * event bus, its agent surface and its PTYs. Two of these can be mounted side by side and
+ * share nothing.
+ *
+ * The load-bearing rule is that a background instance is HIDDEN, never unmounted. Unmounting
+ * would dispose its agent surface, which kills the WebSocket, which kills the PTY, which ends
+ * a conversation the user only meant to look away from. So `isActive` reaches exactly three
+ * things — `hidden`, `inert`, and page-data polling — and never a session, a socket or a
+ * session factory.
+ */
+
+/**
+ * The listener half of the agent surface's "open this in the app" bridge.
+ *
+ * `AgentSurface` is mounted OUTSIDE `Shell` (so its PTY/scrollback survives navigation), which
+ * leaves it with no handle on Shell's navigation state — it fires a
+ * `dreamcontext-agent-open-page` event on this instance's bus instead. Until this existed
+ * nothing listened, so the chat's "Open in app ↗" collapsed the overlay onto whatever page
+ * happened to be underneath. This closes that loop, and is what makes the transcript's
+ * `task`/`knowledge`/`core` action buttons actually land on the item.
+ *
+ * THE BUS, NOT `window`. The payload's `id` is a task/knowledge slug that exists in exactly
+ * one vault. Heard by every mounted instance, project A's "Open in app ↗" would also navigate
+ * project B's Shell to a slug B has never had — the visible result being B silently jumping
+ * to its Tasks page with nothing focused. Scoped to the bus, only the project the chat
+ * belongs to moves.
+ *
+ * Rendered inside Shell's children — so it has `nav`, and it is under this instance's
+ * `VaultProvider`, which is where `useInstanceEvent` reads the bus from. Renders nothing.
+ */
+function AgentPageNavBridge({ nav }: { nav: ShellNavigation }) {
+  useInstanceEvent<{ page?: unknown; id?: unknown } | undefined>(
+    'dreamcontext-agent-open-page',
+    (detail) => {
+      const page = detail?.page;
+      if (page !== 'tasks' && page !== 'knowledge' && page !== 'core') return;
+      nav.navigate(page, typeof detail?.id === 'string' && detail.id ? detail.id : null);
+    },
+  );
+  return null;
+}
+
+/**
+ * The forwarding half of the chip strip's signal.
+ *
+ * `AgentSurface` is the only surface that can see a project's sessions, but it has no idea it
+ * is one of several projects in a window — so it publishes a rollup on this instance's bus and
+ * says nothing about who it is. This bridge is where the rollup gets its NAME: it is mounted
+ * once per instance, closes over that instance's vault, and hands both to the chrome's sink.
+ *
+ * Rendered inside `VaultProvider`, because that is where `useInstanceEvent` reads the bus
+ * from — a hook called in `ProjectInstance`'s own body would subscribe to the off-instance
+ * fallback bus and never hear a thing. Renders nothing.
+ */
+function RollupBridge({
+  vault, onRollup,
+}: { vault: string; onRollup?: (vault: string, rollup: ProjectRollup) => void }) {
+  useInstanceEvent<ProjectRollup>(PROJECT_ROLLUP_EVENT, (rollup) => onRollup?.(vault, rollup));
+  return null;
+}
+
+function PageRouter({ nav }: { nav: ShellNavigation }) {
+  const handleBrainNavigate = (target: BrainNavigatePage, nodeId: string) => {
+    const pageMap: Record<BrainNavigatePage, Page> = {
+      tasks: 'tasks',
+      knowledge: 'knowledge',
+      core: 'core',
+    };
+    nav.navigate(pageMap[target], nodeId);
+  };
+
+  // A navigation focus target (set by the ⌘K palette and the Brain map). The
+  // `nonce` bumps on every navigate() so destination pages re-open the item even
+  // when it's the same page or the same id. Without this, pages render their
+  // default state and the navigated-to doc never opens.
+  const focus = { id: nav.focusId, nonce: nav.nonce };
+
+  switch (nav.page) {
+    case 'brain':
+      return <BrainPage onNavigate={handleBrainNavigate} />;
+    case 'tasks':
+      return <TasksPage focus={focus} />;
+    case 'roadmap':
+      return <RoadmapPage onNavigate={(page, id) => nav.navigate(page, id ?? null)} focus={focus} />;
+    case 'hypotheses':
+      return <HypothesesPage focus={focus} />;
+    case 'lab':
+      return <LabPage focus={focus} />;
+    case 'automations':
+      return <AutomationsPage />;
+    case 'sleep':
+      return <SleepPage />;
+    case 'core':
+      return <CorePage onNavigateTaxonomy={() => nav.navigate('taxonomy', null)} focus={focus} />;
+    case 'knowledge':
+      return <KnowledgePage focus={focus} />;
+    case 'council':
+      return <CouncilPage />;
+    case 'settings':
+      return <SettingsPage focus={focus} />;
+    case 'packs':
+      return <PacksPage />;
+    case 'taxonomy':
+      return <TaxonomyPage />;
+    case 'about':
+      return <AboutPage />;
+    case 'announcements':
+      return <AnnouncementsPage focus={focus} />;
+  }
+}
+
+export interface ProjectInstanceProps {
+  /** Which project this subtree IS. Every request, storage key and session it owns is bound
+   *  to this name — it is read once at mount and never changes for the life of the mount. */
+  vault: string;
+  /** Stable for this mount, never reused; namespaces anything two instances would collide on. */
+  instanceId: string;
+  /** Whether this is the chip the user is looking at. Gates visibility and polling ONLY. */
+  isActive: boolean;
+  /**
+   * Rail width, hoisted to the window: N instances each running their own `useSidebarCollapse`
+   * would diverge the moment one toggled, and two rails of different widths inside one window
+   * reads as broken. Forwarded straight to `Shell`, which no longer owns the state.
+   */
+  sidebarCollapsed: boolean;
+  onToggleSidebar: () => void;
+  /**
+   * Publishes this project's chip state (worst-of status, live conversations, how many are
+   * blocked on the user) up to the window chrome, which is what draws its chip. Optional
+   * because an instance is perfectly valid without a strip above it — it simply goes unheard.
+   */
+  onRollup?: (vault: string, rollup: ProjectRollup) => void;
+}
+
+export function ProjectInstance({
+  vault, instanceId, isActive, sidebarCollapsed, onToggleSidebar, onRollup,
+}: ProjectInstanceProps) {
+  /*
+   * Both of these are per-instance identities that must survive every re-render: a new
+   * QueryClient would drop the project's whole cache mid-session, and a new EventTarget would
+   * silently orphan every listener already subscribed to the old one. Lazily initialised
+   * through a ref rather than `useRef(create())`, which would construct (and throw away) a
+   * fresh client on every single render.
+   */
+  const clientRef = useRef<QueryClient | null>(null);
+  if (clientRef.current === null) clientRef.current = createInstanceQueryClient();
+  const queryClient = clientRef.current;
+
+  const busRef = useRef<EventTarget | null>(null);
+  if (busRef.current === null) busRef.current = new EventTarget();
+  const bus = busRef.current;
+
+  // Page-data polling follows visibility. Nothing else does — see this file's header.
+  useEffect(() => {
+    setInstanceActive(queryClient, isActive);
+  }, [queryClient, isActive]);
+
+  return (
+    /*
+     * `hidden` + `inert` is the whole hiding mechanism, and both halves are needed: `hidden`
+     * (backed by the `!important` rule in ProjectInstance.css) takes the subtree out of layout
+     * so nothing measures or paints it, and `inert` takes it out of the focus and interaction
+     * order so a keystroke meant for the visible project can never land in a hidden one.
+     */
+    <div
+      className="project-instance"
+      data-instance={instanceId}
+      hidden={!isActive}
+      inert={!isActive}
+    >
+      <QueryClientProvider client={queryClient}>
+        <VaultProvider vault={vault} instanceId={instanceId} isActive={isActive} bus={bus}>
+          <ProjectProvider>
+            <I18nProvider>
+              <Shell sidebarCollapsed={sidebarCollapsed} onToggleSidebar={onToggleSidebar}>
+                {(nav) => (
+                  <>
+                    <PageRouter nav={nav} />
+                    <AgentPageNavBridge nav={nav} />
+                    <AnnouncementsModal onOpenPage={(id) => nav.navigate('announcements', id ?? null)} />
+                  </>
+                )}
+              </Shell>
+              {/* BEFORE `AgentSurface`, and that is not cosmetic. Sibling effects are flushed
+                  in tree order, so this subscribes to the bus before the surface's first
+                  publish fires — mounted after it, the opening rollup would be emitted into
+                  an empty bus and dropped. The chrome would then hold `rollup: null` for a
+                  project that had already said what it was doing: its badge would sit blank
+                  until the next status flip, and the ceiling would refuse to evict it. */}
+              <RollupBridge vault={vault} onRollup={onRollup} />
+              {/* Mounted OUTSIDE Shell, exactly as it was at the app root: the agent floater
+                  keeps its PTY/scrollback alive across navigation and collapse/expand, which
+                  only holds while it is not remounted by the page switch. */}
+              <AgentSurface />
+            </I18nProvider>
+          </ProjectProvider>
+        </VaultProvider>
+      </QueryClientProvider>
+    </div>
+  );
+}

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -18,13 +18,17 @@ export class RequestError extends Error {
 }
 
 /**
- * The vault this window is pinned to. Set once at boot from the `?vault=` URL
- * param (see setActiveVault). When present it is forwarded on every request as
- * the X-Dreamcontext-Vault header, which the server resolves per-request to the
- * matching context root. Null in launcher mode (no vault pinned).
+ * The vault this WINDOW was pinned to at boot.
+ *
+ * @deprecated Legacy single-vault state. One window now holds N live projects, so the vault
+ * is a property of the CLIENT (`new ApiClient(vault)`), not of the module — see
+ * `context/VaultContext.tsx`'s `useApi()`. This variable exists solely to keep the two
+ * deprecated accessors below working while the call sites migrate; it is deleted, together
+ * with them, at the end of Faz 2. Nothing else in this module reads it.
  */
 let activeVault: string | null = null;
 
+/** @deprecated Removed at the end of Faz 2 — construct an `ApiClient` with the vault instead. */
 export function setActiveVault(v: string | null): void {
   activeVault = v;
 }
@@ -33,6 +37,8 @@ export function setActiveVault(v: string | null): void {
  * The pinned vault name, for callers that can't use the header — notably the
  * agent-terminal WebSocket (the browser WS API can't set request headers), which
  * carries the vault as a `?vault=<name>` query param instead.
+ *
+ * @deprecated Removed at the end of Faz 2 — take the vault from `useVault()` and thread it.
  */
 export function getActiveVault(): string | null {
   return activeVault;
@@ -48,13 +54,18 @@ export function getActiveVault(): string | null {
  * `no_vault`, and the transcript showed a can't-load card for a file sitting right there.
  * Anything that reaches the file endpoint as an element `src` must be built here.
  *
+ * Deliberately a MODULE FUNCTION taking the vault, not an `ApiClient` method: two of its
+ * callers are pure, non-React helpers (`chatEntities.ts`'s `rawUrl`, `PageView.tsx`'s
+ * `resolveImage`) that render markdown and have no business holding a client just to read
+ * one scalar. Same one-parameter shape as `uploadAgentFile`/`mintPromptToken` — one pattern.
+ *
  * `raw` asks for the bytes (range-streamed, so video seeks); without it the endpoint
  * answers the JSON text preview that `api.get` reads.
  */
-export function agentFileUrl(path: string, opts: { raw?: boolean } = {}): string {
+export function agentFileUrl(vault: string | null, path: string, opts: { raw?: boolean } = {}): string {
   const raw = opts.raw ? '&raw=1' : '';
-  const vault = activeVault ? `&vault=${encodeURIComponent(activeVault)}` : '';
-  return `${BASE_URL}/agent/file?path=${encodeURIComponent(path)}${raw}${vault}`;
+  const scope = vault ? `&vault=${encodeURIComponent(vault)}` : '';
+  return `${BASE_URL}/agent/file?path=${encodeURIComponent(path)}${raw}${scope}`;
 }
 
 /**
@@ -68,20 +79,32 @@ export function agentFileUrl(path: string, opts: { raw?: boolean } = {}): string
  * distilled from is a vault file being read by a vault page, so it belongs here — routing it
  * through the chat surface's endpoint would answer "desktop only" outside the app.
  */
-export function graphContentUrl(path: string, opts: { raw?: boolean } = {}): string {
+export function graphContentUrl(vault: string | null, path: string, opts: { raw?: boolean } = {}): string {
   const raw = opts.raw ? '&raw=1' : '';
-  const vault = activeVault ? `&vault=${encodeURIComponent(activeVault)}` : '';
-  return `${BASE_URL}/graph/content?path=${encodeURIComponent(path)}${raw}${vault}`;
+  const scope = vault ? `&vault=${encodeURIComponent(vault)}` : '';
+  return `${BASE_URL}/graph/content?path=${encodeURIComponent(path)}${raw}${scope}`;
 }
 
-class ApiClient {
+/**
+ * One project's view of the local API. The vault is bound at CONSTRUCTION and forwarded on
+ * every request as `X-Dreamcontext-Vault`, which the server resolves per-request to that
+ * project's context root.
+ *
+ * Per-instance rather than a module singleton because one window now hosts several live
+ * projects at once: a module-level "active vault" would make every in-flight request race
+ * whichever chip the user touched last. Components get theirs from `useApi()`; the `null`
+ * client below is the launcher/browser case, where no project is pinned.
+ */
+export class ApiClient {
+  constructor(private readonly vault: string | null) {}
+
   private async request<T>(path: string, options?: RequestInit): Promise<T> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...(options?.headers as Record<string, string> | undefined),
     };
-    if (activeVault) {
-      headers['X-Dreamcontext-Vault'] = activeVault;
+    if (this.vault) {
+      headers['X-Dreamcontext-Vault'] = this.vault;
     }
     const res = await fetch(`${BASE_URL}${path}`, {
       ...options,
@@ -135,4 +158,9 @@ class ApiClient {
   }
 }
 
-export const api = new ApiClient();
+/**
+ * The unpinned client — no vault header, so the server answers for its own pinned root.
+ * This is what the launcher, the capture bar, the perch and the checklist window use (and
+ * what `useApi()` returns outside a `VaultProvider`), which is why it must stay exported.
+ */
+export const api = new ApiClient(null);

--- a/dashboard/src/components/automations/AutomationDetailPanel.tsx
+++ b/dashboard/src/components/automations/AutomationDetailPanel.tsx
@@ -6,8 +6,10 @@ import {
   useAutomationSession,
   useRunAutomation,
 } from '../../hooks/useAutomations';
-import { requestAutomationRunChat, runChatUnavailableReason } from '../../lib/automationRunChat';
+import { openAutomationRunChat, runChatUnavailableReason } from '../../lib/automationRunChat';
+import { useVault } from '../../context/VaultContext';
 import { pushOverlay, popOverlay, isTopOverlay } from '../../lib/overlayStack';
+import { useOverlayId } from '../../lib/useOverlayId';
 import './AutomationDetailPanel.css';
 
 /**
@@ -146,6 +148,7 @@ function RunHandoff({
   onBack: () => void;
   onOpened: () => void;
 }) {
+  const { bus } = useVault();
   const { data: session, isLoading, isError } = useAutomationSession(slug, runNumber);
   /** One dispatch per hand-off. The query re-delivers its (cached) data on every render of
    *  this panel, and a second dispatch would ask the surface to reopen a tab it just
@@ -158,7 +161,7 @@ function RunHandoff({
     const reason = runChatUnavailableReason(session, pendingReviewCardId);
     if (reason) { setRefused(reason); return; }
     sentRef.current = true;
-    const accepted = requestAutomationRunChat({
+    const accepted = openAutomationRunChat(bus, {
       slug,
       automationTitle,
       runNumber,
@@ -207,14 +210,14 @@ export function AutomationDetailPanel({ summary, runningSlug, onClose, onToast }
   const detail = useAutomation(summary.slug);
   const runNow = useRunAutomation();
   const approve = useApproveAutomation();
+  const overlayId = useOverlayId('automation-detail-panel');
   /** Which run's session is open, 1-based newest-first. Null = the history list. */
   const [openSession, setOpenSession] = useState<number | null>(null);
 
   useEffect(() => {
-    const id = 'automation-detail-panel';
-    pushOverlay(id);
+    pushOverlay(overlayId);
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || !isTopOverlay(id)) return;
+      if (e.key !== 'Escape' || !isTopOverlay(overlayId)) return;
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT')) {
         target.blur();
@@ -227,9 +230,9 @@ export function AutomationDetailPanel({ summary, runningSlug, onClose, onToast }
     window.addEventListener('keydown', onKey, true);
     return () => {
       window.removeEventListener('keydown', onKey, true);
-      popOverlay(id);
+      popOverlay(overlayId);
     };
-  }, [onClose]);
+  }, [onClose, overlayId]);
 
   const automation = detail.data?.automation ?? null;
   const approved = detail.data?.approved ?? summary.approved;

--- a/dashboard/src/components/brain/BrainSyncControl.tsx
+++ b/dashboard/src/components/brain/BrainSyncControl.tsx
@@ -10,8 +10,9 @@ import {
   type ScrubBlock,
 } from '../../hooks/useBrainStatus';
 import { useAgentCapabilities, isSleepAgentReady } from '../../hooks/useAgentCapabilities';
+import { useVault } from '../../context/VaultContext';
 import { readAgentSettings } from '../../lib/agentSettings';
-import { requestBrainResolveAgent, DREAM_SYNC_COMMAND } from '../../lib/brainResolveAgent';
+import { runBrainResolveAgent, DREAM_SYNC_COMMAND } from '../../lib/brainResolveAgent';
 import { readAutoCheckpointOnOpen } from '../../lib/brainSyncPrefs';
 import './BrainSyncControl.css';
 
@@ -54,6 +55,7 @@ interface BrainSyncControlProps {
 
 export function BrainSyncControl({ onOpenSettings }: BrainSyncControlProps) {
   const { t } = useI18n();
+  const { vault, bus } = useVault();
   const { data: brainStatus } = useBrainStatus();
   const { data: caps } = useAgentCapabilities();
   const runSync = useRunBrainSync();
@@ -156,13 +158,13 @@ export function BrainSyncControl({ onOpenSettings }: BrainSyncControlProps) {
   useEffect(() => {
     if (autoSyncedRef.current) return;
     autoSyncedRef.current = true;
-    runSyncWithFeedback('pull-only', { silentNoop: true, noCheckpoint: !readAutoCheckpointOnOpen() });
+    runSyncWithFeedback('pull-only', { silentNoop: true, noCheckpoint: !readAutoCheckpointOnOpen(vault) });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleResolveClick = () => {
     if (canRunAgent) {
-      requestBrainResolveAgent();
+      runBrainResolveAgent(bus);
       showFeedback({ kind: 'ok', message: t('brain.resolve.launching') });
       setFallbackOpen(false);
     } else {

--- a/dashboard/src/components/lab/InsightDetailPanel.tsx
+++ b/dashboard/src/components/lab/InsightDetailPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { InsightSummary, SyncEvent } from '../../hooks/useLab';
 import { useLabInsight, useSyncInsight, useUpdateTweaks } from '../../hooks/useLab';
 import { pushOverlay, popOverlay, isTopOverlay } from '../../lib/overlayStack';
+import { useOverlayId } from '../../lib/useOverlayId';
 import { TweakEditor } from './TweakEditor';
 import { RangeControl, nonWindowTweaks } from './RangeControl';
 import { chartEntry, detailBodyFor } from './chartRegistry';
@@ -72,15 +73,15 @@ export function InsightDetailPanel({ summary, onClose, onToast }: Props) {
   const sync = useSyncInsight();
   const updateTweaks = useUpdateTweaks();
   const { locale } = useI18n();
+  const overlayId = useOverlayId('insight-detail-panel');
 
   // Esc closes — but only when this panel is the topmost overlay (overlayStack,
   // same contract as CommandModal) and never while the user is typing in a form
   // field (Esc there dismisses the field, not the panel with their unsaved edits).
   useEffect(() => {
-    const id = 'insight-detail-panel';
-    pushOverlay(id);
+    pushOverlay(overlayId);
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || !isTopOverlay(id)) return;
+      if (e.key !== 'Escape' || !isTopOverlay(overlayId)) return;
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT')) {
         target.blur();
@@ -93,9 +94,9 @@ export function InsightDetailPanel({ summary, onClose, onToast }: Props) {
     window.addEventListener('keydown', onKey, true);
     return () => {
       window.removeEventListener('keydown', onKey, true);
-      popOverlay(id);
+      popOverlay(overlayId);
     };
-  }, [onClose]);
+  }, [onClose, overlayId]);
 
   const manifest = detail.data?.insight ?? null;
   const cache = detail.data?.cache ?? null;

--- a/dashboard/src/components/lab/funnel/labRoute.ts
+++ b/dashboard/src/components/lab/funnel/labRoute.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { emitInstance, useInstanceEvent, useVault } from '../../../context/VaultContext';
 
 /**
  * Multi-page insight routing (A2) — the minimal contract a render kind can
@@ -12,6 +13,13 @@ import { useCallback, useEffect, useState } from 'react';
  * STRING so `?vault=` and `?page=` survive untouched; back/forward work via
  * real history entries + popstate. `funnel` is the only adopter today — a
  * future table/cohort-grid insight reuses this module, not a new framework.
+ *
+ * ONE ADDRESS BAR, N LIVE PROJECTS. A window now holds several projects at once (the chip
+ * strip), and there is still exactly one URL. So the address bar is an owned resource: the
+ * instance the user is looking at holds it, and every other instance PARKS its route in
+ * memory instead of stamping it over the visible project's. Parking is not a downgrade —
+ * a parked route is restored to the real URL the moment that chip comes forward, which is
+ * what makes "switch away and come back" land you where you left.
  */
 
 export interface LabRoute {
@@ -19,8 +27,79 @@ export interface LabRoute {
   funnelId: string | null;
 }
 
-/** Fired after our own pushState/replaceState (popstate only covers back/forward). */
+/**
+ * Fired after our own pushState/replaceState (popstate only covers back/forward), on the
+ * INSTANCE bus rather than `window`: on `window` every mounted project re-reads the one URL
+ * whenever ANY project navigates, so opening a funnel in the foreground would yank three
+ * background Lab pages onto a slug that does not exist in their vault.
+ */
 const NAV_EVENT = 'dc-lab-route';
+
+/**
+ * The bus of the instance that currently owns the window's address bar, or null when nobody
+ * has claimed it (boot before the first Lab page mounts, the launcher, tests). Identity is
+ * the bus rather than a bare boolean so a release can be REFUSED: on a chip switch React runs
+ * every cleanup before every effect body, but even if that order ever changed, the outgoing
+ * instance's `setLabRouteWritable(false)` cannot unseat the incoming one — it is not the
+ * owner by then, so it is ignored.
+ */
+let urlOwner: EventTarget | null = null;
+
+/**
+ * Where each non-owning instance would be if it held the address bar, as a `pathname+search`
+ * string. Keyed by the instance bus and weak, so a closed chip's route is collected with it.
+ */
+const parkedRoutes = new WeakMap<EventTarget, string>();
+
+/**
+ * May this caller read and write the real URL?
+ *
+ * An ABSENT bus reads as "yes" on purpose. `pushLabPath` is also called from surfaces this
+ * module cannot hand a bus to (`LabBoard`, `FunnelOverviewPage`), and every one of those call
+ * sites is a click handler — a background instance is `hidden` + `inert`, so it takes no
+ * pointer events and no focus, and a click is therefore proof that the caller IS the
+ * foreground instance. See the note on `pushLabPath`.
+ */
+function ownsUrl(bus: EventTarget | undefined): boolean {
+  return bus === undefined || urlOwner === null || urlOwner === bus;
+}
+
+/** This instance's location — the live URL when it owns the address bar, its parked route otherwise. */
+function currentTarget(bus: EventTarget | undefined): string {
+  if (ownsUrl(bus)) return window.location.pathname + window.location.search;
+  return parkedRoutes.get(bus as EventTarget) ?? '/';
+}
+
+function splitTarget(target: string): { pathname: string; search: string } {
+  const i = target.indexOf('?');
+  return i === -1
+    ? { pathname: target, search: '' }
+    : { pathname: target.slice(0, i), search: target.slice(i) };
+}
+
+function notify(bus: EventTarget | null | undefined): void {
+  if (bus) emitInstance(bus, NAV_EVENT);
+}
+
+/**
+ * The single place a lab route is committed. The owner writes real history; everyone else
+ * parks the same string in memory and tells only its own hooks — which is the whole reason a
+ * background project can keep coherent React state without touching the visible URL.
+ */
+function commit(target: string, mode: 'push' | 'replace', bus: EventTarget | undefined): void {
+  if (ownsUrl(bus)) {
+    if (window.location.pathname + window.location.search === target) return;
+    if (mode === 'push') window.history.pushState(null, '', target);
+    else window.history.replaceState(null, '', target);
+    // With no bus passed, the click came from the foreground instance — notify the owner.
+    notify(bus ?? urlOwner);
+    return;
+  }
+  const parked = bus as EventTarget;
+  if ((parkedRoutes.get(parked) ?? '/') === target) return;
+  parkedRoutes.set(parked, target);
+  notify(parked);
+}
 
 export function parseLabPath(pathname: string): LabRoute {
   const m = /^\/lab\/([^/]+)(?:\/f\/([^/]+))?\/?$/.exec(pathname);
@@ -39,70 +118,114 @@ export function labPath(slug: string | null, funnelId: string | null): string {
     : `/lab/${encodeURIComponent(slug)}`;
 }
 
-function notify(): void {
-  window.dispatchEvent(new Event(NAV_EVENT));
-}
-
-/** Push a new lab location (path change = a history entry the Back button pops). */
-export function pushLabPath(slug: string | null, funnelId: string | null): void {
-  const target = labPath(slug, funnelId) + window.location.search;
-  if (window.location.pathname + window.location.search === target) return;
-  window.history.pushState(null, '', target);
-  notify();
+/**
+ * Push a new lab location (path change = a history entry the Back button pops).
+ *
+ * `bus` is optional ONLY because two click-driven callers outside this module's reach
+ * (`LabBoard`, `FunnelOverviewPage`) cannot pass one; omitting it means "I am the foreground
+ * instance", which a click proves. Anything that can fire without a click — an effect, a
+ * timer, a message — MUST pass its bus, or it will write over the visible project's URL.
+ */
+export function pushLabPath(slug: string | null, funnelId: string | null, bus?: EventTarget): void {
+  commit(labPath(slug, funnelId) + splitTarget(currentTarget(bus)).search, 'push', bus);
 }
 
 /** Replace the current query string (view-state edits don't spam history). */
-export function replaceSearch(params: URLSearchParams): void {
+export function replaceSearch(params: URLSearchParams, bus?: EventTarget): void {
   const search = params.toString();
-  const target = window.location.pathname + (search ? `?${search}` : '');
-  if (window.location.pathname + window.location.search === target) return;
-  window.history.replaceState(null, '', target);
-  notify();
+  commit(splitTarget(currentTarget(bus)).pathname + (search ? `?${search}` : ''), 'replace', bus);
 }
 
 /** Reset the path to `/` (keeps the query) — used when leaving the Lab page. */
-export function clearLabPath(): void {
-  if (window.location.pathname === '/') return;
-  window.history.replaceState(null, '', '/' + window.location.search);
-  notify();
+export function clearLabPath(bus?: EventTarget): void {
+  commit('/' + splitTarget(currentTarget(bus)).search, 'replace', bus);
 }
 
-/** The absolute deep link for the CURRENT location (copy-link actions). */
-export function currentDeepLink(): string {
-  return window.location.href;
+/** The absolute deep link for THIS instance's current location (copy-link actions). */
+export function currentDeepLink(bus?: EventTarget): string {
+  return window.location.origin + currentTarget(bus);
+}
+
+/**
+ * Claim or release the window's address bar for one instance.
+ *
+ * Releasing parks where this instance was (so coming back restores it) and hands the path
+ * back to `/`, keeping the query string — the same reset `clearLabPath` does when you leave
+ * the Lab page, and for the same reason: a reload must not resurrect this project's funnel
+ * page underneath whichever project is showing.
+ */
+export function setLabRouteWritable(on: boolean, bus: EventTarget): void {
+  if (on) {
+    urlOwner = bus;
+    return;
+  }
+  if (urlOwner !== bus) return; // already superseded — a stale release must not unseat the new owner
+  parkedRoutes.set(bus, window.location.pathname + window.location.search);
+  urlOwner = null;
+  if (window.location.pathname !== '/') {
+    window.history.replaceState(null, '', '/' + window.location.search);
+  }
+}
+
+/**
+ * Restore the owning instance's parked route to the real URL — called when a chip comes
+ * forward. `replaceState`, not `pushState`: bringing a project back into view is not a
+ * navigation the Back button should have to step through.
+ */
+export function flushBufferedRoute(): void {
+  const bus = urlOwner;
+  if (!bus) return;
+  const parked = parkedRoutes.get(bus);
+  if (parked === undefined) return;
+  parkedRoutes.delete(bus);
+  if (window.location.pathname + window.location.search === parked) return;
+  window.history.replaceState(null, '', parked);
+  notify(bus);
+}
+
+/**
+ * Back/forward is genuinely a WINDOW gesture — the browser owns it, so the listener stays on
+ * `window`. Only the instance holding the address bar reacts, because a popstate describes
+ * that instance's history and nobody else's. Checked at event time rather than in the
+ * dependency array so a change of owner never needs a resubscribe.
+ */
+function usePopstate(bus: EventTarget, reread: () => void): void {
+  useEffect(() => {
+    const onPop = () => {
+      if (ownsUrl(bus)) reread();
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, [bus, reread]);
 }
 
 /** Live view of the lab route (path segments). Re-renders on push/pop. */
 export function useLabRoute(): LabRoute {
-  const [route, setRoute] = useState<LabRoute>(() => parseLabPath(window.location.pathname));
-  useEffect(() => {
-    const onChange = () => setRoute(parseLabPath(window.location.pathname));
-    window.addEventListener('popstate', onChange);
-    window.addEventListener(NAV_EVENT, onChange);
-    return () => {
-      window.removeEventListener('popstate', onChange);
-      window.removeEventListener(NAV_EVENT, onChange);
-    };
-  }, []);
+  const { bus } = useVault();
+  const [route, setRoute] = useState<LabRoute>(() => parseLabPath(splitTarget(currentTarget(bus)).pathname));
+  const reread = useCallback(
+    () => setRoute(parseLabPath(splitTarget(currentTarget(bus)).pathname)),
+    [bus],
+  );
+  useInstanceEvent(NAV_EVENT, reread);
+  usePopstate(bus, reread);
   return route;
 }
 
 /** Live view of the query string + an updater that preserves foreign params. */
 export function useLabSearchParams(): [URLSearchParams, (mutate: (params: URLSearchParams) => void) => void] {
-  const [params, setParams] = useState(() => new URLSearchParams(window.location.search));
-  useEffect(() => {
-    const onChange = () => setParams(new URLSearchParams(window.location.search));
-    window.addEventListener('popstate', onChange);
-    window.addEventListener(NAV_EVENT, onChange);
-    return () => {
-      window.removeEventListener('popstate', onChange);
-      window.removeEventListener(NAV_EVENT, onChange);
-    };
-  }, []);
+  const { bus } = useVault();
+  const [params, setParams] = useState(() => new URLSearchParams(splitTarget(currentTarget(bus)).search));
+  const reread = useCallback(
+    () => setParams(new URLSearchParams(splitTarget(currentTarget(bus)).search)),
+    [bus],
+  );
+  useInstanceEvent(NAV_EVENT, reread);
+  usePopstate(bus, reread);
   const update = useCallback((mutate: (params: URLSearchParams) => void) => {
-    const next = new URLSearchParams(window.location.search);
+    const next = new URLSearchParams(splitTarget(currentTarget(bus)).search);
     mutate(next);
-    replaceSearch(next);
-  }, []);
+    replaceSearch(next, bus);
+  }, [bus]);
   return [params, update];
 }

--- a/dashboard/src/components/layout/AnnouncementsModal.tsx
+++ b/dashboard/src/components/layout/AnnouncementsModal.tsx
@@ -4,9 +4,8 @@ import { useAnnouncementInbox } from '../../hooks/useAnnouncements';
 import { formatVersion, readSeenIds, unreadAnnouncements, type Announcement } from '../../lib/announcements';
 import { AnnouncementStoryTeaser } from '../announcements/AnnouncementStoryTeaser';
 import { pushOverlay, popOverlay, isTopOverlay } from '../../lib/overlayStack';
+import { useOverlayId } from '../../lib/useOverlayId';
 import './AnnouncementsModal.css';
-
-const OVERLAY_ID = 'announcements-modal';
 
 interface Props {
   /**
@@ -44,6 +43,7 @@ interface Props {
  */
 export function AnnouncementsModal({ onOpenPage }: Props) {
   const { t } = useI18n();
+  const overlayId = useOverlayId('announcements-modal');
   const { unread, loading, markAllRead } = useAnnouncementInbox();
   const dismissed = useRef(false);
   // One-way latch for the pin effect below. Idempotency invariant: the
@@ -102,9 +102,9 @@ export function AnnouncementsModal({ onOpenPage }: Props) {
   // components gate on their `open` prop.
   useEffect(() => {
     if (!show) return;
-    pushOverlay(OVERLAY_ID);
+    pushOverlay(overlayId);
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || !isTopOverlay(OVERLAY_ID)) return;
+      if (e.key !== 'Escape' || !isTopOverlay(overlayId)) return;
       e.preventDefault();
       e.stopImmediatePropagation();
       dismiss();
@@ -112,9 +112,9 @@ export function AnnouncementsModal({ onOpenPage }: Props) {
     window.addEventListener('keydown', onKey, true);
     return () => {
       window.removeEventListener('keydown', onKey, true);
-      popOverlay(OVERLAY_ID);
+      popOverlay(overlayId);
     };
-  }, [show, dismiss]);
+  }, [show, dismiss, overlayId]);
 
   if (!show || !hero) return null;
 

--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -1,44 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useTheme } from '../../context/ThemeContext';
-import { startTitleBarDrag, toggleMaximizeWindow } from '../../lib/desktop';
+import { useVault } from '../../context/VaultContext';
 import { SearchIcon } from '../sleepy/TypeIcons';
 import { UpdateBadge } from './UpdateBadge';
 import { SleepDebtTracker } from './SleepDebtTracker';
 import type { Page } from './Sidebar';
 import './Header.css';
-
-const ZOOM_LEVELS = [0.85, 0.9, 1.0, 1.1, 1.2];
-const ZOOM_STORAGE_KEY = 'dreamcontext-zoom';
-
-function getStoredZoom(): number {
-  try {
-    const stored = localStorage.getItem(ZOOM_STORAGE_KEY);
-    if (stored !== null) {
-      const val = parseFloat(stored);
-      if (ZOOM_LEVELS.includes(val)) return val;
-    }
-  } catch { /* ignore */ }
-  return 1.0;
-}
-
-function applyZoom(zoom: number) {
-  document.documentElement.style.setProperty('--zoom', String(zoom));
-  // Broadcast so surfaces that don't read CSS font tokens can react — notably the
-  // embedded Agent terminal, whose xterm font size is set imperatively in JS and
-  // would otherwise ignore app zoom entirely.
-  window.dispatchEvent(new CustomEvent('dreamcontext-zoom', { detail: zoom }));
-}
-
-/** Active vault display name (passed by the launcher via `?vault=`). */
-function readVaultLabel(): string {
-  if (typeof window === 'undefined') return '';
-  try {
-    return new URLSearchParams(window.location.search).get('vault') ?? '';
-  } catch {
-    return '';
-  }
-}
 
 interface HeaderProps {
   /** Switch the active page (used by the update badge to open Packs). */
@@ -52,17 +19,21 @@ interface HeaderProps {
 }
 
 /**
- * Title bar. Mirrors the design: a sidebar toggle on the left, the active vault
- * name centered, and utility controls on the right. The brand wordmark lives
- * ONLY in the sidebar lockup now — the header no longer repeats it.
+ * One PROJECT's header — a sidebar toggle and the search pill on the left, that project's
+ * own status controls on the right.
+ *
+ * It is no longer the title bar, and it no longer says which project it belongs to. One
+ * window now holds several projects at once, so both of those became window-level jobs and
+ * moved to `WindowChrome`: the chip strip names the projects, and the zoom control, the
+ * theme toggle and the drag/maximize gestures belong to the window that contains them all.
+ * What stays here is what is genuinely per-vault — this project's sleep debt, this project's
+ * refresh, this project's update badge — because N of them are mounted at once and each must
+ * answer for its own vault.
  */
 export function Header({ onNavigate, sidebarCollapsed, onToggleSidebar, onOpenSearch }: HeaderProps) {
-  const { theme, setTheme, resolved } = useTheme();
   const queryClient = useQueryClient();
-  const [zoom, setZoom] = useState(getStoredZoom);
+  const { isActive } = useVault();
   const [refreshing, setRefreshing] = useState(false);
-
-  const vaultLabel = readVaultLabel();
 
   // Manual refresh: pull every active query at once (sleep debt, tasks,
   // knowledge, …). Queries also poll on an interval, but this gives an
@@ -76,45 +47,8 @@ export function Header({ onNavigate, sidebarCollapsed, onToggleSidebar, onOpenSe
     }
   };
 
-  useEffect(() => {
-    applyZoom(zoom);
-  }, [zoom]);
-
-  const cycleTheme = () => {
-    const next = theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system';
-    setTheme(next);
-  };
-
-  const themeLabel = theme === 'system' ? `System (${resolved})` : resolved === 'dark' ? 'Dark' : 'Light';
-
-  const zoomIndex = ZOOM_LEVELS.indexOf(zoom);
-  const canZoomOut = zoomIndex > 0;
-  const canZoomIn = zoomIndex < ZOOM_LEVELS.length - 1;
-
-  const changeZoom = (delta: -1 | 1) => {
-    const nextIndex = zoomIndex + delta;
-    if (nextIndex < 0 || nextIndex >= ZOOM_LEVELS.length) return;
-    const next = ZOOM_LEVELS[nextIndex];
-    setZoom(next);
-    try { localStorage.setItem(ZOOM_STORAGE_KEY, String(next)); } catch { /* ignore */ }
-  };
-
   return (
-    <header
-      className="header"
-      // NOTE: deliberately NO `data-tauri-drag-region`. That attribute injects
-      // Tauri's OWN drag + double-click-maximize handlers, and the dblclick →
-      // toggleMaximize part fires even with `dragDropEnabled: false` — competing
-      // with our handler (and macOS native zoom) and flickering the window
-      // between maximized/restored. We remove it and own both gestures in JS.
-      //
-      // Drag: start ONLY after the pointer moves past a small threshold, so plain
-      // clicks and double-clicks are NOT forwarded to the native window (which
-      // would trigger native zoom on top of ours). Maximize is our single,
-      // deterministic onDoubleClick below.
-      onMouseDown={startTitleBarDrag}
-      onDoubleClick={(e) => void toggleMaximizeWindow(e.target)}
-    >
+    <header className="header">
       <div className="header-left">
         <button
           className="header-icon-btn"
@@ -145,14 +79,12 @@ export function Header({ onNavigate, sidebarCollapsed, onToggleSidebar, onOpenSe
         </button>
       </div>
 
-      {vaultLabel && <div className="header-vault" title={vaultLabel}>{vaultLabel}</div>}
-
       <div className="header-right">
         <SleepDebtTracker onOpen={onNavigate ? () => onNavigate('sleep') : undefined} />
         <button
           className={`header-refresh ${refreshing ? 'header-refresh--spinning' : ''}`}
           onClick={refreshAll}
-          disabled={refreshing}
+          disabled={refreshing || !isActive}
           title="Refresh now"
           aria-label="Refresh now"
         >
@@ -162,22 +94,6 @@ export function Header({ onNavigate, sidebarCollapsed, onToggleSidebar, onOpenSe
           </svg>
         </button>
         <UpdateBadge onManagePacks={onNavigate ? () => onNavigate('packs') : undefined} />
-        <div className="zoom-controls">
-          <button className="zoom-btn" onClick={() => changeZoom(-1)} disabled={!canZoomOut} title="Zoom out">-</button>
-          <span className="zoom-label">{Math.round(zoom * 100)}%</span>
-          <button className="zoom-btn" onClick={() => changeZoom(1)} disabled={!canZoomIn} title="Zoom in">+</button>
-        </div>
-        <button className="theme-toggle" onClick={cycleTheme} title={`Theme: ${themeLabel}`}>
-          {resolved === 'dark' ? (
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M8 1a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 1zm0 10a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 11zm7-3a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 15 8zM5 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 5 8zm7.07-4.07a.5.5 0 0 1 0 .71l-1.41 1.41a.5.5 0 1 1-.71-.71l1.41-1.41a.5.5 0 0 1 .71 0zM6.05 10.66a.5.5 0 0 1 0 .71l-1.41 1.41a.5.5 0 0 1-.71-.71l1.41-1.41a.5.5 0 0 1 .71 0zm7.72 3.12a.5.5 0 0 1-.71 0l-1.41-1.41a.5.5 0 1 1 .71-.71l1.41 1.41a.5.5 0 0 1 0 .71zM5.34 6.05a.5.5 0 0 1-.71 0L3.22 4.64a.5.5 0 0 1 .71-.71l1.41 1.41a.5.5 0 0 1 0 .71zM8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8z" />
-            </svg>
-          ) : (
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z" />
-            </svg>
-          )}
-        </button>
       </div>
     </header>
   );

--- a/dashboard/src/components/layout/ProjectTabs.css
+++ b/dashboard/src/components/layout/ProjectTabs.css
@@ -1,0 +1,564 @@
+/*
+ * The window-level chrome: the title bar that now belongs to the WINDOW rather than to any
+ * one project, and the centred chip strip inside it.
+ *
+ * Both live in this one stylesheet on purpose — `WindowChrome.tsx` ships no `.css` of its
+ * own, and the bar exists only to hold the strip, so splitting them would put two halves of
+ * one layout in two files that must stay in lock-step. Every palette value here is a design
+ * token — the only literal colour is the opaque end of a mask gradient, where the channel is
+ * ignored and only the alpha ramp is read.
+ */
+
+/* ─────────────────────────── Window chrome (the title bar) ─────────────────────────── */
+
+.window-chrome {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--color-bg);
+  /* The chrome bar is one title bar tall. Captured here, BEFORE the rebasing below
+     redefines `--header-height` for the instances, so the two can't drift apart. */
+  --chrome-bar-height: var(--header-height);
+}
+
+.window-chrome-bar {
+  position: relative;
+  z-index: 40; /* above the instance Header (30) — this bar is never covered by a project */
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: var(--header-height);
+  padding: 0 var(--space-3);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+  /* It's a title bar: nothing in it is selectable, or a double-click to maximize would
+     select text instead (the same reason `.header` sets this). */
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: default;
+}
+
+/*
+ * macOS overlay title bar: the native traffic lights float over our own bar's top-left, so
+ * the strip has to start clear of them. `.tauri-overlay` is set on <html> by main.tsx and is
+ * the ONLY probe for this case anywhere in the app — no new detection here.
+ */
+/*
+ * CENTRED AGAINST THE WINDOW, NOT AGAINST THE LEFTOVER SPACE.
+ *
+ * The obvious layout — a strip with `flex: 1` between a left inset and a right cluster —
+ * centres the strip inside whatever is LEFT OVER, so the zoom and theme controls on the right
+ * push it visibly off-centre by half their width. The eye reads the capsule against the
+ * WINDOW, and it lands wrong.
+ *
+ * Giving both sides `flex: 1 1 0` makes them share the free space EQUALLY, so the middle is
+ * centred on the window's own axis with no measurement and no JS. `min-width` still guards
+ * both ends: the macOS traffic lights on the left, and the controls' own content on the right
+ * (a flex item's default `min-width: auto` refuses to shrink below min-content).
+ */
+.window-chrome-inset {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.tauri-overlay .window-chrome-inset {
+  min-width: 86px;
+}
+
+.window-chrome-right {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+/*
+ * Why a tab was refused (the 6-instance ceiling, closing the last chip, detaching it).
+ * Transient and inline rather than a toast: it answers a click the user just made, so it
+ * belongs next to the thing they clicked.
+ */
+/*
+ * Sits between the strip and the right cluster, so while it is up the strip is nudged off the
+ * window's axis. Accepted: it is transient (it answers a click the user just made) and rare
+ * (a refused tab), and a momentary shift toward the thing that just refused is a reasonable
+ * thing for the eye to follow.
+ */
+.window-chrome-notice {
+  flex: 0 1 auto;
+  max-width: 320px;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-warning-subtle);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*
+ * Every mounted project lives here, stacked. Exactly one is visible; the rest are hidden
+ * with `hidden` + `inert` (T6) and stay MOUNTED so their PTYs and WebSockets survive.
+ * `position: relative` so an instance's own fixed/absolute surfaces measure against the
+ * body area rather than the viewport's title-bar row.
+ */
+.window-chrome-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+
+  /*
+   * REBASING THE TITLE-BAR ORIGIN — one declaration instead of a dozen patches.
+   *
+   * Every surface in the app that has to sit "below the title bar" measures that distance as
+   * `--header-height`, against the viewport: the expanded agent overlay
+   * (`AgentTerminal.css:30,43`), `FullscreenOverlay`, `TaskDetailPanel`, the sidebar's
+   * `calc(100vh - …)`, and the three board components' inline `calc(100dvh - …)`.
+   *
+   * There are now TWO bars above a project's content — this window's chrome bar and the
+   * project's own header — so for anything INSIDE an instance that distance is both of them.
+   * Redefining the variable for this subtree makes every one of those surfaces correct
+   * without editing a single one of their stylesheets, and keeps them correct if the bar
+   * height ever changes. The project header is the one thing that must stay one bar tall, so
+   * it is put back onto the captured value below.
+   */
+  --header-height: calc(var(--chrome-bar-height) * 2);
+}
+
+/* The visible instance fills the body; hidden ones are `display:none` and take no space. */
+.window-chrome-body > *:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/*
+ * `.shell` is `height: 100vh` (Shell.css), which predates having anything above it — inside
+ * the chrome that overflows by exactly the bar. It fills the body instead.
+ */
+.window-chrome-body .shell {
+  height: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* One bar tall, against the rebased variable above. */
+.window-chrome-body .header {
+  height: var(--chrome-bar-height);
+}
+
+/*
+ * The traffic lights float over the CHROME bar now, not over a project's header — so the
+ * inset that used to clear them (`Header.css`'s `.tauri-overlay .header`) would leave the
+ * rail toggle stranded 80px from the left edge for no reason.
+ */
+.tauri-overlay .window-chrome-body .header {
+  padding-left: var(--space-4);
+}
+
+/* ───────────────────────────────── The chip strip ───────────────────────────────── */
+
+/*
+ * ONE PIECE OF GLASS, NOT N PILLS.
+ *
+ * The projects read as options inside a single continuous capsule — the segmented-control
+ * shape Apple's Liquid Glass uses — rather than as separate bordered chips. The reason is
+ * semantic, not decorative: these are mutually exclusive choices about ONE thing (which
+ * project this window is showing), and a segmented control says "pick one of these" where a
+ * row of independent pills says "here are some unrelated buttons".
+ *
+ * Three layers make the material, and each is doing a job:
+ *   1. a translucent fill + backdrop blur — the surface behind shows through, so the bar
+ *      belongs to the window instead of sitting on top of it;
+ *   2. a specular top highlight (inset hairline) — light hits the top edge of a real curved
+ *      surface, and this is the single cheapest cue that reads as "glass" rather than "grey box";
+ *   3. a soft ambient shadow — it lifts off the bar just enough to be a distinct object.
+ *
+ * Every colour is derived from a token via `color-mix`, so the whole material re-tints itself
+ * in light and dark mode with no second palette to keep in sync. The only literal colour in
+ * this file remains the opaque end of the overflow mask, where the channel is ignored and
+ * only the alpha ramp is read.
+ */
+.project-tabs {
+  /* Sized by its content and allowed to shrink — the two side regions above are what claim
+     the free space, and they are what centres this. */
+  flex: 0 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  /* A 42px bar has no room for a scrollbar; the edge fades below are the affordance. */
+  scrollbar-width: none;
+}
+
+.project-tabs::-webkit-scrollbar {
+  height: 0;
+}
+
+.project-tabs[data-overflow='true'] {
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+  mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+}
+
+/*
+ * The track IS the capsule now. `margin-inline: auto` still carries RULE 2 (fall left when it
+ * doesn't fit): auto margins resolve to 0 the moment the content outgrows its scroll
+ * container, so the glass left-aligns and becomes scrollable at exactly the width where
+ * centring would start clipping — in CSS, so it can never disagree with the observer for a
+ * frame. The observer only publishes `data-overflow`, which turns on the edge fades.
+ */
+.project-tabs-track {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: var(--space-1);
+  margin-inline: auto; /* ← Rule 2 (see above) */
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--color-text) 6%, transparent);
+  border: 1px solid color-mix(in oklab, var(--color-text) 8%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, var(--color-bg) 65%, transparent),
+    0 1px 2px color-mix(in oklab, var(--color-text) 8%, transparent);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  backdrop-filter: blur(24px) saturate(180%);
+}
+
+/*
+ * RULE 1 — frozen while the pointer is inside the strip. The measured leading gap is written
+ * to `--tabs-lead` and the auto margins are dropped, so closing a chip cannot slide the
+ * neighbouring chip under the cursor and invite a second accidental close.
+ */
+.project-tabs[data-frozen='true'] .project-tabs-track {
+  margin-inline: 0 auto;
+  margin-left: var(--tabs-lead, 0);
+}
+
+/* The empty slot a chip left behind while the layout is frozen. */
+.project-tab-ghost {
+  flex: 0 0 auto;
+  height: 28px;
+}
+
+/* ───────────────────────────── One segment of the glass ───────────────────────────── */
+
+/*
+ * A segment carries no shell of its own — the capsule around it is the shell. What used to be
+ * a border and a background here would now be a box drawn inside a box.
+ */
+.project-tab {
+  --tab-kind-color: var(--color-text-tertiary); /* neutral: ready / starting / saved / ended */
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  height: 28px;
+  padding-right: 2px;
+  border-radius: var(--radius-full);
+  border: 1px solid transparent;
+  background: transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+/*
+ * Only the two states that mean "this project needs your eyes" take colour; everything else
+ * is neutral. An idle project rolls up as `ended` (the calmest state, and what an empty row
+ * set answers), so mapping `ended` to the error hue would paint every quiet chip red.
+ */
+.project-tab[data-kind='asking'] {
+  --tab-kind-color: var(--color-error);
+}
+
+.project-tab[data-kind='working'] {
+  --tab-kind-color: var(--color-accent);
+}
+
+/* Hovering an inactive segment fogs the glass under it — a hint, not a selection. */
+.project-tab:hover:not([data-active='true']) {
+  background: color-mix(in oklab, var(--color-text) 5%, transparent);
+}
+
+/*
+ * THE LENS — the active segment.
+ *
+ * TWO CHANNELS, KEPT APART. The lens says WHERE YOU ARE; the dot and badge inside it say WHAT
+ * IS HAPPENING. So "you are here" is a raised pane of brighter glass, never a change to the
+ * state colours — a project that is asking looks the same whether or not you are standing in
+ * it, because it IS the same. The strip has exactly one active segment, so the lens is
+ * unambiguous even when the dot inside it happens to be the accent hue too.
+ *
+ * It reads as a piece of glass floating INSIDE the capsule rather than a filled tab: a
+ * brighter surface, its own specular top edge, and a small drop shadow for the gap between
+ * the two layers. The accent appears only as a whisper in the border — enough to tie it to
+ * the app's action colour without turning the strip into a coloured widget.
+ *
+ * The other half of this separation lives in ProjectTabs.tsx: the active segment never
+ * bounces. Motion is the "come over here" signal, and it is wrong for the place the user is.
+ */
+.project-tab[data-active='true'] {
+  background: color-mix(in oklab, var(--color-bg-elevated) 88%, var(--color-accent) 4%);
+  border-color: color-mix(in oklab, var(--color-accent) 22%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, var(--color-bg) 80%, transparent),
+    0 1px 3px color-mix(in oklab, var(--color-text) 14%, transparent);
+}
+
+/* A torn-down segment: the project is still listed, its instance is not mounted. */
+.project-tab[data-cold='true'] {
+  opacity: 0.55;
+}
+
+.project-tab[data-cold='true'] .project-tab-dot {
+  box-shadow: inset 0 0 0 1px var(--tab-kind-color);
+  background: transparent;
+}
+
+.project-tab[data-cold='true']:hover {
+  opacity: 1;
+}
+
+.project-tab-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  height: 26px;
+  padding: 0 var(--space-1) 0 var(--space-3);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-text);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-caption);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.project-tab-main:hover {
+  color: var(--color-text);
+}
+
+.project-tab[data-active='true'] .project-tab-main {
+  color: var(--color-text);
+  font-weight: var(--font-weight-semibold);
+}
+
+.project-tab-main:focus-visible,
+.project-tab-close:focus-visible,
+.project-tabs-add:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-accent-soft), 0 0 0 1px var(--color-accent);
+}
+
+.project-tab-main:active {
+  transform: scale(0.98);
+}
+
+.project-tab-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--tab-kind-color);
+}
+
+/* The one state that is genuinely in motion gets a pulse; the rest hold still. */
+.project-tab[data-kind='working'] .project-tab-dot {
+  animation: projectTabDotPulse 1.6s ease-in-out infinite;
+}
+
+.project-tab-name {
+  min-width: 0;
+  max-width: 168px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/*
+ * The live-conversation count. Omitted entirely at 0 (see ProjectTabs.tsx) — a "0" badge is
+ * noise on a chip that has nothing going on.
+ */
+.project-tab-badge {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: var(--radius-full);
+  background: var(--tab-kind-color);
+  color: var(--color-text-on-brand);
+  /* Matches `.header-search-pill-kbd`'s 10px, scaled by app zoom like every other size. */
+  font-size: calc(10px * var(--zoom));
+  font-weight: var(--font-weight-bold);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.project-tab-close {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+}
+
+/* The × stays out of the way until the chip is in play — but never hides from the keyboard. */
+.project-tab:hover .project-tab-close,
+.project-tab[data-active='true'] .project-tab-close,
+.project-tab-close:focus-visible {
+  opacity: 1;
+}
+
+.project-tab-close:hover:not(:disabled) {
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+}
+
+.project-tab-close:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.project-tab-close:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.project-tab[data-active='true'] .project-tab-close:disabled,
+.project-tab:hover .project-tab-close:disabled {
+  opacity: 0.35;
+}
+
+/*
+ * One-shot bounce when a BACKGROUND project starts waiting on the user — the moment the whole
+ * strip exists for. Driven by a flag the component sets on the `waiting` 0→>0 edge and clears
+ * on `animationend`, so it fires once per question rather than looping, and never on the chip
+ * the user is already looking at.
+ */
+.project-tab[data-bouncing='true'] {
+  animation: projectTabBounce var(--transition-bounce) both;
+}
+
+@keyframes projectTabBounce {
+  0% { transform: translateY(0); }
+  30% { transform: translateY(-5px); }
+  55% { transform: translateY(0); }
+  75% { transform: translateY(-2px); }
+  100% { transform: translateY(0); }
+}
+
+@keyframes projectTabDotPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+/* ─────────────────────────────── The `+` affordance ─────────────────────────────── */
+
+/*
+ * Inside the capsule, behind a hairline — "add another option to this set", not a separate
+ * button parked next to the glass. The divider is what stops it reading as a sixth project.
+ */
+.project-tabs-add {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-left: var(--space-1);
+  padding-left: var(--space-1);
+  border: none;
+  border-left: 1px solid color-mix(in oklab, var(--color-text) 10%, transparent);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  background: transparent;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  box-sizing: content-box;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.project-tabs-add:hover {
+  background: color-mix(in oklab, var(--color-text) 6%, transparent);
+  color: var(--color-text);
+}
+
+.project-tabs-add:active {
+  transform: scale(0.94);
+}
+
+/* ───────────────────────────── Chip context menu ───────────────────────────── */
+
+.project-tab-menu {
+  position: fixed;
+  z-index: 70; /* above the chrome bar and the instance Header, below modals (1100) */
+  min-width: 200px;
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-xl);
+}
+
+.project-tab-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text);
+  font-family: var(--font-family-text);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.project-tab-menu-item:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.project-tab-menu-item:focus-visible {
+  outline: none;
+  background: var(--color-bg-tertiary);
+  box-shadow: 0 0 0 2px var(--color-accent-soft) inset;
+}
+
+/* ───────────────────────────────── Reduced motion ───────────────────────────────── */
+
+/*
+ * The bounce and the pulse are the only motion here, and both encode state that is ALSO
+ * carried by colour and by the badge — so removing them loses nothing but the movement.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .project-tab[data-bouncing='true'],
+  .project-tab[data-kind='working'] .project-tab-dot {
+    animation: none;
+  }
+
+  .project-tab-main:active,
+  .project-tab-close:active:not(:disabled),
+  .project-tabs-add:active {
+    transform: none;
+  }
+}

--- a/dashboard/src/components/layout/ProjectTabs.tsx
+++ b/dashboard/src/components/layout/ProjectTabs.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
+import type { SessionStatusKind } from '../sleepy/agentStatus';
+import './ProjectTabs.css';
+
+/**
+ * The centre-aligned project chip strip — the one place a window says which projects it is
+ * holding and which of them needs you.
+ *
+ * Every chip is a LIVE project: switching chips hides an instance, it never unmounts one, so
+ * the strip is a visibility control, not a router. A chip therefore has to carry state that
+ * belongs to a surface you are not currently looking at — the dot's colour, the count of
+ * conversations actually running, and a one-shot bounce when one of them starts waiting on
+ * an answer.
+ *
+ * Presentational on purpose: it owns its own geometry (the two layout rules below) and
+ * nothing else. `WindowChrome` owns which projects exist, which is active, and the ceiling.
+ */
+
+/** One project's chip. `worst`/`live`/`waiting` come straight from `rollupProject()`. */
+export interface ProjectChip {
+  vault: string;
+  active: boolean;
+  /** Torn down to free a slot at the instance ceiling; the chip stays, the instance is gone. */
+  cold: boolean;
+  /** Worst-of session state across the project — drives the dot and badge colour. */
+  worst: SessionStatusKind;
+  /** Live conversations. The badge NUMBER; the badge is omitted entirely at 0. */
+  live: number;
+  /**
+   * Sessions blocked on the user. Its own 0→>0 edge is the ONE bounce trigger, detected in
+   * this component and nowhere else — see the bounce effect below.
+   */
+  waiting: number;
+  /**
+   * ACCEPTED AND IGNORED — do not reach for this.
+   *
+   * An earlier shape had the chrome count the `waiting` edges and hand the strip a nonce to
+   * replay. That is a second edge detector for an edge `waiting` already carries, and two
+   * places deciding when a chip bounces is exactly how one ends up bouncing twice for one
+   * question. The strip derives it, so the field has no reader left; it stays declared only
+   * because the chrome's chip builder still sets it, and both lines should go together.
+   */
+  bounceNonce?: number;
+}
+
+interface ProjectTabsProps {
+  chips: ProjectChip[];
+  onActivate(vault: string): void;
+  onClose(vault: string): void;
+  onAdd(): void;
+  onDetach(vault: string): void;
+}
+
+/**
+ * The strip's geometry, captured the moment the pointer entered it (Rule 1).
+ * `order` is the chip order AT FREEZE TIME, which is what lets a closed chip leave an empty
+ * slot behind instead of pulling its neighbour under the cursor.
+ */
+interface FrozenLayout {
+  lead: number;
+  order: string[];
+  widths: Record<string, number>;
+}
+
+interface ChipMenu {
+  vault: string;
+  x: number;
+  y: number;
+}
+
+/** Keep a context menu fully on screen when a chip is right-clicked near an edge. */
+const MENU_WIDTH = 200;
+const MENU_MARGIN = 8;
+
+/** Whether the user has asked the OS for less movement. Queried at fire time, not at mount,
+ *  so flipping the system setting mid-session takes effect on the very next question. */
+function prefersReducedMotion(): boolean {
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false; // no matchMedia (test env) — the stylesheet's own guard still applies
+  }
+}
+
+/**
+ * What the chip's dot and badge SAY, in words. WCAG's "never by colour alone" applies twice
+ * over here: the dot's hue is the only visual carrier of `asking`, and the bounce that
+ * accompanies it is removed outright under `prefers-reduced-motion`.
+ */
+function describeChip(chip: ProjectChip): string {
+  const parts = [chip.vault];
+  if (chip.cold) parts.push('sleeping, click to reopen');
+  if (chip.worst === 'asking') parts.push('needs you');
+  else {
+    if (chip.worst === 'working') parts.push('working');
+    // `waiting` with no question on screen: a backgrounded session finished or rang the bell.
+    // It is what makes the chip bounce, so it has to be readable as words too.
+    if (chip.waiting > 0) parts.push('wants a look');
+  }
+  if (chip.live > 0) parts.push(`${chip.live} live`);
+  return parts.join(' — ');
+}
+
+export function ProjectTabs({ chips, onActivate, onClose, onAdd, onDetach }: ProjectTabsProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [frozen, setFrozen] = useState<FrozenLayout | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const [bouncing, setBouncing] = useState<Record<string, true>>({});
+  const [menu, setMenu] = useState<ChipMenu | null>(null);
+  const seenWaitingRef = useRef<Record<string, number>>({});
+
+  // The last chip is the window's only project — closing or detaching it would leave an
+  // empty window, so the control is disabled rather than silently refusing on click.
+  const canClose = chips.length > 1;
+
+  /* ── Rule 2: publish whether the track has outgrown the strip ─────────────────────
+     The CENTRING itself is pure CSS (`margin-inline: auto` on the track collapses to 0 the
+     moment the content is wider than its scroll container, which left-aligns it at exactly
+     the right width). This observer only decides whether to draw the edge fades that say
+     "there is more strip off-screen" — so the layout can never be a frame out of step with
+     the flag that describes it. */
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    const track = trackRef.current;
+    if (!host || !track) return;
+    const measure = () => setOverflowing(track.scrollWidth > host.clientWidth + 1);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(host);
+    ro.observe(track);
+    return () => ro.disconnect();
+  }, [chips]);
+
+  /* ── Rule 1: freeze the layout while the pointer is inside the strip ───────────────
+     Centre-aligned means every add and every close shifts every chip sideways — so closing
+     one puts its neighbour directly under the cursor and invites a second, unintended
+     close. On enter we snapshot the leading gap and each chip's width and hold them; a
+     closed chip's slot stays empty until the pointer leaves. Same reason Chrome freezes tab
+     widths while you are closing tabs. */
+  const freeze = useCallback(() => {
+    const host = hostRef.current;
+    const track = trackRef.current;
+    if (!host || !track) return;
+    const hostLeft = host.getBoundingClientRect().left;
+    const order: string[] = [];
+    const widths: Record<string, number> = {};
+    for (const node of track.querySelectorAll<HTMLElement>('[data-vault]')) {
+      const vault = node.dataset.vault;
+      if (!vault) continue;
+      order.push(vault);
+      widths[vault] = node.getBoundingClientRect().width;
+    }
+    setFrozen({
+      lead: track.getBoundingClientRect().left - hostLeft + host.scrollLeft,
+      order,
+      widths,
+    });
+  }, []);
+
+  const release = useCallback(() => setFrozen(null), []);
+
+  /* ── One-shot bounce: a background project just started waiting on an answer ──────
+     The EDGE, not the level. A chip sitting at `waiting: 2` across a re-render has not asked
+     a second question, and re-running the animation every time the strip re-renders reads as
+     a chip that never settles — so the previous count is held per vault and only a genuine
+     0→>0 crossing fires. This is the single place in the app that decides a chip bounces:
+     `attention.ts` deliberately exposes no subscriber to bounce off (it already raises the
+     chime, banner and Dock bounce for the same question), and one edge with two detectors is
+     how a chip ends up jumping twice for one interruption.
+
+     Three chips never fire, each for its own reason:
+      · the ACTIVE one — the question is already on screen in front of the user; motion that
+        says "come here" is wrong for the place they already are;
+      · one seen for the FIRST time — opening a project that happens to be mid-question is
+        the user's own click, not an interruption;
+      · any chip, when the user asked for reduced motion. Read at fire time rather than at
+        mount so a mid-session change is honoured. The colour and the badge still change, so
+        nothing is carried by the animation alone (the stylesheet suppresses the keyframes
+        too — this arm is what also keeps the flag below from latching with no `animationend`
+        ever coming to clear it). */
+  useEffect(() => {
+    const started: string[] = [];
+    const next: Record<string, number> = {};
+    for (const chip of chips) {
+      const seen = seenWaitingRef.current[chip.vault];
+      next[chip.vault] = chip.waiting;
+      if (seen === 0 && chip.waiting > 0 && !chip.active) started.push(chip.vault);
+    }
+    seenWaitingRef.current = next; // drops vaults whose chip is gone
+    if (started.length === 0 || prefersReducedMotion()) return;
+    setBouncing((prev) => {
+      const merged = { ...prev };
+      for (const vault of started) merged[vault] = true;
+      return merged;
+    });
+  }, [chips]);
+
+  const endBounce = useCallback((vault: string) => {
+    setBouncing((prev) => {
+      if (!prev[vault]) return prev;
+      const next = { ...prev };
+      delete next[vault];
+      return next;
+    });
+  }, []);
+
+  /* ── Context menu lifecycle ─────────────────────────────────────────────────────
+     A transient popover, not a modal: it is dismissed by anything that moves the page
+     underneath it, and it deliberately does NOT enter the overlay stack, which exists to
+     arbitrate Escape between stacked MODALS. */
+  useEffect(() => {
+    if (!menu) return;
+    const dismiss = () => setMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setMenu(null);
+      }
+    };
+    window.addEventListener('pointerdown', dismiss);
+    window.addEventListener('resize', dismiss);
+    window.addEventListener('blur', dismiss);
+    window.addEventListener('keydown', onKey, true);
+    return () => {
+      window.removeEventListener('pointerdown', dismiss);
+      window.removeEventListener('resize', dismiss);
+      window.removeEventListener('blur', dismiss);
+      window.removeEventListener('keydown', onKey, true);
+    };
+  }, [menu]);
+
+  const openMenu = useCallback((e: ReactMouseEvent, vault: string) => {
+    e.preventDefault();
+    setMenu({
+      vault,
+      x: Math.min(e.clientX, window.innerWidth - MENU_WIDTH - MENU_MARGIN),
+      y: e.clientY,
+    });
+  }, []);
+
+  // While frozen, render the freeze-time order so a closed chip leaves its slot behind;
+  // anything opened since (rare — it needs the switcher while hovering the strip) is
+  // appended at its natural width.
+  const byVault = new Map(chips.map((c) => [c.vault, c]));
+  const order = frozen
+    ? [...frozen.order, ...chips.filter((c) => !frozen.order.includes(c.vault)).map((c) => c.vault)]
+    : chips.map((c) => c.vault);
+
+  return (
+    <div
+      className="project-tabs"
+      ref={hostRef}
+      data-overflow={overflowing ? 'true' : 'false'}
+      data-frozen={frozen ? 'true' : 'false'}
+      onPointerEnter={freeze}
+      onPointerLeave={release}
+    >
+      <div
+        className="project-tabs-track"
+        ref={trackRef}
+        style={frozen ? ({ '--tabs-lead': `${frozen.lead}px` } as CSSProperties) : undefined}
+      >
+        {order.map((vault) => {
+          const chip = byVault.get(vault);
+          const width = frozen?.widths[vault];
+
+          // A chip that closed while the layout is frozen: its slot is held open and empty.
+          if (!chip) {
+            return <div key={vault} className="project-tab-ghost" style={{ width }} aria-hidden="true" />;
+          }
+
+          return (
+            <div
+              key={vault}
+              className="project-tab"
+              data-vault={vault}
+              data-active={chip.active ? 'true' : 'false'}
+              data-cold={chip.cold ? 'true' : 'false'}
+              data-kind={chip.worst}
+              data-bouncing={bouncing[vault] ? 'true' : 'false'}
+              style={width !== undefined ? { width } : undefined}
+              // Animation events bubble, so name-check it: any finite animation added to a
+              // descendant later would otherwise cut the bounce short.
+              onAnimationEnd={(e) => { if (e.animationName === 'projectTabBounce') endBounce(vault); }}
+              onContextMenu={(e) => openMenu(e, vault)}
+            >
+              <button
+                type="button"
+                className="project-tab-main"
+                aria-current={chip.active ? 'true' : undefined}
+                title={chip.cold ? `${vault} — sleeping, click to reopen` : vault}
+                // The dot and the badge are colour and a bare number; the label is where the
+                // same information is available to anyone not reading the pixels.
+                aria-label={describeChip(chip)}
+                onClick={() => onActivate(vault)}
+              >
+                <span className="project-tab-dot" aria-hidden="true" />
+                <span className="project-tab-name">{vault}</span>
+                {/* Omitted at 0: a "0" badge is noise on a project with nothing running. */}
+                {chip.live > 0 && (
+                  <span className="project-tab-badge" aria-hidden="true">{chip.live}</span>
+                )}
+              </button>
+              <button
+                type="button"
+                className="project-tab-close"
+                disabled={!canClose}
+                title={canClose ? `Close ${vault}` : 'The window must keep one project open'}
+                aria-label={`Close ${vault}`}
+                onClick={() => onClose(vault)}
+              >
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+                  <path d="M1.5 1.5 L8.5 8.5 M8.5 1.5 L1.5 8.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+          );
+        })}
+
+        <button
+          type="button"
+          className="project-tabs-add"
+          title="Open another project"
+          aria-label="Open another project"
+          onClick={onAdd}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M6 1.5v9M1.5 6h9" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+
+      {menu && (
+        <div
+          className="project-tab-menu"
+          role="menu"
+          style={{ left: menu.x, top: menu.y }}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="project-tab-menu-item"
+            onClick={() => {
+              const { vault } = menu;
+              setMenu(null);
+              onDetach(vault);
+            }}
+          >
+            Open in New Window
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/Shell.tsx
+++ b/dashboard/src/components/layout/Shell.tsx
@@ -1,21 +1,33 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Header } from './Header';
 import { Sidebar, type Page } from './Sidebar';
 import { CommandPalette } from '../search/CommandPalette';
-import { useSidebarCollapse } from '../../hooks/useSidebarCollapse';
+import { useVault, emitInstance } from '../../context/VaultContext';
+import { readScopedRaw, writeScopedRaw } from '../../lib/scopedStorage';
 import './Shell.css';
 
 const ACTIVE_PAGE_STORAGE_KEY = 'dreamcontext.dashboard.activePage';
 const VALID_PAGES: readonly Page[] = ['tasks', 'roadmap', 'hypotheses', 'lab', 'core', 'knowledge', 'sleep', 'brain', 'council', 'taxonomy', 'settings', 'packs', 'about', 'announcements'];
 
-function readStoredPage(): Page {
+/**
+ * Which page a project was last on — per-project navigation, so it goes through the
+ * scoped-storage RAW layer (not JSON): the stored value has always been the bare page name,
+ * and staying on that format is what lets an existing pre-scoping value migrate correctly
+ * (a JSON layer would try to `JSON.parse('tasks')` and fail on anything but the literal word
+ * "tasks", silently losing everyone else's remembered page).
+ */
+function readStoredPage(vault: string | null, instanceId: string): Page {
   if (typeof window === 'undefined') return 'tasks';
-  // A `/lab/<slug>` deep link (multi-page insights — funnel overview/detail)
-  // must land on the Lab page regardless of the remembered page.
-  try {
-    if (window.location.pathname.startsWith('/lab/')) return 'lab';
-  } catch {
-    // fall through
+  // A `/lab/<slug>` deep link (multi-page insights — funnel overview/detail) must land on
+  // the Lab page regardless of the remembered page. There is exactly one URL for the whole
+  // window, so only the FIRST instance may claim it — a chip opened afterward reads this
+  // same pathname and must not also jump itself to Lab.
+  if (instanceId === 'inst-1') {
+    try {
+      if (window.location.pathname.startsWith('/lab/')) return 'lab';
+    } catch {
+      // fall through
+    }
   }
   // An explicit `?page=<page>` deep-link wins over the remembered page, so a URL
   // can land directly on a section (used by the launcher and for sharing links).
@@ -27,13 +39,9 @@ function readStoredPage(): Page {
   } catch {
     // URL unparseable — fall through to the stored page.
   }
-  try {
-    const stored = window.localStorage.getItem(ACTIVE_PAGE_STORAGE_KEY);
-    if (stored && (VALID_PAGES as readonly string[]).includes(stored)) {
-      return stored as Page;
-    }
-  } catch {
-    // localStorage unavailable (private mode, etc.) — fall through to default
+  const stored = readScopedRaw(vault, ACTIVE_PAGE_STORAGE_KEY);
+  if (stored && (VALID_PAGES as readonly string[]).includes(stored)) {
+    return stored as Page;
   }
   return 'tasks';
 }
@@ -49,19 +57,32 @@ export interface ShellNavigation {
 
 interface ShellProps {
   children: (nav: ShellNavigation) => ReactNode;
+  /**
+   * Rail width, hoisted to the window chrome: with N projects mounted at once, each running
+   * its own collapse state would diverge the moment one of them toggled — two rails of
+   * different widths in one window reads as broken. The KEY behind this stays window-global
+   * on purpose (see `WindowChrome`); only the state's single owner moved.
+   */
+  sidebarCollapsed: boolean;
+  onToggleSidebar: () => void;
 }
 
-export function Shell({ children }: ShellProps) {
-  const [activePage, setActivePage] = useState<Page>(readStoredPage);
+export function Shell({ children, sidebarCollapsed, onToggleSidebar }: ShellProps) {
+  const { vault, instanceId, isActive, bus } = useVault();
+  const [activePage, setActivePage] = useState<Page>(() => readStoredPage(vault, instanceId));
   const [focusId, setFocusId] = useState<string | null>(null);
   const [nonce, setNonce] = useState(0);
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const { collapsed, toggle: toggleSidebar } = useSidebarCollapse();
+  const shellRef = useRef<HTMLDivElement | null>(null);
 
   // ⌘K / Ctrl-K toggles the global command palette from anywhere (including over the
-  // expanded agent overlay — the agent host only grabs ⌘D/⌘T/⌘W, never ⌘K).
+  // expanded agent overlay — the agent host only grabs ⌘D/⌘T/⌘W, never ⌘K). Gated on
+  // `isActive` first: a hidden instance is `inert`, so it can't normally receive focus-bound
+  // input, but a window-level keydown listener isn't focus-scoped — without this check a ⌘K
+  // meant for the foreground project would also pop the palette of every backgrounded one.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if (!isActive) return;
       if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setPaletteOpen((o) => !o);
@@ -69,28 +90,32 @@ export function Shell({ children }: ShellProps) {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [isActive]);
 
-  // Publish the sidebar collapse state on <html> so surfaces mounted OUTSIDE the Shell
-  // tree (the Agent overlay, at the app root) can bound themselves to the content area —
-  // its expanded left edge reads `--app-content-left`, which this attribute flips.
+  // Publish the sidebar collapse state on the nearest `.project-instance` ancestor so
+  // surfaces mounted OUTSIDE the Shell tree but INSIDE that instance (the expanded Agent
+  // overlay, a sibling of Shell under `ProjectInstance`) can bound themselves to the content
+  // area — its expanded left edge reads `--app-content-left`, which this attribute flips.
+  // Scoped to the instance (not `<html>`) because one window now holds several projects, each
+  // with its own content-area rect.
   useEffect(() => {
-    document.documentElement.dataset.sidebar = collapsed ? 'collapsed' : 'expanded';
-  }, [collapsed]);
+    const instanceEl = shellRef.current?.closest('.project-instance');
+    if (instanceEl instanceof HTMLElement) {
+      instanceEl.dataset.sidebar = sidebarCollapsed ? 'collapsed' : 'expanded';
+    }
+  }, [sidebarCollapsed]);
 
   const navigate = useCallback((page: Page, id: string | null) => {
     setActivePage(page);
     setFocusId(id);
     setNonce((n) => n + 1);
-    // Tell the Agent overlay (mounted outside this tree, at the app root) that the user
-    // navigated, so it auto-collapses from fullscreen and reveals the page they picked.
-    window.dispatchEvent(new CustomEvent('dreamcontext-navigate', { detail: { page } }));
-    try {
-      window.localStorage.setItem(ACTIVE_PAGE_STORAGE_KEY, page);
-    } catch {
-      // localStorage unavailable — ignore
-    }
-  }, []);
+    // Tell this instance's Agent overlay (mounted outside this tree, but inside the same
+    // `ProjectInstance`) that the user navigated, so it auto-collapses from fullscreen and
+    // reveals the page they picked. On the instance bus, not `window` — on `window` every
+    // mounted project would hear another project's navigation and react to it.
+    emitInstance(bus, 'dreamcontext-navigate', { page });
+    writeScopedRaw(vault, ACTIVE_PAGE_STORAGE_KEY, page);
+  }, [bus, vault]);
 
   const handleSidebarNavigate = useCallback(
     (page: Page, id?: string) => {
@@ -107,15 +132,15 @@ export function Shell({ children }: ShellProps) {
   const closePalette = useCallback(() => setPaletteOpen(false), []);
 
   return (
-    <div className="shell">
+    <div className="shell" ref={shellRef}>
       <Header
         onNavigate={handleSidebarNavigate}
-        sidebarCollapsed={collapsed}
-        onToggleSidebar={toggleSidebar}
+        sidebarCollapsed={sidebarCollapsed}
+        onToggleSidebar={onToggleSidebar}
         onOpenSearch={() => setPaletteOpen(true)}
       />
       <div className="shell-body">
-        <Sidebar activePage={activePage} onNavigate={handleSidebarNavigate} collapsed={collapsed} />
+        <Sidebar activePage={activePage} onNavigate={handleSidebarNavigate} collapsed={sidebarCollapsed} />
         <main className="shell-main">
           {children({ page: activePage, focusId, nonce, navigate, clearFocus })}
         </main>

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -7,17 +7,9 @@ import { useAuthStatus, useBrainStatus } from '../../hooks/useBrainStatus';
 import { useAnnouncementInbox } from '../../hooks/useAnnouncements';
 import { useTheses } from '../../hooks/useTheses';
 import { BrainSyncControl } from '../brain/BrainSyncControl';
+import { useVault } from '../../context/VaultContext';
+import { readScopedRaw, writeScopedRaw } from '../../lib/scopedStorage';
 import './Sidebar.css';
-
-/** The active vault's display name, as passed by the launcher via `?vault=`. */
-function readVaultLabel(): string {
-  if (typeof window === 'undefined') return '';
-  try {
-    return new URLSearchParams(window.location.search).get('vault') ?? '';
-  } catch {
-    return '';
-  }
-}
 
 export type Page = 'tasks' | 'roadmap' | 'hypotheses' | 'lab' | 'automations' | 'core' | 'knowledge' | 'sleep' | 'brain' | 'council' | 'settings' | 'packs' | 'about' | 'taxonomy' | 'announcements';
 
@@ -80,9 +72,13 @@ const NAV_GROUPS: NavGroup[] = [
 ];
 
 // One-time first-run nudge: the "What is this?" entry pulses until the user
-// opens it once, then this flag persists so it never nags again.
+// opens it once, then this flag persists so it never nags again. GLOBAL on purpose —
+// "I have read what this app is" lives in the user's head, not in a project, and
+// re-explaining dreamcontext once per project would be nagging.
 const ABOUT_SEEN_STORAGE_KEY = 'dreamcontext.dashboard.aboutSeen';
-// Same pattern for the GitHub cloud-sync CTA pinned to the rail footer.
+// Same first-run pattern for the GitHub cloud-sync CTA pinned to the rail footer, but
+// PER VAULT: unlike `aboutSeen`, what this CTA *does* (`brain enable`) is per-project, so
+// dismissing it in a synced project must not hide it in one that is still unsynced.
 const GITHUB_SYNC_SEEN_STORAGE_KEY = 'dreamcontext.dashboard.githubSyncSeen';
 
 function readFlag(key: string): boolean {
@@ -104,10 +100,15 @@ function writeFlag(key: string): void {
 
 export function Sidebar({ activePage, onNavigate, collapsed }: SidebarProps) {
   const { t } = useI18n();
+  // Which project this rail belongs to. Read from the instance, NOT from `?vault=`: the
+  // window's URL names the first chip, and several projects render their own rail here.
+  const { vault } = useVault();
   // aboutSeen: whether the user has opened "What is this?" at least once.
   // Until then, the entry bounces to invite the first click.
   const [aboutSeen, setAboutSeen] = useState<boolean>(() => readFlag(ABOUT_SEEN_STORAGE_KEY));
-  const [githubSyncSeen, setGithubSyncSeen] = useState<boolean>(() => readFlag(GITHUB_SYNC_SEEN_STORAGE_KEY));
+  const [githubSyncSeen, setGithubSyncSeen] = useState<boolean>(
+    () => readScopedRaw(vault, GITHUB_SYNC_SEEN_STORAGE_KEY) === '1',
+  );
 
   const { data: authStatus } = useAuthStatus();
   const { data: brainStatus } = useBrainStatus();
@@ -123,7 +124,7 @@ export function Sidebar({ activePage, onNavigate, collapsed }: SidebarProps) {
   // worse than one that simply doesn't label it yet.
   const { data: thesesData } = useTheses();
   const learningOff = thesesData?.enabled === false;
-  const vaultLabel = readVaultLabel();
+  const vaultLabel = vault ?? '';
 
   // 3-state cloud-sync CTA: not signed in → invite sign-in; signed in but no
   // remote configured yet → invite setup; connected → the sync control
@@ -143,7 +144,7 @@ export function Sidebar({ activePage, onNavigate, collapsed }: SidebarProps) {
   const openGithubSync = () => {
     if (!githubSyncSeen) {
       setGithubSyncSeen(true);
-      writeFlag(GITHUB_SYNC_SEEN_STORAGE_KEY);
+      writeScopedRaw(vault, GITHUB_SYNC_SEEN_STORAGE_KEY, '1');
     }
     onNavigate('settings', 'brain');
   };

--- a/dashboard/src/components/layout/SleepDebtTracker.tsx
+++ b/dashboard/src/components/layout/SleepDebtTracker.tsx
@@ -3,8 +3,9 @@ import { useI18n } from '../../context/I18nContext';
 import { useSleep, getSleepLevelKey, getSleepMood, displayDebt, SLEEP_DEBT_MAX } from '../../hooks/useSleep';
 import { useAgentCapabilities, isSleepAgentReady } from '../../hooks/useAgentCapabilities';
 import { readAgentSettings, AGENT_SETTINGS_EVENT, type AgentSettings } from '../../lib/agentSettings';
+import { useVault, useInstanceEvent } from '../../context/VaultContext';
 import {
-  requestSleepAgent,
+  runSleepAgent,
   markSleepPending,
   clearSleepPending,
   sleepPendingSince,
@@ -38,22 +39,27 @@ export function SleepDebtTracker({ onOpen }: SleepDebtTrackerProps) {
   const { data: caps } = useAgentCapabilities();
   const [menuOpen, setMenuOpen] = useState(false);
   const [agentSettings, setAgentSettings] = useState<AgentSettings>(() => readAgentSettings());
-  const [pendingAt, setPendingAt] = useState<number | null>(() => sleepPendingSince());
+  // Every sleep signal below is per PROJECT: the debt itself comes from this instance's
+  // `useSleep()` query, the "waiting" marker is stored under this vault's key, and the spawn
+  // request goes to this instance's agent surface. One window can hold several projects, each
+  // with its own debt and its own consolidation.
+  const { vault, bus } = useVault();
+  const [pendingAt, setPendingAt] = useState<number | null>(() => sleepPendingSince(vault));
   const wrapRef = useRef<HTMLDivElement | null>(null);
 
-  // Mirror the persisted "waiting to sleep" marker (set on click, cleared once a real sleep
-  // starts). Broadcast keeps us in sync instantly; the interval re-evaluates so the marker's
-  // TTL self-clears the shim if the spawned agent never reaches `sleep start`.
+  // Mirror this vault's persisted "waiting to sleep" marker (set on click, cleared once a real
+  // sleep starts). The bus event keeps us in sync instantly; the interval re-evaluates so the
+  // marker's TTL self-clears the shim if the spawned agent never reaches `sleep start`.
+  useInstanceEvent(SLEEP_PENDING_EVENT, () => setPendingAt(sleepPendingSince(vault)));
   useEffect(() => {
-    const sync = () => setPendingAt(sleepPendingSince());
-    window.addEventListener(SLEEP_PENDING_EVENT, sync);
-    const iv = window.setInterval(sync, 4_000);
-    return () => { window.removeEventListener(SLEEP_PENDING_EVENT, sync); window.clearInterval(iv); };
-  }, []);
+    const iv = window.setInterval(() => setPendingAt(sleepPendingSince(vault)), 4_000);
+    return () => window.clearInterval(iv);
+  }, [vault]);
 
   // Track the Agents-surface enable toggle live (Settings broadcasts on save) — a
   // disabled surface renders no dock, so "Run sleep agent" must be disabled too or a
-  // click would spawn an invisible session.
+  // click would spawn an invisible session. Still on `window`: what is left in that blob is
+  // genuinely app-global, so every project's tracker should react to it at once.
   useEffect(() => {
     const onChange = (e: Event) => {
       const detail = (e as CustomEvent<AgentSettings>).detail;
@@ -66,8 +72,8 @@ export function SleepDebtTracker({ onOpen }: SleepDebtTrackerProps) {
   // Once a real sleep actually begins (epoch stamped), retire the "waiting" shim — the
   // tracker hands off to its authoritative "Sleeping 💤" state.
   useEffect(() => {
-    if (sleep?.sleep_started_at && sleepPendingSince() != null) clearSleepPending();
-  }, [sleep?.sleep_started_at]);
+    if (sleep?.sleep_started_at && sleepPendingSince(vault) != null) clearSleepPending(bus, vault);
+  }, [sleep?.sleep_started_at, bus, vault]);
 
   // Close the menu on any outside click or Esc — a lightweight popover, no backdrop.
   useEffect(() => {
@@ -103,8 +109,8 @@ export function SleepDebtTracker({ onOpen }: SleepDebtTrackerProps) {
 
   const runAgent = () => {
     setMenuOpen(false);
-    markSleepPending();
-    requestSleepAgent();
+    markSleepPending(bus, vault);
+    runSleepAgent(bus);
   };
   const showDetails = () => {
     setMenuOpen(false);

--- a/dashboard/src/components/layout/UpdateBadge.tsx
+++ b/dashboard/src/components/layout/UpdateBadge.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useVersionCheck } from '../../hooks/useVersionCheck';
 import { MarkdownPreview } from '../core/MarkdownPreview';
 import { useI18n } from '../../context/I18nContext';
-import { api } from '../../api/client';
+import { useApi } from '../../context/VaultContext';
 import { closeCurrentWindow } from '../../lib/desktop';
 import './UpdateBadge.css';
 
@@ -33,6 +33,7 @@ const POLL_MS = 1200;
 
 export function UpdateBadge({ onManagePacks }: UpdateBadgeProps) {
   const { t } = useI18n();
+  const api = useApi();
   const { data } = useVersionCheck();
   const nudge = data?.nudge ?? null;
   const newPacks = data?.newPacks ?? [];
@@ -70,7 +71,7 @@ export function UpdateBadge({ onManagePacks }: UpdateBadgeProps) {
         .then(applyStatus)
         .catch(() => { /* transient — keep polling */ });
     }, POLL_MS);
-  }, [applyStatus, stopPolling]);
+  }, [api, applyStatus, stopPolling]);
 
   // Restore an in-flight OR just-finished upgrade on (re)mount — popover closed+reopened,
   // window reloaded mid-upgrade, or an upgrade that completed but wasn't relaunched yet. We
@@ -87,7 +88,7 @@ export function UpdateBadge({ onManagePacks }: UpdateBadgeProps) {
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };
-  }, [applyStatus, startPolling]);
+  }, [api, applyStatus, startPolling]);
 
   useEffect(() => () => stopPolling(), [stopPolling]);
 
@@ -101,7 +102,7 @@ export function UpdateBadge({ onManagePacks }: UpdateBadgeProps) {
       setPhase('error');
       setLog(e instanceof Error ? e.message : 'Failed to start the upgrade.');
     }
-  }, [startPolling]);
+  }, [api, startPolling]);
 
   const relaunch = useCallback(async () => {
     setRelaunching(true);
@@ -121,7 +122,7 @@ export function UpdateBadge({ onManagePacks }: UpdateBadgeProps) {
       setLog((prev) => `${prev}\n\nCouldn't reach the relaunch service. Reopen the app manually to finish.`.trimStart());
     }
     setRelaunching(false);
-  }, []);
+  }, [api]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/dashboard/src/components/layout/UpgradeRelaunchBanner.tsx
+++ b/dashboard/src/components/layout/UpgradeRelaunchBanner.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useServerHealth } from '../../hooks/useServerHealth';
 import { useI18n } from '../../context/I18nContext';
-import { api } from '../../api/client';
+import { useApi } from '../../context/VaultContext';
 import { isDesktop, closeAllWindows } from '../../lib/desktop';
 import './UpgradeRelaunchBanner.css';
 
@@ -30,6 +30,7 @@ const RELAUNCH_STUCK_MS = 8_000;
 
 export function UpgradeRelaunchBanner() {
   const { t } = useI18n();
+  const api = useApi();
   const { health } = useServerHealth();
   const ready = health?.upgradeReady ?? null;
   const running = __DC_VERSION__;
@@ -68,7 +69,7 @@ export function UpgradeRelaunchBanner() {
     firedRef.current = false;
     setRelaunching(false);
     setFailed(true);
-  }, []);
+  }, [api]);
 
   // Countdown ticker — runs only while a relaunch is pending, not deferred/failed.
   useEffect(() => {

--- a/dashboard/src/components/layout/WindowChrome.tsx
+++ b/dashboard/src/components/layout/WindowChrome.tsx
@@ -1,0 +1,596 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useServerHealth } from '../../hooks/useServerHealth';
+import { useSidebarCollapse } from '../../hooks/useSidebarCollapse';
+import { useTheme } from '../../context/ThemeContext';
+import { setChipActiveProbe } from '../../lib/attention';
+import { setActiveOverlayScope } from '../../lib/overlayStack';
+import {
+  focusWindow,
+  openVaultWindow,
+  setGoToProjectHandler,
+  startTitleBarDrag,
+  toggleMaximizeWindow,
+} from '../../lib/desktop';
+import { HEARTBEAT_MS, findWindowForVault, publishOpenVaults, releaseWindow } from '../../lib/windowRegistry';
+import type { ProjectRollup } from '../sleepy/agentStatus';
+import { ProjectInstance } from '../../ProjectInstance';
+import { ProjectSwitcher } from '../search/ProjectSwitcher';
+import { UpgradeRelaunchBanner } from './UpgradeRelaunchBanner';
+import { ProjectTabs, type ProjectChip } from './ProjectTabs';
+import './ProjectTabs.css';
+import './Header.css';
+
+/**
+ * The window-level shell: everything that belongs to the WINDOW rather than to any one
+ * project it is holding.
+ *
+ * dreamcontext used to be one OS window per project, which made "the window" and "the
+ * project" the same thing — so the title bar could show a vault name, the zoom control could
+ * live in a project's Header, and a chip strip was unnecessary. Now one window holds several
+ * LIVE projects at once. This component owns the split: the chip strip and the controls that
+ * are genuinely per-window (zoom, theme, the server-level banners, the rail width) live here;
+ * everything per-vault (sleep debt, refresh, the update badge) stays in the instance Header.
+ *
+ * The instances themselves are all MOUNTED, all the time. Switching a chip toggles
+ * visibility — it never unmounts, because an unmounted instance is a killed PTY and a dropped
+ * WebSocket mid-conversation.
+ */
+
+/**
+ * How many projects may be mounted and live at once. Each instance carries its own
+ * QueryClient, agent surface and (usually) one or more PTYs, so this is a real resource
+ * ceiling rather than a UI preference.
+ */
+export const MAX_LIVE_INSTANCES = 6;
+
+/** How long a refusal stays on screen before it stops being an answer and starts being noise. */
+const NOTICE_MS = 6_000;
+
+export interface OpenProject {
+  vault: string;
+  /** Stable for the life of THIS mount, never reused — a reopened project gets a fresh id. */
+  instanceId: string;
+  /** Torn down to free a slot at the ceiling: the chip survives, the instance does not. */
+  cold: boolean;
+  /**
+   * The latest rollup this instance published, or null when it has not published one yet.
+   * **null is not idle** — see {@link oldestEvictable}.
+   */
+  rollup: ProjectRollup | null;
+}
+
+/** What `addTab` actually did, so the caller can tell "opened" from "already had it". */
+export type AddTabResult = 'added' | 'focused-tab' | 'focused-window' | 'refused-ceiling';
+
+export interface ChromeApi {
+  open: OpenProject[];
+  activeVault: string;
+  addTab(vault: string): Promise<AddTabResult>;
+  activate(vault: string): void;
+  closeTab(vault: string): void;
+  detachToWindow(vault: string): Promise<void>;
+}
+
+/**
+ * What `useChrome()` answers with no `WindowChrome` above it — the launcher window, which
+ * mounts `ProjectSwitcher` too but holds no instances. It must not throw and must not
+ * pretend there are chips: picking a project from the launcher opens that project's WINDOW,
+ * which is exactly what the launcher did before any of this existed.
+ */
+const DETACHED_CHROME: ChromeApi = {
+  open: [],
+  activeVault: '',
+  addTab: async (vault: string) => {
+    await openVaultWindow(vault);
+    return 'focused-window';
+  },
+  activate: () => {},
+  closeTab: () => {},
+  detachToWindow: async (vault: string) => {
+    await openVaultWindow(vault);
+  },
+};
+
+const ChromeContext = createContext<ChromeApi>(DETACHED_CHROME);
+
+/** This window's tab state and the operations on it; {@link DETACHED_CHROME} in the launcher. */
+export function useChrome(): ChromeApi {
+  return useContext(ChromeContext);
+}
+
+/* ─────────────────────────────── window-level chrome bits ─────────────────────────────── */
+
+const ZOOM_LEVELS = [0.85, 0.9, 1.0, 1.1, 1.2];
+const ZOOM_STORAGE_KEY = 'dreamcontext-zoom';
+
+function getStoredZoom(): number {
+  try {
+    const stored = localStorage.getItem(ZOOM_STORAGE_KEY);
+    if (stored !== null) {
+      const val = parseFloat(stored);
+      if (ZOOM_LEVELS.includes(val)) return val;
+    }
+  } catch { /* ignore */ }
+  return 1.0;
+}
+
+/**
+ * Zoom is a WINDOW property, not a project one — every instance's type scales together.
+ * Which is also why the broadcast below stays on `window` rather than moving to an instance
+ * bus: each mounted agent surface sets its xterm font size imperatively in JS and would
+ * otherwise ignore app zoom entirely, so ALL of them have to hear this.
+ */
+function applyZoom(zoom: number) {
+  document.documentElement.style.setProperty('--zoom', String(zoom));
+  window.dispatchEvent(new CustomEvent('dreamcontext-zoom', { detail: zoom }));
+}
+
+/**
+ * Version handshake against the running server process. Per-SERVER, not per-vault (one
+ * server serves every project in this window), so it belongs to the chrome.
+ *
+ * This bundle is served fresh from disk, but a long-lived server keeps its route table in
+ * memory — after an upgrade it serves THIS (new) bundle with an OLD API and newer routes
+ * 404. An exact version match is the only check that can't drift.
+ */
+function StaleServerBanner() {
+  const { health, serverCurrent } = useServerHealth();
+  if (!health || serverCurrent) return null;
+  return (
+    <div className="stale-server-banner">
+      ⚠ The dashboard server is running an older build (
+      {health.version ?? 'unknown'} vs {__DC_VERSION__}) — some actions will fail.
+      Restart it: <code>dreamcontext dashboard</code>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────── ceiling rules ──────────────────────────────────── */
+
+/** Instances actually mounted right now (cold chips cost nothing). */
+function liveInstanceCount(open: OpenProject[]): number {
+  return open.reduce((n, p) => (p.cold ? n : n + 1), 0);
+}
+
+/**
+ * The oldest instance it is SAFE to tear down, or null when there is none.
+ *
+ * The null-rollup case is the load-bearing one. `rollup === null` means the instance has not
+ * published its state yet — freshly mounted, just revived from a cold chip, or (until T19
+ * lands the publisher) simply never.
+ * It does **not** mean idle. Reading null as "nothing running here" would tear down an
+ * instance holding a live chat, killing its PTY mid-conversation, which is the single thing
+ * this whole design is not allowed to do. So an instance is evictable only once it has said,
+ * in its own words, that it has nothing live.
+ *
+ * The active instance is never a candidate either: the user is looking at it.
+ *
+ * Reads `alive`, never `live`. `live` is a PRESENTATION count for the chip badge — it
+ * excludes shells on purpose, because a plain terminal has no agent behind it and isn't an
+ * "active chat". A dev server or build watch running in a shell is exactly the kind of PTY
+ * this ceiling must never kill, and it would report `live: 0` while still very much alive.
+ * `alive` counts every session still holding a live PTY/WebSocket, shells included — it is
+ * the only field allowed to gate a teardown.
+ */
+function oldestEvictable(open: OpenProject[], keep: readonly string[]): OpenProject | null {
+  for (const p of open) {
+    if (p.cold || keep.includes(p.vault)) continue;
+    if (p.rollup !== null && p.rollup.alive === 0) return p;
+  }
+  return null;
+}
+
+/** Tear an instance down to a cold chip: it unmounts, its chip stays, its rollup is void. */
+function chill(open: OpenProject[], vault: string): OpenProject[] {
+  return open.map((p) => (p.vault === vault ? { ...p, cold: true, rollup: null } : p));
+}
+
+/* ──────────────────────────────────── the component ──────────────────────────────────── */
+
+export function WindowChrome({ initialVault }: { initialVault: string }) {
+  const { theme, setTheme, resolved } = useTheme();
+  const [zoom, setZoom] = useState(getStoredZoom);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  /**
+   * One rail width for the whole window. Hoisted out of `Shell` because N instances each
+   * running their own `useSidebarCollapse()` would read the shared key at mount and then
+   * diverge the moment one of them toggled — two rails of different widths in one window.
+   */
+  const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useSidebarCollapse();
+
+  /*
+   * NO PERSISTENCE, deliberately. The window opens with exactly the one project the launcher
+   * named in `?vault=`, every time. A restored tab list would resurrect N live agent surfaces
+   * (and N PTYs) on a launch the user meant as a fresh start, and would do it before they had
+   * a chance to say otherwise.
+   */
+  const [open, setOpenState] = useState<OpenProject[]>(() => [
+    { vault: initialVault, instanceId: 'inst-1', cold: false, rollup: null },
+  ]);
+  const [activeVault, setActiveState] = useState(initialVault);
+
+  /*
+   * `addTab` has to READ the current tabs and DECIDE in one synchronous pass (is it already
+   * here? is there room? who can be evicted?) before returning its verdict to the caller. A
+   * state variable captured in a closure is one render behind for that, so the tab list is
+   * mirrored into a ref and every write goes through these two setters.
+   */
+  const openRef = useRef(open);
+  const activeRef = useRef(activeVault);
+  const seqRef = useRef(1);
+
+  const setOpen = useCallback((next: OpenProject[]) => {
+    openRef.current = next;
+    setOpenState(next);
+  }, []);
+
+  const setActive = useCallback((vault: string) => {
+    activeRef.current = vault;
+    setActiveState(vault);
+  }, []);
+
+  /** A fresh instance id. Never reuses a retired one — stale ids would collide in the DOM. */
+  const mintInstanceId = useCallback(() => {
+    seqRef.current += 1;
+    return `inst-${seqRef.current}`;
+  }, []);
+
+  /**
+   * The rollup sink: where every instance's published chip state lands, and the only place a
+   * rollup lives.
+   *
+   * Kept ON the tab record rather than in a second `Record<vault, ProjectRollup>` beside it,
+   * because a separate map would need its own invalidation on close, on eviction and on
+   * revival — and the failure mode of getting that wrong is a stale `live: 0` making a
+   * freshly-rebuilt instance look evictable. Here the rollup goes away exactly when the tab
+   * that owns it does: `closeTab` drops the record, `chill` and `activate` null the field.
+   *
+   * Bails out BEFORE `setOpen` when the three fields are unchanged. A publisher re-emits on
+   * every status flip its surface notices — keystroke-driven `working`↔`ready` churn included
+   * — and re-rendering the whole chrome (every chip, every consumer of `useChrome`) for a
+   * rollup that says the same thing is the difference between a strip that idles and one that
+   * repaints under the user's hands. Object identity is no use as the test: each publish is a
+   * fresh object.
+   */
+  const handleRollup = useCallback((vault: string, next: ProjectRollup) => {
+    const current = openRef.current;
+    const index = current.findIndex((p) => p.vault === vault);
+    if (index === -1) return;            // closed while its instance was tearing down
+    const tab = current[index];
+    if (tab.cold) return;                // evicted; whatever it says is about a dead instance
+    const prev = tab.rollup;
+    if (prev && prev.worst === next.worst && prev.live === next.live && prev.waiting === next.waiting) {
+      return;
+    }
+    const updated = [...current];
+    updated[index] = { ...tab, rollup: next };
+    setOpen(updated);
+  }, [setOpen]);
+
+  const noticeTimer = useRef<number | null>(null);
+  const notify = useCallback((message: string) => {
+    setNotice(message);
+    if (noticeTimer.current !== null) window.clearTimeout(noticeTimer.current);
+    noticeTimer.current = window.setTimeout(() => setNotice(null), NOTICE_MS);
+  }, []);
+  useEffect(() => () => {
+    if (noticeTimer.current !== null) window.clearTimeout(noticeTimer.current);
+  }, []);
+
+  useEffect(() => {
+    applyZoom(zoom);
+  }, [zoom]);
+
+  /**
+   * Teach the ask alarm which project is on screen.
+   *
+   * Without this, `attention.ts` can only ask whether the WINDOW is focused — and a focused
+   * window holding six projects tells it nothing about the one that is asking. It would skip
+   * the banner and the Dock bounce for a background project's question, which is the single
+   * scenario the chip strip exists to surface.
+   *
+   * Reads `activeRef`, never the `activeVault` closure: an empty dep array over a captured
+   * value would pin the probe to whichever project was active at MOUNT and answer for it for
+   * the life of the window — a quieter version of the bug this fixes. Registered once and
+   * torn down on unmount so a closed window never leaves a dangling answer behind.
+   */
+  useEffect(() => {
+    setChipActiveProbe((vault) => vault === activeRef.current);
+    return () => setChipActiveProbe(null);
+  }, []);
+
+  /**
+   * Point the overlay stack at the project on screen, so Esc closes the panel the user can
+   * SEE.
+   *
+   * Every instance stays mounted, so a background project's Esc handler is still registered
+   * on `window` and still fires. Sharing one flat LIFO across them lets two projects steal
+   * each other's Esc in both directions — a panel open in the background can sit on top and
+   * deafen the foreground, or answer an Esc meant for it. `overlayStack.ts` carries the
+   * reasoning; this is the one line that tells it which project is in front.
+   *
+   * Keyed on the INSTANCE id rather than the vault: reviving a cold chip mints a fresh id,
+   * and the revived project's overlays must not inherit the dead instance's scope.
+   */
+  const activeInstanceId = open.find((p) => p.vault === activeVault)?.instanceId ?? null;
+  useEffect(() => {
+    setActiveOverlayScope(activeInstanceId);
+    return () => setActiveOverlayScope(null);
+  }, [activeInstanceId]);
+
+  const activate = useCallback((vault: string) => {
+    const current = openRef.current;
+    const target = current.find((p) => p.vault === vault);
+    if (!target) return;
+
+    if (target.cold) {
+      // Reviving a cold chip rebuilds a real instance, so it has to pass the ceiling too.
+      let next = current;
+      if (liveInstanceCount(current) >= MAX_LIVE_INSTANCES) {
+        const victim = oldestEvictable(current, [vault, activeRef.current]);
+        if (!victim) {
+          notify(`Can't reopen ${vault} — every other project has a live session.`);
+          return;
+        }
+        next = chill(next, victim.vault);
+      }
+      setOpen(next.map((p) => (
+        p.vault === vault ? { ...p, cold: false, rollup: null, instanceId: mintInstanceId() } : p
+      )));
+    }
+
+    setActive(vault);
+  }, [mintInstanceId, notify, setActive, setOpen]);
+
+  const addTab = useCallback(async (vault: string): Promise<AddTabResult> => {
+    // 1. Already a chip in THIS window — the same project must never be open twice.
+    if (openRef.current.some((p) => p.vault === vault)) {
+      activate(vault);
+      return 'focused-tab';
+    }
+
+    // 2. Already open in ANOTHER window — surface that window and add no chip here. One
+    //    project, one home: two windows both live on the same `state/.agent-sessions.json`.
+    //    The REGISTRY-ONLY lookup is the right one here, and deliberately so: it may name a
+    //    window that has since closed, but the cost of that is a `focusWindow` resolving
+    //    false, which falls straight through to opening the chip locally. (The corroborated
+    //    `resolveLiveWindowForVault` is reserved for the checklist payload, where a wrong
+    //    answer leaks a secret instead of costing a no-op — see `windowRegistry.ts`.)
+    const otherWindow = findWindowForVault(vault);
+    if (otherWindow && await focusWindow(otherWindow)) return 'focused-window';
+
+    /*
+     * That await yielded, so the tab list may have moved underneath: a rollup landed, or a
+     * second pick of the same project got in behind this one. Re-read it — deciding the
+     * ceiling from a pre-await snapshot and then writing it back would silently undo whatever
+     * happened in between — and re-run the duplicate check on the fresh list.
+     */
+    const current = openRef.current;
+    if (current.some((p) => p.vault === vault)) {
+      activate(vault);
+      return 'focused-tab';
+    }
+
+    // 3. At the ceiling — free a slot, or say why we can't.
+    let next = current;
+    if (liveInstanceCount(current) >= MAX_LIVE_INSTANCES) {
+      const victim = oldestEvictable(current, [activeRef.current]);
+      if (!victim) {
+        notify(`${MAX_LIVE_INSTANCES} projects are open and all of them have a live session — close one first.`);
+        return 'refused-ceiling';
+      }
+      next = chill(next, victim.vault);
+      notify(`${victim.vault} was idle, so it was put to sleep to make room. Click its chip to reopen it.`);
+    }
+
+    // 4. Room to grow.
+    setOpen([...next, { vault, instanceId: mintInstanceId(), cold: false, rollup: null }]);
+    setActive(vault);
+    return 'added';
+  }, [activate, mintInstanceId, notify, setActive, setOpen]);
+
+  const closeTab = useCallback((vault: string) => {
+    const current = openRef.current;
+    if (current.length <= 1) {
+      notify('This window always keeps one project open.');
+      return;
+    }
+    const index = current.findIndex((p) => p.vault === vault);
+    if (index === -1) return;
+
+    const next = current.filter((p) => p.vault !== vault);
+    setOpen(next);
+
+    if (activeRef.current === vault) {
+      // Prefer the chip that took its place, then walk left; skip cold chips so closing a tab
+      // never lands the user on a blank body.
+      const searchOrder = [...next.slice(index), ...next.slice(0, index).reverse()];
+      setActive((searchOrder.find((p) => !p.cold) ?? searchOrder[0]).vault);
+    }
+  }, [notify, setActive, setOpen]);
+
+  const detachToWindow = useCallback(async (vault: string) => {
+    if (openRef.current.length <= 1) {
+      notify(`${vault} is this window's only project — open another one first.`);
+      return;
+    }
+    try {
+      // Open FIRST, close second: if the window can't be created we still have the chip,
+      // whereas the other order would drop the project on the floor.
+      await openVaultWindow(vault);
+    } catch (err) {
+      notify(`Couldn't open a window for ${vault}: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    closeTab(vault);
+  }, [closeTab, notify]);
+
+  /**
+   * Take over `goToProject` for as long as this window can hold chips.
+   *
+   * "Go to project X" used to mean "open X's window" because a window WAS a project. It now
+   * means "add a chip here" — but the callers that say it (the ⌘P switcher, and anything
+   * non-React that reaches for `lib/desktop`) can't see chrome state, so the inversion happens
+   * through a registration rather than an import. Cleared on unmount: a window that is going
+   * away must not keep answering for chips it no longer has, and the launcher — which
+   * registers nothing — keeps opening a separate window exactly as before.
+   */
+  useEffect(() => {
+    setGoToProjectHandler(async (vault: string) => { await addTab(vault); });
+    return () => setGoToProjectHandler(null);
+  }, [addTab]);
+
+  /**
+   * Publish this window's chips to the cross-window registry, on every change and on a
+   * heartbeat.
+   *
+   * COLD CHIPS ARE PUBLISHED TOO. A cold chip is still this window's claim on that project —
+   * clicking it rebuilds the instance HERE — so another window asking "who has X?" has to be
+   * told about it, or the same project ends up live in two windows with two writers on one
+   * `state/.agent-sessions.json`.
+   *
+   * Keyed on the SERIALISED vault list rather than on `open` itself, so the write fires when
+   * the set of projects changes and not every time a rollup ticks — `open` gets a new identity
+   * on every published status flip, which would otherwise republish several times a second.
+   */
+  const openVaultsKey = JSON.stringify(open.map((p) => p.vault));
+  useEffect(() => {
+    const vaults = JSON.parse(openVaultsKey) as string[];
+    publishOpenVaults(vaults);
+    const beat = window.setInterval(() => publishOpenVaults(vaults), HEARTBEAT_MS);
+    return () => window.clearInterval(beat);
+  }, [openVaultsKey]);
+
+  /**
+   * Withdraw this window's row the moment it starts closing, instead of leaving a lookup
+   * pointing at it for up to `STALE_MS`. `beforeunload` covers the real exit; the unmount
+   * cleanup covers a teardown that never becomes a page unload (a dev reload, say). The
+   * registry's staleness GC is the backstop for the crash neither of them can catch.
+   */
+  useEffect(() => {
+    window.addEventListener('beforeunload', releaseWindow);
+    return () => {
+      window.removeEventListener('beforeunload', releaseWindow);
+      releaseWindow();
+    };
+  }, []);
+
+  const chrome = useMemo<ChromeApi>(
+    () => ({ open, activeVault, addTab, activate, closeTab, detachToWindow }),
+    [open, activeVault, addTab, activate, closeTab, detachToWindow],
+  );
+
+  const chips = useMemo<ProjectChip[]>(() => open.map((p) => ({
+    vault: p.vault,
+    active: p.vault === activeVault,
+    cold: p.cold,
+    // Everything but `asking` and `working` renders neutral, so an unpublished rollup is
+    // indistinguishable from a quiet project — which is exactly right.
+    worst: p.rollup?.worst ?? 'ended',
+    live: p.rollup?.live ?? 0,
+    waiting: p.rollup?.waiting ?? 0,
+    // TODO(T19): the bounce has exactly one writer, and it is not this memo. The sink above
+    // holds the state a bounce is derived FROM (`waiting` crossing 0→>0); T19 owns turning
+    // that edge into a nonce, alongside the publisher that makes the edge happen at all.
+    bounceNonce: 0,
+  })), [open, activeVault]);
+
+  const zoomIndex = ZOOM_LEVELS.indexOf(zoom);
+  const changeZoom = (delta: -1 | 1) => {
+    const nextIndex = zoomIndex + delta;
+    if (nextIndex < 0 || nextIndex >= ZOOM_LEVELS.length) return;
+    const next = ZOOM_LEVELS[nextIndex];
+    setZoom(next);
+    try { localStorage.setItem(ZOOM_STORAGE_KEY, String(next)); } catch { /* ignore */ }
+  };
+
+  const cycleTheme = () => {
+    setTheme(theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system');
+  };
+  const themeLabel = theme === 'system' ? `System (${resolved})` : resolved === 'dark' ? 'Dark' : 'Light';
+
+  /**
+   * The `+` opens the ⌘P switcher by firing the keystroke it already listens for.
+   * TODO(T9): `ProjectSwitcher` gains a chrome-owned open handle and this goes away — until
+   * then this task does not reach into a file it doesn't own to add one.
+   */
+  const openSwitcher = useCallback(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', metaKey: true, bubbles: true }));
+  }, []);
+
+  return (
+    <ChromeContext.Provider value={chrome}>
+      <div className="window-chrome">
+        <UpgradeRelaunchBanner />
+        <StaleServerBanner />
+
+        {/*
+          This bar IS the title bar now. Drag and double-click-maximize are handled in JS
+          rather than with `data-tauri-drag-region`: that attribute injects Tauri's own
+          dblclick→toggleMaximize, which fires even with `dragDropEnabled: false` and fights
+          our handler (and macOS native zoom) into a maximize/restore flicker — the reason
+          `Header` dropped it. `startTitleBarDrag` already exempts every button, so a chip and
+          the `+` are un-draggable and only the strip's empty space grabs the window.
+        */}
+        <div
+          className="window-chrome-bar"
+          onMouseDown={startTitleBarDrag}
+          onDoubleClick={(e) => void toggleMaximizeWindow(e.target)}
+        >
+          <div className="window-chrome-inset" aria-hidden="true" />
+
+          <ProjectTabs
+            chips={chips}
+            onActivate={activate}
+            onClose={closeTab}
+            onAdd={openSwitcher}
+            onDetach={(vault) => void detachToWindow(vault)}
+          />
+
+          {notice && <div className="window-chrome-notice" role="status">{notice}</div>}
+
+          <div className="window-chrome-right">
+            <div className="zoom-controls">
+              <button className="zoom-btn" onClick={() => changeZoom(-1)} disabled={zoomIndex <= 0} title="Zoom out">-</button>
+              <span className="zoom-label">{Math.round(zoom * 100)}%</span>
+              <button className="zoom-btn" onClick={() => changeZoom(1)} disabled={zoomIndex >= ZOOM_LEVELS.length - 1} title="Zoom in">+</button>
+            </div>
+            <button className="theme-toggle" onClick={cycleTheme} title={`Theme: ${themeLabel}`}>
+              {resolved === 'dark' ? (
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 1a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 1zm0 10a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 11zm7-3a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 15 8zM5 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 5 8zm7.07-4.07a.5.5 0 0 1 0 .71l-1.41 1.41a.5.5 0 1 1-.71-.71l1.41-1.41a.5.5 0 0 1 .71 0zM6.05 10.66a.5.5 0 0 1 0 .71l-1.41 1.41a.5.5 0 0 1-.71-.71l1.41-1.41a.5.5 0 0 1 .71 0zm7.72 3.12a.5.5 0 0 1-.71 0l-1.41-1.41a.5.5 0 1 1 .71-.71l1.41 1.41a.5.5 0 0 1 0 .71zM5.34 6.05a.5.5 0 0 1-.71 0L3.22 4.64a.5.5 0 0 1 .71-.71l1.41 1.41a.5.5 0 0 1 0 .71zM8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8z" />
+                </svg>
+              ) : (
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/*
+          Every non-cold project, mounted at once. `isActive` decides which one is VISIBLE;
+          it must never decide which one exists.
+        */}
+        <div className="window-chrome-body">
+          {open.filter((p) => !p.cold).map((p) => (
+            <ProjectInstance
+              key={p.instanceId}
+              vault={p.vault}
+              instanceId={p.instanceId}
+              isActive={p.vault === activeVault}
+              sidebarCollapsed={sidebarCollapsed}
+              onToggleSidebar={toggleSidebar}
+              onRollup={handleRollup}
+            />
+          ))}
+        </div>
+
+        {/* One switcher for the window, not one per project. */}
+        <ProjectSwitcher />
+      </div>
+    </ChromeContext.Provider>
+  );
+}

--- a/dashboard/src/components/search/BrainSearch.tsx
+++ b/dashboard/src/components/search/BrainSearch.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useRecall, haikuRecallOnce, recallOnce, type RecallHit } from '../../hooks/useRecall';
 import { useRecallMode } from '../../hooks/useSleep';
+import { useApi } from '../../context/VaultContext';
 import { TypeIcon, SearchIcon, SparkIcon } from '../sleepy/TypeIcons';
 import { tagHue } from '../../lib/tagColor';
 import './BrainSearch.css';
@@ -88,6 +89,7 @@ function Highlight({ text, tokens }: { text: string; tokens: string[] }) {
 export function BrainSearch({
   scope, placeholder, selectedSlug, onOpen, browse, detail, formatTitle,
 }: BrainSearchProps) {
+  const api = useApi();
   const [q, setQ] = useState('');
   const [debouncedQ, setDebouncedQ] = useState('');
   // When the vault recall mode is 'hybrid', live search already runs BM25+dense
@@ -149,16 +151,16 @@ export function BrainSearch({
     setIntelliQuery(query);
     setFocused(0);
     try {
-      const res = await haikuRecallOnce(query, types);
+      const res = await haikuRecallOnce(api, query, types);
       setIntelliHits(res.hits);
       setIntelliMode(res.mode);
     } catch {
       // Haiku unreachable — degrade to local BM25 so search still answers.
-      try { setIntelliHits(await recallOnce(query, types, 14)); } catch { setIntelliHits([]); }
+      try { setIntelliHits(await recallOnce(api, query, types, 14)); } catch { setIntelliHits([]); }
       setIntelliMode('bm25');
     }
     setIntelliState('done');
-  }, [trimmedQ, types]);
+  }, [api, trimmedQ, types]);
 
   const toggleIntelligent = () => {
     setIntelligentPref(v => {

--- a/dashboard/src/components/search/CommandPalette.tsx
+++ b/dashboard/src/components/search/CommandPalette.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useRecall, haikuRecallOnce, recallOnce, type RecallHit } from '../../hooks/useRecall';
 import { useRecallMode } from '../../hooks/useSleep';
+import { useApi } from '../../context/VaultContext';
 import { TypeIcon, SearchIcon, SparkIcon } from '../sleepy/TypeIcons';
 import { DocContent } from '../sleepy/DocContent';
 import { recallNavTarget } from '../../lib/recallNav';
+import { useOverlayId } from '../../lib/useOverlayId';
 import { CommandModal, useListKeyboardNav } from './CommandModal';
 import type { Page } from '../layout/Sidebar';
 import './CommandPalette.css';
@@ -75,6 +77,8 @@ interface CommandPaletteProps {
 }
 
 export function CommandPalette({ open, onClose, onNavigate }: CommandPaletteProps) {
+  const api = useApi();
+  const overlayId = useOverlayId('command-palette');
   const [q, setQ] = useState('');
   const [debouncedQ, setDebouncedQ] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -153,15 +157,15 @@ export function CommandPalette({ open, onClose, onNavigate }: CommandPaletteProp
     setFocused(0);
     const level = minLevel || undefined;
     try {
-      const res = await haikuRecallOnce(query, [], level);
+      const res = await haikuRecallOnce(api, query, [], level);
       setIntelliHits(res.hits);
       setIntelliMode(res.mode);
     } catch {
-      try { setIntelliHits(await recallOnce(query, [], 12, level)); } catch { setIntelliHits([]); }
+      try { setIntelliHits(await recallOnce(api, query, [], 12, level)); } catch { setIntelliHits([]); }
       setIntelliMode('bm25');
     }
     setIntelliState('done');
-  }, [trimmed, setFocused, minLevel]);
+  }, [api, trimmed, setFocused, minLevel]);
 
   // 0 → 2 → 3 → 0. A 3-position dial, so clicking cycles rather than opening a menu.
   const cycleLevel = useCallback(() => {
@@ -207,7 +211,7 @@ export function CommandPalette({ open, onClose, onNavigate }: CommandPaletteProp
 
   return (
     <CommandModal
-      id="command-palette"
+      id={overlayId}
       open={open}
       onClose={onClose}
       ariaLabel="Search the brain"

--- a/dashboard/src/components/search/ProjectSwitcher.tsx
+++ b/dashboard/src/components/search/ProjectSwitcher.tsx
@@ -1,30 +1,24 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLauncherStatus, type VaultStatus } from '../../hooks/useLauncher';
-import { goToProject, openLauncherHome } from '../../lib/desktop';
+import { goToProject, openLauncherHome, openVaultWindow } from '../../lib/desktop';
+import { useChrome } from '../layout/WindowChrome';
 import { CommandModal, useListKeyboardNav } from './CommandModal';
 import { VaultDot } from '../layout/VaultDot';
 import './ProjectSwitcher.css';
 
 /**
- * ⌘P "Go to Project" — a fast, tab-like project switcher available in EVERY
- * window (launcher and vault). It removes the two big multi-window pains:
- * hunting for another project's window, and having no quick way back to the
- * launcher.
+ * ⌘P "Go to Project" — a fast, tab-like project switcher, mounted once per window.
  *
- * Every project keeps its OWN window: picking one opens it, or FOCUSES it if it's
- * already open (see `goToProject`) — the window you're in is never closed. The
- * "Launcher" row (shown in vault windows) focuses or reopens the home window the
- * same way. ⌘1…⌘9 jump straight to the Nth project without opening the palette.
+ * A window used to hold exactly one project, so picking one from here meant opening
+ * or focusing that project's OWN window. Now a vault window holds several LIVE
+ * projects as chips, so the default action is to add (or focus) a chip in THIS
+ * window instead (`useChrome().addTab`) — `openVaultWindow` remains as the
+ * ⇧-click / ⇧+Enter escape hatch for anyone who wants a real second OS window.
+ *
+ * The launcher window has no chips to add to (it renders no `WindowChrome`), so it
+ * keeps the old behaviour untouched: picking a project opens/focuses that project's
+ * window. `useChrome()` tells the two apart — see `inLauncher` below.
  */
-
-/** The vault this window is pinned to (`?vault=`), or null in the launcher. */
-function currentVault(): string | null {
-  try {
-    return new URLSearchParams(window.location.search).get('vault');
-  } catch {
-    return null;
-  }
-}
 
 /** Don't hijack ⌘1-9 while the user is typing in a field or the agent terminal. */
 function isEditableTarget(el: EventTarget | null): boolean {
@@ -44,8 +38,18 @@ function isTerminalTarget(el: EventTarget | null): boolean {
 }
 
 export function ProjectSwitcher() {
+  const chrome = useChrome();
+  // A real `WindowChrome` always seeds a non-empty `activeVault` (the launcher's
+  // `?vault=`, read once at boot). The only way to see '' is `DETACHED_CHROME` —
+  // the context's default with no provider above it, i.e. this mount is the
+  // launcher window, which renders no chrome at all.
+  const inLauncher = chrome.activeVault === '';
+  const active = inLauncher ? null : chrome.activeVault;
+
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState('');
+  /** Why the last `addTab` attempt didn't open anything — cleared on any successful pick. */
+  const [blockedReason, setBlockedReason] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   // Fetch ONLY while open. Without this gate the query inherits the app-wide 15s
@@ -54,12 +58,19 @@ export function ProjectSwitcher() {
   // result cached, so a reopen within the cache window renders instantly.
   const { data } = useLauncherStatus(open);
   const vaults = useMemo(() => data?.vaults ?? [], [data]);
-  const active = currentVault();
-  const inLauncher = active === null;
 
-  // Existing projects, in listed order — the target set for both the palette and
-  // the ⌘1-9 quick jumps (a gone folder can't be opened).
+  // Existing projects, in listed order — the launcher's ⌘1-9 target set (a gone
+  // folder can't be opened).
   const openable = useMemo(() => vaults.filter((v) => v.exists), [vaults]);
+
+  // The ⌘1-9 quick-jump set: in a vault window it's THIS WINDOW'S CHIPS in chip
+  // order (not registry order — chip order and registry order are unrelated once a
+  // window can hold several projects); in the launcher it's every registered
+  // project, exactly as before.
+  const quickTargets = useMemo(
+    () => (inLauncher ? openable.map((v) => v.name) : chrome.open.map((p) => p.vault)),
+    [inLauncher, openable, chrome.open],
+  );
 
   const filtered = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -69,12 +80,38 @@ export function ProjectSwitcher() {
     );
   }, [vaults, q]);
 
-  const pick = useCallback((v: VaultStatus) => {
-    setOpen(false);
+  const pick = useCallback((v: VaultStatus, opts?: { newWindow?: boolean }) => {
     if (!v.exists) return; // gone folder — nothing to open
-    if (v.name === active) return; // already here
-    void goToProject(v.name);
-  }, [active]);
+
+    // The escape hatch: a real second OS window, regardless of chip state or window.
+    if (opts?.newWindow) {
+      setOpen(false);
+      setBlockedReason(null);
+      void openVaultWindow(v.name);
+      return;
+    }
+
+    if (inLauncher) {
+      setOpen(false);
+      setBlockedReason(null);
+      void goToProject(v.name);
+      return;
+    }
+
+    void chrome.addTab(v.name).then((result) => {
+      if (result === 'refused-ceiling') {
+        // Every open project has a live session, so a new tab would have to evict
+        // one and there's nothing safe to evict. Don't close silently — the user
+        // needs to know why nothing happened, and how to get it anyway.
+        setBlockedReason(
+          `Every open project has a live session — close one first, or ⇧-click ${v.name} to open it in its own window.`,
+        );
+        return;
+      }
+      setBlockedReason(null);
+      setOpen(false);
+    });
+  }, [inLauncher, chrome]);
 
   const goHome = useCallback(() => {
     setOpen(false);
@@ -94,15 +131,15 @@ export function ProjectSwitcher() {
   const rows = useMemo<Row[]>(() => {
     const list: Row[] = [];
     if (!inLauncher) list.push({ kind: 'home' });
-    for (const v of filtered) list.push({ kind: 'vault', vault: v, quickIdx: openable.indexOf(v) });
+    for (const v of filtered) list.push({ kind: 'vault', vault: v, quickIdx: quickTargets.indexOf(v.name) });
     return list;
-  }, [inLauncher, filtered, openable]);
+  }, [inLauncher, filtered, quickTargets]);
 
-  const activate = useCallback((i: number) => {
+  const activate = useCallback((i: number, opts?: { newWindow?: boolean }) => {
     const row = rows[i];
     if (!row) return;
     if (row.kind === 'home') goHome();
-    else pick(row.vault);
+    else pick(row.vault, opts);
   }, [rows, goHome, pick]);
 
   // Shared ↑/↓/Enter list nav (+ length clamp). Esc is owned by <CommandModal>.
@@ -110,6 +147,18 @@ export function ProjectSwitcher() {
     length: rows.length,
     onEnter: activate,
   });
+
+  // Shift+Enter is the same escape hatch as ⇧-click. The shared nav hook has no
+  // notion of modifier keys, so it's intercepted here and everything else falls
+  // through to it unchanged.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && e.shiftKey) {
+      e.preventDefault();
+      activate(focused, { newWindow: true });
+      return;
+    }
+    onKeyDown(e);
+  }, [activate, focused, onKeyDown]);
 
   // Keep the keyboard-focused row scrolled into view as ↑/↓ move past the fold.
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -119,7 +168,7 @@ export function ProjectSwitcher() {
       ?.scrollIntoView({ block: 'nearest' });
   }, [focused]);
 
-  // Global keys: ⌘P toggles the palette; ⌘1-9 jump to the Nth openable project.
+  // Global keys: ⌘P toggles the palette; ⌘1-9 jump to the Nth quick target.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -130,20 +179,29 @@ export function ProjectSwitcher() {
         return;
       }
       if (/^[1-9]$/.test(e.key) && !e.shiftKey && !isEditableTarget(e.target)) {
-        const target = openable[Number(e.key) - 1];
-        if (!target) return;
-        e.preventDefault();
-        if (target.name !== active) void goToProject(target.name);
+        const idx = Number(e.key) - 1;
+        if (inLauncher) {
+          const target = openable[idx];
+          if (!target) return;
+          e.preventDefault();
+          if (target.name !== active) void goToProject(target.name);
+        } else {
+          const target = chrome.open[idx];
+          if (!target) return;
+          e.preventDefault();
+          chrome.activate(target.vault);
+        }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [openable, active]);
+  }, [openable, active, inLauncher, chrome]);
 
   // Reset + focus each time it opens.
   useEffect(() => {
     if (!open) return;
     setQ('');
+    setBlockedReason(null);
     setFocused(0);
     const raf = requestAnimationFrame(() => { try { inputRef.current?.focus(); } catch { /* ignore */ } });
     return () => cancelAnimationFrame(raf);
@@ -160,11 +218,27 @@ export function ProjectSwitcher() {
           spellCheck={false}
           autoComplete="off"
           aria-label="Go to project"
-          onChange={(e) => { setQ(e.target.value); setFocused(0); }}
-          onKeyDown={onKeyDown}
+          onChange={(e) => { setQ(e.target.value); setFocused(0); setBlockedReason(null); }}
+          onKeyDown={handleKeyDown}
         />
         <kbd className="psw-kbd">esc</kbd>
       </div>
+
+      {blockedReason && (
+        <div
+          className="psw-blocked-notice"
+          role="status"
+          style={{
+            padding: '8px 16px',
+            fontSize: 12,
+            lineHeight: 1.4,
+            color: 'var(--color-text-secondary)',
+            borderBottom: '1px solid var(--color-border)',
+          }}
+        >
+          {blockedReason}
+        </div>
+      )}
 
       <div className="psw-list" role="listbox" aria-label="Projects" ref={listRef}>
         {rows.map((row, i) => {
@@ -188,7 +262,12 @@ export function ProjectSwitcher() {
             );
           }
           const { vault: v, quickIdx } = row;
-          const isCurrent = v.name === active;
+          // "current" = the one active chip; "open" = any other chip already in this
+          // window. Both reuse the existing dimmed treatment so an already-open
+          // project reads as "nothing to do here" at a glance; only the active one
+          // gets the accent-coloured label.
+          const isActiveChip = !inLauncher && v.name === active;
+          const isOpenChip = !inLauncher && chrome.open.some((p) => p.vault === v.name);
           return (
             <button
               key={v.name}
@@ -197,8 +276,8 @@ export function ProjectSwitcher() {
               aria-selected={isFocused}
               data-row-index={i}
               disabled={!v.exists}
-              className={`psw-row${isFocused ? ' psw-row--focused' : ''}${isCurrent ? ' psw-row--current' : ''}`}
-              onClick={() => pick(v)}
+              className={`psw-row${isFocused ? ' psw-row--focused' : ''}${isOpenChip ? ' psw-row--current' : ''}`}
+              onClick={(e) => pick(v, { newWindow: e.shiftKey })}
               onMouseEnter={() => setFocused(i)}
             >
               <VaultDot exists={v.exists} needsUpdate={v.needsUpdate} />
@@ -206,8 +285,10 @@ export function ProjectSwitcher() {
                 <span className="psw-row-name">{v.name}</span>
                 <span className="psw-row-path">{v.path}</span>
               </span>
-              {isCurrent ? (
+              {isActiveChip ? (
                 <span className="psw-row-hint psw-row-hint--current">current</span>
+              ) : isOpenChip ? (
+                <span className="psw-row-hint">open</span>
               ) : quickIdx >= 0 && quickIdx < 9 ? (
                 <kbd className="psw-row-num">⌘{quickIdx + 1}</kbd>
               ) : null}

--- a/dashboard/src/components/settings/SystemDependencies.tsx
+++ b/dashboard/src/components/settings/SystemDependencies.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useI18n } from '../../context/I18nContext';
-import { api } from '../../api/client';
+import { useApi, useVault } from '../../context/VaultContext';
 import { useAgentCapabilities } from '../../hooks/useAgentCapabilities';
 import { claudeAuthRow, requestClaudeSignIn } from '../../lib/claudeAuth';
 import type { Capabilities } from '../sleepy/agentSession';
@@ -85,6 +85,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  */
 export function useSystemInstall() {
   const queryClient = useQueryClient();
+  const api = useApi();
   const [running, setRunning] = useState<InstallTarget | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -172,6 +173,7 @@ function DepRow({ dep, caps }: { dep: DepMeta; caps: Capabilities }) {
  */
 function ClaudeAccountRow({ caps }: { caps: Capabilities }) {
   const { t } = useI18n();
+  const { bus } = useVault();
   const row = claudeAuthRow(caps.claudeAuth);
   if (!row) return null;
   // The in-app sign-in opens a terminal pane, which needs the embedded terminal. Without
@@ -190,7 +192,7 @@ function ClaudeAccountRow({ caps }: { caps: Capabilities }) {
       </span>
       {row.identity && <span className="sysdep-manual">{row.identity}</span>}
       {canSignInInApp && (
-        <button className="btn btn--primary btn--sm" onClick={requestClaudeSignIn}>
+        <button className="btn btn--primary btn--sm" onClick={() => requestClaudeSignIn(bus)}>
           {t('system.auth.signIn')}
         </button>
       )}

--- a/dashboard/src/components/sleepy/AgentSetup.tsx
+++ b/dashboard/src/components/sleepy/AgentSetup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, type CSSProperties } from 'react';
-import { api } from '../../api/client';
+import { useApi } from '../../context/VaultContext';
 import { ACCENT, type Capabilities, type ConfirmRequest } from './agentSession';
 
 /**
@@ -103,6 +103,7 @@ export function BypassPill({ bypass, setBypass }: { bypass: boolean; setBypass: 
 type InstallTarget = 'claude' | 'pty';
 
 export function Prereqs({ caps, onRefresh }: { caps: Capabilities; onRefresh: () => Promise<Capabilities | null> }) {
+  const api = useApi();
   const [busy, setBusy] = useState<InstallTarget | null>(null);
   const [log, setLog] = useState('');
   const [err, setErr] = useState('');
@@ -126,7 +127,7 @@ export function Prereqs({ caps, onRefresh }: { caps: Capabilities; onRefresh: ()
     } finally {
       setBusy(null);
     }
-  }, [onRefresh]);
+  }, [api, onRefresh]);
 
   const rows: { target: InstallTarget; label: string; ok: boolean; desc: string }[] = [
     { target: 'claude', label: 'Claude CLI', ok: caps.claudeCli, desc: 'Anthropic’s claude command — the agent that runs in the terminal.' },

--- a/dashboard/src/components/sleepy/AgentSurface.tsx
+++ b/dashboard/src/components/sleepy/AgentSurface.tsx
@@ -3,7 +3,8 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import './AgentTerminal.css';
-import { api, getActiveVault } from '../../api/client';
+import { api } from '../../api/client';
+import { useVault, useApi, useInstanceEvent, emitInstance } from '../../context/VaultContext';
 import { uploadAgentFile } from '../../lib/agentDrop';
 import {
   createSession, currentZoom,
@@ -12,11 +13,13 @@ import {
 import { createChatSession, type ChatSession, type ChatUserItem } from './chatSession';
 import { ChatPaneHost, type ChatSurfaceActions } from './ChatPaneHost';
 import {
-  initAgentSettingsFromServer, readAgentSettings, patchAgentSettings, matchesAccel,
+  initAgentSettingsFromServer, readAgentSettings, matchesAccel,
   doubleTapToken, createDoubleTapMatcher,
   AGENT_SETTINGS_EVENT, type AgentSettings,
+  readChatPermissionMode, writeChatPermissionMode,
+  CHAT_PERMISSION_MODE_EVENT, type ChatPermissionMode,
 } from '../../lib/agentSettings';
-import { deriveSessionStatus, type SessionRow } from './agentStatus';
+import { deriveSessionStatus, rollupProject, type ProjectRollup, type SessionRow } from './agentStatus';
 import { PaneFragment, type PaneActions } from './PaneFragment';
 import { AgentTabs, type PaneVM } from './AgentTabs';
 import { AgentDock } from './AgentDock';
@@ -72,6 +75,16 @@ import { ChatHistoryPicker, type PastSession } from './ChatHistoryPicker';
  * Desktop-only and capability-gated. Bypass-permissions is OFF by default (armed
  * explicitly per session, shown as a ⚡ on that session's tab).
  */
+
+/**
+ * This project's chip state, published on the INSTANCE bus for the window chrome to draw.
+ *
+ * On the bus rather than on `window` for the usual reason — with several projects mounted in
+ * one window, a `window` event would have every chip repainted from whichever surface emitted
+ * last. The detail is a {@link ProjectRollup}; the chrome keys it by the vault of the instance
+ * that forwarded it, so the surface never has to name itself.
+ */
+export const PROJECT_ROLLUP_EVENT = 'dc-project-rollup';
 
 // ── Layout model ─────────────────────────────────────────────────────────────────
 
@@ -170,6 +183,22 @@ function removeFromPane(p: PaneState, sid: string): PaneState {
 // ── The persistent surface ─────────────────────────────────────────────────────
 
 export function AgentSurface() {
+  // Which project this surface belongs to. Every session it spawns, every file it uploads and
+  // the checklist bridge it registers are bound to THIS vault — one window holds several live
+  // projects, so reading an "active vault" module global here would spawn a project's agent
+  // against whichever chip the user last touched.
+  // `isActive` is whether this project is the chip the user is LOOKING at. It gates two
+  // things only — when a terminal grabs focus, and when it is (re)fitted. It must never
+  // reach a WebSocket: a hidden instance stays mounted and fully live, its chat still
+  // streaming, and the only thing a chip switch changes is what the pixels are measured
+  // against (see HARD CONSTRAINT #2 in the project-tabs plan).
+  const { vault, isActive, bus } = useVault();
+  // A vault-scoped client for the PER-VAULT routes below (session roster, auto-title,
+  // open-terminal) — none of these are on the server's `VAULT_AGNOSTIC_PREFIXES` list, so the
+  // module `api` singleton would resolve them against whichever vault the server happens to be
+  // pinned to. `/agent/capabilities` and `/agent/session-model` stay on the singleton: they are
+  // agnostic (machine-level facts / keyed by claudeId), same answer for every instance.
+  const scopedApi = useApi();
   // The whole surface is mounted once (App.tsx) and toggled between a hidden state and
   // a fullscreen overlay by this local flag. Sessions live in the detached-DOM garage
   // either way, so toggling `expanded` NEVER remounts xterm/WebSocket/PTY.
@@ -244,11 +273,51 @@ export function AgentSurface() {
   const claudeReady = chatMode || !!(caps?.embeddedTerminal && caps?.claudeCli);
 
   const sessions = useRef<Map<string, Session | ChatSession>>(new Map());
-  // The remembered chat permission mode, mirrored into a ref so `spawn` reads the CURRENT
-  // value even when called from a closure captured before the change landed in state —
-  // see `changeChatPermissionMode` and spawn's chat arm.
-  const chatPermissionModeRef = useRef(agentSettings.chatPermissionMode);
-  chatPermissionModeRef.current = agentSettings.chatPermissionMode;
+
+  // Dispose every session when this surface unmounts.
+  //
+  // Until projects became chips this was unnecessary — the surface was mounted once, at the
+  // app root, and outlived everything, so the only way to end a session was to close it
+  // explicitly (`closeSessionById` and the chat resume/hand-off paths). A `ProjectInstance`
+  // can now be torn down under the user: closing a chip, and the ceiling rule evicting the
+  // oldest idle project into a cold chip. Without this, that teardown leaks the PTY, the
+  // WebSocket, the xterm, the theme `MutationObserver` and the per-session
+  // `AGENT_SETTINGS_EVENT` listener — and leaves an orphaned `claude` process on the machine.
+  //
+  // This is the cleanup for an unmount somebody ELSE decided on; nothing here ever decides to
+  // unmount an instance. Empty deps so it runs on unmount ONLY, never on a re-render.
+  // `dispose()` is internally try/caught per teardown step, but wrap per SESSION too so one
+  // throw cannot abort the loop and strand the rest.
+  useEffect(() => () => {
+    sessions.current.forEach((s) => { try { s.dispose(); } catch { /* best-effort */ } });
+    sessions.current.clear();
+  }, []);
+  // ── The remembered chat permission mode — PER VAULT, not part of `agentSettings` ────
+  //
+  // Everything in `agentSettings` is a surface preference that is genuinely the same in every
+  // project. This one decides whether an agent auto-approves everything it is asked to do,
+  // against ONE project's files and ONE project's git, so it is stored per vault and its
+  // change notification rides this instance's bus (see `lib/agentSettings.ts`'s split note).
+  // On `window` — which is where it lived while a project meant a whole OS window — flipping
+  // bypass while looking at project A would rewrite the remembered default for every other
+  // live project, and every session they spawned afterwards would run auto-approved in a
+  // project the user never opted in for.
+  //
+  // `vault` is fixed for the life of this mount (`ProjectInstance` reads it once and never
+  // changes it), so seeding from storage in the initializer is the whole read path.
+  const [chatPermissionMode, setChatPermissionMode] = useState<ChatPermissionMode>(
+    () => readChatPermissionMode(vault),
+  );
+  // Mirrored into a ref so `spawn` reads the CURRENT value even when called from a closure
+  // captured before the change landed in state — see `changeChatPermissionMode` and spawn's
+  // chat arm.
+  const chatPermissionModeRef = useRef(chatPermissionMode);
+  chatPermissionModeRef.current = chatPermissionMode;
+  // A Settings page in THIS project changed it. Same instance, same bus — and a Settings page
+  // in another chip cannot reach us, which is the point.
+  useInstanceEvent<ChatPermissionMode>(CHAT_PERMISSION_MODE_EVENT, (mode) => {
+    if (mode) setChatPermissionMode(mode);
+  });
   const garageRef = useRef<HTMLDivElement | null>(null);
   const hostRef = useRef<HTMLDivElement | null>(null);
   // The session id of the tab currently being dragged. The DnD payload is ALSO written to
@@ -294,6 +363,10 @@ export function AgentSurface() {
 
   // ── Agent-surface settings: load the server-persisted prefs once, then track
   //    live changes the Settings page broadcasts (no reload needed). ──
+  // Deliberately on `window`: what remains in this blob (surface on/off, restore-tabs,
+  // renderer, hotkey, Chat-vs-Terminal) is genuinely app-global and mirrored to
+  // ~/.dreamcontext/agent-ui.json, so EVERY live project should re-apply a change at once.
+  // The one field that was not — `chatPermissionMode` — has left this blob entirely.
   useEffect(() => {
     let cancelled = false;
     void initAgentSettingsFromServer().then((s) => {
@@ -331,7 +404,7 @@ export function AgentSurface() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await api.get<{ sessions: SavedMeta[] }>('/agent/sessions');
+        const res = await scopedApi.get<{ sessions: SavedMeta[] }>('/agent/sessions');
         // Terminals are never remembered — drop any shell entry, plus any legacy roster
         // row still named "Terminal N" (a stale shell saved before we stopped persisting
         // them; auto-title only ever renames AGENTS, so that default name is a reliable
@@ -370,7 +443,7 @@ export function AgentSurface() {
       finally { if (!cancelled) hydratedRef.current = true; }
     })();
     return () => { cancelled = true; };
-  }, [caps, settingsReady, agentSettings.restoreTabs, agentSettings.chatView]);
+  }, [caps, settingsReady, agentSettings.restoreTabs, agentSettings.chatView, scopedApi]);
 
   // Persist on every roster change (post-hydrate), debounced. AGENTS and CHATS are
   // remembered — plain TERMINALS are session-local and never reopened on launch (the server
@@ -388,10 +461,10 @@ export function AgentSurface() {
             title: m.title, kind: m.kind, bypass: m.bypass, minimized: false, size: 1, sessionId: m.claudeId,
           })),
       };
-      void api.put('/agent/sessions', payload).catch(() => { /* best-effort mirror */ });
+      void scopedApi.put('/agent/sessions', payload).catch(() => { /* best-effort mirror */ });
     }, 400);
     return () => clearTimeout(handle);
-  }, [sessionList]);
+  }, [sessionList, scopedApi]);
 
   // ── Session actions ────────────────────────────────────────────────────────
   // claudeId omitted → a fresh conversation (new UUID via `--session-id`); provided with
@@ -400,8 +473,8 @@ export function AgentSurface() {
   // `preparePrompt` (lib/agentPrompt.ts) BEFORE calling spawn, so spawn itself stays
   // synchronous (the delegate ACK in lib/delegateAgent.ts depends on that).
   // `bp` is every caller's REQUESTED bypass (the surface-wide toggle, a delegate's own
-  // per-card choice, …) — for a CHAT session it is overridden here by the remembered
-  // permission-mode default (`agentSettings.chatPermissionMode`, state 6's top-right
+  // per-card choice, …) — for a CHAT session it is overridden here by THIS VAULT's remembered
+  // permission-mode default (`chatPermissionMode`, state 6's top-right
   // dropdown) rather than trusted verbatim. Centralizing the resolution HERE (instead of
   // at each call site) means every current and future chat-spawn path — addSession,
   // addSplitSession, openAgentInChat, dormant resume, resumeChatSession, runSleepAgent,
@@ -418,27 +491,27 @@ export function AgentSurface() {
   // run under bypassPermissions.
   const spawn = useCallback((bp: boolean, claudeId?: string, resume = false, kind: SessionKind = 'agent', initialPrompt = '', model = '', submitInitial = true, promptToken = '', deferPrompt = false, effort = '', explicitBypass = false) => {
     if (kind === 'chat') {
-      // Read through the REF, not the settings object: `changeChatPermissionMode` below can
+      // Read through the REF, not the state value: `changeChatPermissionMode` below can
       // respawn a conversation in the very same tick it changes the mode, and this closure's
-      // `agentSettings` would still be the pre-change render's — spawning the fallback under
-      // exactly the mode the user just left.
+      // `chatPermissionMode` would still be the pre-change render's — spawning the fallback
+      // under exactly the mode the user just left.
       const effectiveBypass = explicitBypass ? bp : chatPermissionModeRef.current === 'bypass';
       // Chat (BETA) is a headless stream-json engine, not a PTY — createChatSession has its
       // own factory (chatSession.ts), takes `effort` at spawn (the terminal only ever
       // switches it live via `/effort`, so its own createSession has no such param), and has
       // no `submitInitial` concept (an initial prompt is always delivered server-side; see
       // chatSession.ts's header note).
-      const cs = createChatSession(effectiveBypass, bumpStatus, claudeId ?? newClaudeId(), resume, model, effort, initialPrompt, promptToken, deferPrompt);
+      const cs = createChatSession(vault ?? '', effectiveBypass, bumpStatus, claudeId ?? newClaudeId(), resume, model, effort, initialPrompt, promptToken, deferPrompt);
       cs.applyZoom(currentZoom());
       sessions.current.set(cs.id, cs);
       return cs;
     }
     // A shell has no permission model, so bypass is meaningless for it — force it off.
-    const s = createSession(kind === 'shell' ? false : bp, bumpStatus, claudeId ?? newClaudeId(), resume, kind, initialPrompt, model, submitInitial, promptToken, deferPrompt);
+    const s = createSession(vault ?? '', kind === 'shell' ? false : bp, bumpStatus, claudeId ?? newClaudeId(), resume, kind, initialPrompt, model, submitInitial, promptToken, deferPrompt);
     s.applyZoom(currentZoom());
     sessions.current.set(s.id, s);
     return s;
-  }, [agentSettings.chatPermissionMode]);
+  }, [chatPermissionMode, vault]);
 
   // Spawn a fresh session AND append its roster entry — the two steps every "new session"
   // path shares. Callers keep only their pane placement, so the roster-entry shape lives in
@@ -565,12 +638,10 @@ export function AgentSurface() {
   // Settings → here. The System doctor now reports the sign-in state (the server probes it
   // via `claude auth status` — see src/lib/claude-auth.ts) and its "Sign in" button lands on
   // this same flow, because a page below this surface in the tree has no handle on it. Same
-  // page-dispatches/surface-listens bridge as the sleep tracker and Delegate.
-  useEffect(() => {
-    const onRequest = () => { if (canSignInInApp) signInToClaude(); };
-    window.addEventListener(CLAUDE_SIGNIN_EVENT, onRequest);
-    return () => window.removeEventListener(CLAUDE_SIGNIN_EVENT, onRequest);
-  }, [canSignInInApp, signInToClaude]);
+  // page-dispatches/surface-listens bridge as the sleep tracker and Delegate — on THIS
+  // instance's bus, so the one Settings page that asked gets the one sign-in tab it wanted
+  // rather than one per live project.
+  useInstanceEvent(CLAUDE_SIGNIN_EVENT, () => { if (canSignInInApp) signInToClaude(); });
 
   // ── Chat ↔ Terminal conversion (AC7's two directions, BETA) ──────────────────────
   //
@@ -606,9 +677,9 @@ export function AgentSurface() {
     })));
   }, [spawn]);
 
-  // The `bypass` dropdown in a chat composer. The mode is ONE app-wide setting (there is a
-  // single `agentSettings.chatPermissionMode`, and every composer's chip shows it), so
-  // changing it from any pane must mean three things at once:
+  // The `bypass` dropdown in a chat composer. The mode is ONE setting PER PROJECT (there is a
+  // single `chatPermissionMode` for this vault, and every composer's chip in this project
+  // shows it), so changing it from any pane must mean three things at once:
   //   1. remembered      — persisted, so every FUTURE chat spawns under it (`spawn`'s chat arm),
   //   2. applied now     — every LIVE chat conversation switches without being restarted
   //                        (`set_permission_mode`), because a chip that reads "bypass" while
@@ -618,29 +689,29 @@ export function AgentSurface() {
   //                        state at the cost of a process restart.
   const changeChatPermissionMode = useCallback((mode: 'auto' | 'bypass') => {
     chatPermissionModeRef.current = mode;  // eagerly, so a fallback respawn in THIS tick is correct
-    // PATCH, not a whole-object write: this control owns one field, and spreading a render's
-    // settings snapshot would rewrite the others from whatever that render happened to hold
-    // (see patchAgentSettings — it is how `chatView` got reset to its default here).
-    patchAgentSettings({ chatPermissionMode: mode });
+    // Persist under THIS vault's key and announce on THIS instance's bus, which is also what
+    // feeds our own `useInstanceEvent` above and moves the state — one write path, no
+    // second `setChatPermissionMode` here that could disagree with what was stored.
+    writeChatPermissionMode(bus, vault, mode);
     sessions.current.forEach((s) => {
       if (s.kind !== 'chat') return;
       const cs = s as ChatSession;
       cs.setPermissionMode(mode, () => resumeChatSession(cs));
     });
-  }, [agentSettings, resumeChatSession]);
+  }, [bus, vault, resumeChatSession]);
 
   // ChatPane's "Open in app ↗" (state 3 — a dreamcontext entity referenced from chat).
-  // AgentSurface is mounted above the router (App.tsx) with no direct handle on Shell's
-  // navigation state, and threading one through is out of this task's file ownership —
-  // so this does the honest subset available from here: collapse the overlay so the page
-  // underneath is actually visible, and fire a forward-compatible window event (unconsumed
-  // today — a future Shell/page listener can pick it up to deep-link the exact item,
-  // exactly the "page dispatches → surface listens" bridge this file already uses in the
-  // other direction for TASK_MANAGER_STATUS_EVENT etc.).
+  // AgentSurface is mounted beside Shell (under `ProjectInstance`) with no direct handle on
+  // Shell's navigation state, so this collapses the overlay and fires the event
+  // `AgentPageNavBridge` listens for, which does the actual `nav.navigate()`.
+  //
+  // On the INSTANCE bus. `id` is a task/knowledge slug that means something in exactly one
+  // vault: broadcast, every mounted project's bridge would navigate, and all but one would
+  // be deep-linking to a slug that does not exist in their brain.
   const onOpenAppPage = useCallback((page: 'tasks' | 'knowledge' | 'core', id: string) => {
     setExpanded(false);
-    try { window.dispatchEvent(new CustomEvent('dreamcontext-agent-open-page', { detail: { page, id } })); } catch { /* SSR/none */ }
-  }, []);
+    emitInstance(bus, 'dreamcontext-agent-open-page', { page, id });
+  }, [bus]);
 
   // terminal→chat: the per-tab "Open in Chat (BETA)" action (AgentTabs). CLOSE-FIRST
   // semantics — the chat route keeps its OWN `liveConversations` guard Set (server-side,
@@ -818,11 +889,9 @@ export function AgentSurface() {
     setActivePaneId(pid);
   }, [caps, agentSettings.enabled, sessionList, spawn, bypass, focusSession, serverCurrent, claudeKind, claudeReady, resubmitPrompt]);
 
-  useEffect(() => {
-    const onRun = () => runSleepAgent();
-    window.addEventListener(RUN_SLEEP_AGENT_EVENT, onRun);
-    return () => window.removeEventListener(RUN_SLEEP_AGENT_EVENT, onRun);
-  }, [runSleepAgent]);
+  // This project's tracker only. A consolidation rewrites one brain; on `window` a single
+  // click would start one in every project the chip strip is holding.
+  useInstanceEvent(RUN_SLEEP_AGENT_EVENT, () => runSleepAgent());
 
   // ── Run brain-resolve agent (the sidebar's one-click "Resolve with AI") ──────────
   // Spawn a dedicated "/dream-sync" session that reconciles the deferred team merge,
@@ -847,11 +916,7 @@ export function AgentSurface() {
     setExpanded(true);
   }, [caps, agentSettings.enabled, sessionList, spawn, bypass, focusSession, serverCurrent, claudeKind, claudeReady, resubmitPrompt]);
 
-  useEffect(() => {
-    const onRun = () => runBrainResolveAgent();
-    window.addEventListener(RUN_BRAIN_RESOLVE_EVENT, onRun);
-    return () => window.removeEventListener(RUN_BRAIN_RESOLVE_EVENT, onRun);
-  }, [runBrainResolveAgent]);
+  useInstanceEvent(RUN_BRAIN_RESOLVE_EVENT, () => runBrainResolveAgent());
 
   // ── Delegate a task to a background agent (from a board card's context menu) ──────
   // A board task card hands a task to Claude via the DELEGATE_AGENT_EVENT bridge (the
@@ -907,17 +972,17 @@ export function AgentSurface() {
     return true;
   }, [caps, agentSettings.enabled, spawn, serverCurrent, panes, activePaneId, claudeKind, claudeReady]);
 
-  useEffect(() => {
-    // Synchronous ACK: `dispatchEvent` runs listeners inline, so writing `accepted` back onto
-    // the detail is visible to `requestDelegateAgent` the moment it returns.
-    const onDelegate = (e: Event) => {
-      const detail = (e as CustomEvent<DelegateAgentDetail>).detail;
-      // Either transport counts as "there is a prompt"; a detail carrying neither is a no-op.
-      if ((detail?.prompt || detail?.promptToken) && delegateAgent(detail)) detail.accepted = true;
-    };
-    window.addEventListener(DELEGATE_AGENT_EVENT, onDelegate);
-    return () => window.removeEventListener(DELEGATE_AGENT_EVENT, onDelegate);
-  }, [delegateAgent]);
+  // Synchronous ACK: dispatch runs listeners inline, so writing `accepted` back onto the
+  // detail is visible to `requestDelegateAgent` the moment it returns.
+  //
+  // The instance bus is load-bearing HERE above everywhere else. On `window` this listener is
+  // one of N, and the first to run sets `accepted` — so the composer in project A is told its
+  // task was delegated while the agent doing the work is in project B, reading a task file
+  // that does not exist there. See `lib/delegateAgent.ts`'s header.
+  useInstanceEvent<DelegateAgentDetail>(DELEGATE_AGENT_EVENT, (detail) => {
+    // Either transport counts as "there is a prompt"; a detail carrying neither is a no-op.
+    if ((detail?.prompt || detail?.promptToken) && delegateAgent(detail)) detail.accepted = true;
+  });
 
   // ── Open an automation run's conversation (from the Automations run history) ──────
   //
@@ -994,14 +1059,12 @@ export function AgentSurface() {
     restoreMinimized, focusSession, spawn, bypass, claudeKind, panes, activePaneId,
   ]);
 
-  useEffect(() => {
-    const onOpenRun = (e: Event) => {
-      const detail = (e as CustomEvent<AutomationRunChatDetail>).detail;
-      if (detail?.sessionId && openAutomationRunChat(detail)) detail.accepted = true;
-    };
-    window.addEventListener(AUTOMATION_RUN_CHAT_EVENT, onOpenRun);
-    return () => window.removeEventListener(AUTOMATION_RUN_CHAT_EVENT, onOpenRun);
-  }, [openAutomationRunChat]);
+  // Bus, not `window`, for the same ACK reason as the delegate above — and because N surfaces
+  // `--resume`ing one conversation uuid is the dual-attach the bring-forward guard exists to
+  // prevent (two live CLIs interleave their appends on one transcript).
+  useInstanceEvent<AutomationRunChatDetail>(AUTOMATION_RUN_CHAT_EVENT, (detail) => {
+    if (detail?.sessionId && openAutomationRunChat(detail)) detail.accepted = true;
+  });
 
   // ── Checklist submit bridge (T8, plan §1.11/§1.12) ────────────────────────────────
   // The pinned checklist window is a SEPARATE OS window with no WebSocket of its own; its
@@ -1039,10 +1102,9 @@ export function AgentSurface() {
   }, [sessionList]);
 
   useEffect(() => {
-    const vault = getActiveVault();
     if (!vault) return;
     return listenForChecklistSubmits(vault, handleChecklistSubmit);
-  }, [handleChecklistSubmit]);
+  }, [vault, handleChecklistSubmit]);
 
   // ── Bottom strip ─────────────────────────────────────────────────────────────────
   // There is NO separate text field: a skill/file goes straight into the terminal's OWN
@@ -1352,7 +1414,7 @@ export function AgentSurface() {
     panes.forEach((pane) => {
       const s = sessions.current.get(pane.active);
       const slot = slots.get(pane.id);
-      if (s && slot && s.container.parentElement !== slot) { slot.appendChild(s.container); s.ensureOpen(); }
+      if (s && slot && s.container.parentElement !== slot) { slot.appendChild(s.container); s.ensureOpen({ focus: isActive }); }
     });
     sessions.current.forEach((s) => {
       if (!homed.has(s.id) && garageRef.current && s.container.parentElement !== garageRef.current) {
@@ -1362,9 +1424,14 @@ export function AgentSurface() {
     // A freshly-shown container only has offsetParent after display, so open/fit next
     // frame. Refits everything ON SCREEN (a split/combine changes every pane's width).
     const raf = requestAnimationFrame(() => {
-      foreground.forEach((id) => { const s = sessions.current.get(id); if (s) { s.ensureOpen(); s.fitAndResize(); } });
+      foreground.forEach((id) => { const s = sessions.current.get(id); if (s) { s.ensureOpen({ focus: isActive }); s.fitAndResize(); } });
     });
     return () => cancelAnimationFrame(raf);
+    // `isActive` is deliberately NOT a dependency: React runs the effect belonging to the
+    // render whose deps changed, so the flag read here is always the current one, and
+    // re-running the whole placement pass on every chip switch would thrash the DOM for a
+    // set of appendChild calls that are all no-ops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panes, expanded]);
 
   // Keep activePaneId pointing at a real pane (panes shrink as tabs close/move).
@@ -1407,14 +1474,38 @@ export function AgentSurface() {
   // ── On EXPAND the panes go from display:none (offsetParent null) to visible, so
   //    refit every visible session next frame. ──
   const fitVisible = useCallback(() => {
-    panes.forEach((p) => { const s = sessions.current.get(p.active); if (s) { s.ensureOpen(); s.fitAndResize(); } });
-  }, [panes]);
+    // "Visible" now means visible in TWO senses: the overlay is expanded AND this project is
+    // the chip on screen. Fitting a hidden instance measures a `display:none` subtree, where
+    // `getComputedStyle().height` is the computed `auto` rather than a used pixel value — the
+    // FitAddon's NaN guard makes that a no-op today, but "no-op by luck" is not a contract to
+    // hand a live PTY (one explicit height on `.agent-pane-term` and it becomes a 2×1 resize).
+    // No-op when `isActive` is true, so a single-project window behaves exactly as before.
+    if (!isActive) return;
+    panes.forEach((p) => { const s = sessions.current.get(p.active); if (s) { s.ensureOpen({ focus: isActive }); s.fitAndResize(); } });
+  }, [panes, isActive]);
 
   useEffect(() => {
     if (!expanded) return;
     const raf = requestAnimationFrame(() => fitVisible());
     return () => cancelAnimationFrame(raf);
   }, [expanded, fitVisible]);
+
+  // ── On ACTIVATION this project's whole subtree goes from hidden (offsetParent null) to
+  //    visible, so re-drive open+fit next frame. ──
+  // Nothing else fires on "my instance became visible": the placement effect is keyed on
+  // [panes, expanded], the effect above on [expanded], and the ResizeObserver below only
+  // exists while expanded AND is 150ms-debounced. Without this, a terminal spawned while its
+  // project was a background chip never opens (`ensureOpen` bails on a null `offsetParent`)
+  // and, because `fitAndResize` no-ops while `!session.opened`, its PTY keeps the server's
+  // default grid — the TUI comes back clipped at the wrong width.
+  //
+  // The rAF is load-bearing: a freshly-shown container only has a non-null `offsetParent`
+  // after the browser has laid it out, so measuring in the same commit measures nothing.
+  useEffect(() => {
+    if (!isActive) return;
+    const raf = requestAnimationFrame(() => fitVisible());
+    return () => cancelAnimationFrame(raf);
+  }, [isActive, fitVisible]);
 
   // Any container width change → refit every visible pane. A ResizeObserver on the host
   // (not just window `resize`) is required because collapsing/expanding the sidebar is a
@@ -1427,8 +1518,13 @@ export function AgentSurface() {
   // fit reflows every xterm grid mid-animation — the visible frame-by-frame judder.
   // Each event resets the timer, so a continuous animation (sidebar toggle, window
   // drag) yields exactly one fit after its final frame.
+  //
+  // Gated on `isActive` as well as `expanded`: a background project's slots keep changing
+  // size (the sidebar hoist, a window resize) while nobody is looking at them, and an
+  // observer left armed there wakes a debounce timer per frame to fit a hidden grid. The
+  // activation effect above re-fits on the way back in, so nothing is lost by not watching.
   useEffect(() => {
-    if (!expanded) return;
+    if (!expanded || !isActive) return;
     const host = hostRef.current;
     if (!host || typeof ResizeObserver === 'undefined') return;
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -1444,7 +1540,7 @@ export function AgentSurface() {
     // pane add/remove re-arms the observer over the current slot set.
     host.querySelectorAll<HTMLElement>('.agent-pane-slot[data-pane]').forEach((el) => ro.observe(el));
     return () => { ro.disconnect(); if (timer) clearTimeout(timer); };
-  }, [expanded, fitVisible]);
+  }, [expanded, isActive, fitVisible]);
 
   // ── Esc collapses the overlay — but ONLY when focus is outside the terminal, so it
   //    never steals Esc from Claude's TUI (which uses Esc to cancel). It also yields to
@@ -1555,7 +1651,7 @@ export function AgentSurface() {
       const firstUserText = s.kind === 'chat'
         ? (s as ChatSession).getModel().items.find((it): it is ChatUserItem => it.kind === 'user')?.text.trim()
         : undefined;
-      void api.post<{ title: string | null; reason?: string }>(
+      void scopedApi.post<{ title: string | null; reason?: string }>(
         '/agent/title',
         firstUserText ? { claudeId: s.claudeId, message: firstUserText } : { claudeId: s.claudeId },
       )
@@ -1582,7 +1678,7 @@ export function AgentSurface() {
         .catch(() => { /* best-effort: a failed title just leaves the default name */ })
         .finally(() => { titleInFlightRef.current.delete(id); });
     });
-  }, [statusTick, agentSettings.enabled, agentSettings.autoTitle, sessionList]);
+  }, [statusTick, agentSettings.enabled, agentSettings.autoTitle, sessionList, scopedApi]);
 
   // ── Drop-overlay leak guard (the "terminal unreachable after a split" fix) ───────
   // While a tab is dragged, each pane mounts a full-bleed `.agent-pane-droplayer`
@@ -1608,11 +1704,11 @@ export function AgentSurface() {
   // When the user clicks a sidebar item (or jumps via the ⌘K palette) while the agent
   // is fullscreen, collapse it so the page they navigated to is actually visible. The
   // sessions stay alive in the garage — collapsing never tears anything down.
-  useEffect(() => {
-    const onNavigate = () => setExpanded((cur) => (cur ? false : cur));
-    window.addEventListener('dreamcontext-navigate', onNavigate);
-    return () => window.removeEventListener('dreamcontext-navigate', onNavigate);
-  }, []);
+  //
+  // This instance's Shell only (it emits on the same bus): navigating in the foreground
+  // project must not collapse a backgrounded project's overlay out from under it, so that
+  // switching back lands on the agent you left open rather than on its page.
+  useInstanceEvent('dreamcontext-navigate', () => setExpanded((cur) => (cur ? false : cur)));
 
   // ── "＋ New ▾" dropdown: close on outside-click or Esc ────────────────────────
   // The menu is opened by clicking the caret and stays open (no hover-close). A
@@ -1635,6 +1731,10 @@ export function AgentSurface() {
   // ── App zoom → terminal font size. The window's `- 100% +` control sets `--zoom`
   //    (scaling CSS font tokens) and broadcasts `dreamcontext-zoom`; xterm's size is
   //    imperative, so we resize every session's font to match and refit the grid. ──
+  // Stays on `window` ON PURPOSE, unlike the bridges above: zoom is a property of the WINDOW,
+  // the control lives in the window chrome above every instance, and every xterm in it —
+  // foreground and background alike — must end up at the same size. A backgrounded project
+  // that missed a zoom step would repaint at the wrong font the moment you switched to it.
   useEffect(() => {
     const onZoom = (e: Event) => {
       const detail = (e as CustomEvent).detail;
@@ -1681,7 +1781,7 @@ export function AgentSurface() {
   }, [started, addSession, addSplitSession, closeSessionById, focusedSessionId, claudeKind]);
 
   const openExternal = async () => {
-    try { await api.post('/agent/open-terminal', { bypass }); }
+    try { await scopedApi.post('/agent/open-terminal', { bypass }); }
     catch (e) { alert(e instanceof Error ? e.message : 'Could not open Terminal.'); }
   };
 
@@ -1693,14 +1793,14 @@ export function AgentSurface() {
   // (JSON-only), so use raw fetch.
   const deliverDrops = useCallback(async (files: File[], sid: string) => {
     for (const file of files) {
-      const path = await uploadAgentFile(file, file.name);
+      const path = await uploadAgentFile(vault, file, file.name);
       // Inject the path AND land keyboard focus on this session — a drop is async
       // (read bytes → POST), so the user may start typing before it resolves; grabbing
       // focus here guarantees the follow-up prompt goes to the session that got the file.
       const s = sessions.current.get(sid);
       if (path && s) { s.sendText(quoteIfNeeded(path) + ' '); s.focus(); }
     }
-  }, []);
+  }, [vault]);
 
   // NATIVE DOM listeners on the always-mounted surface host — NOT React onDragOver/onDrop
   // props on `.agent-term`. A chat pane's DOM is React-portaled into its detached session
@@ -1785,6 +1885,37 @@ export function AgentSurface() {
       claudeId: s?.claudeId,
     };
   });
+  /*
+   * ── This project's chip, published to the window chrome ──────────────────────────
+   *
+   * The dock already knows everything a chip needs — how many conversations are alive, the
+   * worst state among them, whether any is blocked on an answer — and it knows it for a
+   * project the user may not be looking at. `rollupProject` reduces those rows to the three
+   * scalars the strip draws from.
+   *
+   * NOT PUBLISHED PER RENDER. `dockRows` is rebuilt every render, and this surface re-renders
+   * on every status flip the PTY produces — several a second while a turn is streaming. The
+   * dependency array below IS the shallow compare: four primitives, so the effect runs only
+   * when one of them genuinely changed, and a chip that has nothing new to say never reaches
+   * the chrome at all. (The chrome bails out a second time on the same four fields; both ends
+   * matter, because this one keeps the event off the bus and that one keeps the re-render out
+   * of every other chip.)
+   *
+   * `alive` rides along even though nothing here renders it — it's the ceiling's eviction
+   * signal (a live shell with no chat still has `live: 0`, and reading THAT as idle is what
+   * killed a running PTY before T18 split the two apart). Dropping it from the dependency
+   * array would let a shell open or close without the chrome ever hearing about it, because
+   * `worst`/`live`/`waiting` can all sit unchanged while `alive` moves — the exact staleness
+   * the ceiling rule cannot tolerate.
+   */
+  const rollup: ProjectRollup = rollupProject(dockRows);
+  const { worst: rollupWorst, live: rollupLive, waiting: rollupWaiting, alive: rollupAlive } = rollup;
+  useEffect(() => {
+    emitInstance<ProjectRollup>(bus, PROJECT_ROLLUP_EVENT, {
+      worst: rollupWorst, live: rollupLive, waiting: rollupWaiting, alive: rollupAlive,
+    });
+  }, [bus, rollupWorst, rollupLive, rollupWaiting, rollupAlive]);
+
   // Rows for the corner dock that floats over the EXPANDED overlay — only the sessions the
   // user minimized out of the panes (in minimize order). Empty → no corner dock shown.
   const minimizedRows: SessionRow[] = minimizedIds
@@ -2158,7 +2289,7 @@ export function AgentSurface() {
           // tab-id swap every resume path performs. Undefined for every ordinary chat, which
           // is what keeps the header absent from all of them.
           automation={automationRuns[cs.claudeId]}
-          permissionMode={agentSettings.chatPermissionMode}
+          permissionMode={chatPermissionMode}
           canSignInInApp={canSignInInApp}
           signInCommand={signInCommand}
         />,

--- a/dashboard/src/components/sleepy/AgentTabs.tsx
+++ b/dashboard/src/components/sleepy/AgentTabs.tsx
@@ -167,10 +167,20 @@ export function AgentTabs({
                   title={
                     tab.sessionKind === 'shell' ? 'Terminal (login shell)'
                       : tab.sessionKind === 'chat' ? 'Claude Code chat'
-                        : 'Claude Code agent'
+                        : tab.sessionKind === 'automation' ? 'Automation run — a scheduled job\'s own conversation'
+                          : 'Claude Code agent'
                   }
                   aria-hidden
-                >{tab.sessionKind === 'shell' ? '>_' : tab.sessionKind === 'chat' ? '◆' : '◇'}</span>
+                >{
+                  tab.sessionKind === 'shell' ? '>_'
+                    : tab.sessionKind === 'chat' ? '◆'
+                      // An automation run is the one tab you did not open yourself — it ran
+                      // unattended, with bypassPermissions, while nobody was watching. The
+                      // glyph is deliberately unlike the other three so a strip of tabs
+                      // makes that legible at a glance.
+                      : tab.sessionKind === 'automation' ? '⬡'
+                        : '◇'
+                }</span>
                 {renaming ? (
                   <input
                     className="agent-tab-rename"

--- a/dashboard/src/components/sleepy/AgentTerminal.css
+++ b/dashboard/src/components/sleepy/AgentTerminal.css
@@ -826,6 +826,10 @@
 }
 .agent-tab.active .agent-tab-kind { color: var(--color-text-secondary); }
 .agent-tab-kind[data-session-kind="shell"] { color: var(--color-accent); opacity: 0.85; }
+/* An automation run is the one tab the user did not open — it ran unattended
+   under bypassPermissions. Full opacity and the accent colour so it reads as a
+   distinct class of thing rather than a dimmer agent tab. */
+.agent-tab-kind[data-session-kind="automation"] { color: var(--color-accent); opacity: 1; }
 
 .agent-tab-title {
   /* Don't grow to fill — take exactly the name's natural width so the bar tracks the

--- a/dashboard/src/components/sleepy/ChatHistoryPicker.tsx
+++ b/dashboard/src/components/sleepy/ChatHistoryPicker.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { api } from '../../api/client';
+import { useApi } from '../../context/VaultContext';
+import { useOverlayId } from '../../lib/useOverlayId';
 import { CommandModal, useListKeyboardNav } from '../search/CommandModal';
 import './ChatHistoryPicker.css';
 
@@ -95,6 +96,8 @@ function sizeLabel(bytes: number): string {
 }
 
 export function ChatHistoryPicker({ open, onClose, onPick, openIds }: ChatHistoryPickerProps) {
+  const api = useApi();
+  const overlayId = useOverlayId('chat-history');
   const [q, setQ] = useState('');
   const [data, setData] = useState<ChatHistoryResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -138,7 +141,7 @@ export function ChatHistoryPicker({ open, onClose, onPick, openIds }: ChatHistor
         .finally(() => { if (reqRef.current === seq) setLoading(false); });
     }, q ? 140 : 0);
     return () => clearTimeout(handle);
-  }, [open, q, showAgentRuns]);
+  }, [api, open, q, showAgentRuns]);
 
   const sessions = data?.sessions ?? [];
 
@@ -178,7 +181,7 @@ export function ChatHistoryPicker({ open, onClose, onPick, openIds }: ChatHistor
   const hiddenRuns = data?.agentRuns ?? 0;
 
   return (
-    <CommandModal id="chat-history" open={open} onClose={onClose} ariaLabel="Past chats" className="chp-modal">
+    <CommandModal id={overlayId} open={open} onClose={onClose} ariaLabel="Past chats" className="chp-modal">
       <div className="chp-input-row">
         <span className="chp-input-icon" aria-hidden="true">◷</span>
         <input

--- a/dashboard/src/components/sleepy/ChatPane.tsx
+++ b/dashboard/src/components/sleepy/ChatPane.tsx
@@ -1,7 +1,8 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import { GoalLivePanel } from './GoalLivePanel';
 import { CouncilLivePanel } from './CouncilLivePanel';
-import { api, agentFileUrl } from '../../api/client';
+import { agentFileUrl } from '../../api/client';
+import { useApi, useVault } from '../../context/VaultContext';
 import type { ModelConfig } from '../../lib/agentComposer';
 import {
   classifyReference, subAgentToolUseIds, isGuardedCommand, turnHasVisibleProgress,
@@ -137,6 +138,7 @@ interface TaskLinkInfo { name: string; objectiveLabels: string[] }
 /** Linked-task chip + objectives data, fetched only when `taskSlug` is supplied. No caller
  *  sets `taskSlug` yet, so this hook is a built-but-dormant mechanism in this release. */
 function useTaskLink(taskSlug?: string): TaskLinkInfo | null {
+  const api = useApi();
   const [info, setInfo] = useState<TaskLinkInfo | null>(null);
   useEffect(() => {
     if (!taskSlug) { setInfo(null); return; }
@@ -156,7 +158,7 @@ function useTaskLink(taskSlug?: string): TaskLinkInfo | null {
       }
     })();
     return () => { cancelled = true; };
-  }, [taskSlug]);
+  }, [api, taskSlug]);
   return info;
 }
 
@@ -298,6 +300,8 @@ export function ChatPane({
 }) {
   const [, force] = useReducer((n: number) => n + 1, 0);
   useEffect(() => session.subscribe(() => force()), [session]);
+  const { vault } = useVault();
+  const api = useApi();
 
   const conv = session.getModel();
   const hasPendingQuestion = conv.pending.some((p) => p.kind === 'question');
@@ -981,7 +985,7 @@ export function ChatPane({
     // routing decision in one place rather than relying on that being true forever.
     if (ref.kind === 'board') { setBoardFull(path); return; }
     if (ref.isImage) {
-      setLightbox({ src: agentFileUrl(path, { raw: true }), caption: ref.label, path });
+      setLightbox({ src: agentFileUrl(vault, path, { raw: true }), caption: ref.label, path });
       return;
     }
     // A PDF is a document the window can DISPLAY, so it gets the image's treatment rather
@@ -990,7 +994,7 @@ export function ChatPane({
     // answers "exceeds the preview size cap" and for a small one answers mojibake.
     if (ref.kind === 'pdf') { setPdf({ path, label: ref.label }); return; }
     setSlideOver({ mode: 'file', path });
-  }, []);
+  }, [vault]);
   const handleOpenBoard = useCallback((path: string) => setBoardFull(path), []);
   // The sub-agent card now also holds headless `claude` runs (see `isHeadlessAgentShell`),
   // and those are `local_bash` tasks: the CLI writes no sidechain transcript for them, so
@@ -1026,7 +1030,7 @@ export function ChatPane({
         // Never a dead button (owner report 07-28): if the OS wouldn't take it — gone, or a
         // path that escapes the project root — fall back to this pane's own file panel,
         // which SAYS why instead of the click going nowhere.
-        void revealPath(action.path!).then((err) => { if (err) handleOpenFile(action.path!); });
+        void revealPath(api, action.path!).then((err) => { if (err) handleOpenFile(action.path!); });
         break;
       case 'ask':
         session.sendText(action.text!);
@@ -1036,7 +1040,7 @@ export function ChatPane({
         void openExternalUrl(action.url!);
         break;
     }
-  }, [handleNavApp, handleOpenFile, session]);
+  }, [handleNavApp, handleOpenFile, session, api]);
 
   // ── Transcript pass: skip the spawning Agent/Task tool's OWN card (state 9 — it's
   //    already represented by ONE combined SubAgentCard, rendered at the position of the

--- a/dashboard/src/components/sleepy/DocContent.tsx
+++ b/dashboard/src/components/sleepy/DocContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../../api/client';
+import { useApi } from '../../context/VaultContext';
 import { MarkdownPreview } from '../core/MarkdownPreview';
 import { SqlPreview } from '../core/SqlPreview';
 import { ExcalidrawPreview } from '../core/ExcalidrawPreview';
@@ -54,6 +54,7 @@ function pick(obj: unknown, path: string[]): string {
 }
 
 export function DocContent({ hit }: { hit: RecallHit }) {
+  const api = useApi();
   const plan = useMemo(() => detailPlan(hit), [hit]);
 
   const { data, isLoading, isError } = useQuery({

--- a/dashboard/src/components/sleepy/agentSession.ts
+++ b/dashboard/src/components/sleepy/agentSession.ts
@@ -3,7 +3,6 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { WebglAddon } from '@xterm/addon-webgl';
 import '@xterm/xterm/css/xterm.css';
-import { getActiveVault } from '../../api/client';
 import { copyPreservingUnicode } from '../../lib/clipboard';
 import { nextLineShadow } from '../../lib/lineShadow';
 import { raiseAskAttention } from '../../lib/attention';
@@ -63,9 +62,18 @@ export interface Capabilities {
 }
 
 export type TermStatus = 'connecting' | 'open' | 'closed';
-/** What a session runs: the real Claude Code agent (terminal), a plain vault-scoped login
- *  shell, or a headless stream-json Chat session (beta — see chatSession.ts). */
-export type SessionKind = 'agent' | 'shell' | 'chat';
+/**
+ * What a session runs: the real Claude Code agent (terminal), a plain vault-scoped login
+ * shell, a headless stream-json Chat session (beta — see chatSession.ts), or an
+ * AUTOMATION RUN reopened as a conversation.
+ *
+ * `automation` is a DISPLAY distinction, not a transport one — the run's conversation is
+ * resumed through whichever Claude surface the user has chosen, exactly as before. It earns
+ * its own member because a tab holding a machine's unattended `bypassPermissions` session is
+ * not the same object as one holding a conversation you started, and the tab strip is where
+ * that difference has to be legible. See `AgentTabs`' glyph map.
+ */
+export type SessionKind = 'agent' | 'shell' | 'chat' | 'automation';
 export const ACCENT = '#8b7bff';
 
 // Base xterm font size at 100% zoom. Multiplied by the app's `--zoom` so terminal
@@ -196,7 +204,14 @@ export interface Session {
   asking: boolean;      // a question is on screen — Claude is blocked on YOUR answer
   attention: boolean;   // finished / rang the bell since you last looked
   minimized: boolean;   // mirrored from layout state so the idle timer can read it
-  ensureOpen: () => void;
+  /** Open the terminal into its container once it is in the DOM and visible.
+   *
+   *  `focus` (default `true`) exists because one window now holds several LIVE projects:
+   *  the pane-placement effect can open a terminal belonging to a BACKGROUND project, and
+   *  an unconditional `term.focus()` there would yank the caret out of whatever the user is
+   *  typing in the project they are actually looking at. Callers that may be driving a
+   *  hidden instance pass `{ focus: false }`; everyone else keeps today's behaviour. */
+  ensureOpen: (opts?: { focus?: boolean }) => void;
   fitAndResize: () => void;
   applyZoom: (zoom: number) => void;
   /** Write arbitrary text to the PTY (used to inject a dropped image's path). */
@@ -235,7 +250,14 @@ const WORKING_RE = /esc to interrupt|ctrl\+b to run in background/i;
  * for the upgrade URL never has to be truncated. When set it REPLACES `initialPrompt` on the
  * wire — pass one or the other, never both.
  */
-export function createSession(bypass: boolean, notify: () => void, claudeId: string, resume = false, kind: SessionKind = 'agent', initialPrompt = '', model = '', submitInitial = true, promptToken = '', deferPrompt = false): Session {
+/**
+ * Spawn one terminal session against `vault` — the project this session belongs to, passed in
+ * rather than read from a module global. One window now holds several live projects, so an
+ * "active vault" module read would open the PTY in whichever project the user last clicked;
+ * the vault also names this session's alarm source, which is what lets a background project's
+ * chip raise the user (see `raiseAskAttention` below). Empty string = no project pinned.
+ */
+export function createSession(vault: string, bypass: boolean, notify: () => void, claudeId: string, resume = false, kind: SessionKind = 'agent', initialPrompt = '', model = '', submitInitial = true, promptToken = '', deferPrompt = false): Session {
   const id = `agent-${++sessionSeq}`;
   const container = document.createElement('div');
   container.className = 'agent-pane-term';
@@ -306,7 +328,6 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
   themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] });
   themeObserver.observe(document.body, { attributes: true, attributeFilter: ['data-theme', 'class'] });
 
-  const vault = getActiveVault();
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const theme = currentTermTheme();
   // A shell has no conversation and no permission model, so it carries neither the
@@ -343,7 +364,7 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
   // context rather than opening the conversation itself.
   // Meaningful only when a server-submitted prompt exists at all.
   const deferParam = serverSubmitsPrompt && deferPrompt ? '&deferPrompt=1' : '';
-  const url = `${proto}://${location.host}/api/agent/terminal?vault=${encodeURIComponent(vault ?? '')}&bypass=${bypassParam}&theme=${theme}${idParam}${kindParam}${modelParam}${promptParam}${deferParam}`;
+  const url = `${proto}://${location.host}/api/agent/terminal?vault=${encodeURIComponent(vault)}&bypass=${bypassParam}&theme=${theme}${idParam}${kindParam}${modelParam}${promptParam}${deferParam}`;
   const ws = new WebSocket(url);
   // Binary frames are the server's control channel (hook-reported turn state);
   // arraybuffer (not the default Blob) so they can be decoded synchronously in
@@ -447,8 +468,10 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
         // ONCE per question — redraws can't re-trigger, asking only rises on a fresh edge.
         // No `detail`: all this surface has is a screenful of pixels the regex matched, and
         // scraping a prompt off the terminal tail would put garbled ANSI in a banner.
+        // `source` is this session's own VAULT: it is what the chip strip keys a background
+        // project's alarm off, so a title here would silence the wrong project's chip.
         session.attention = true;
-        raiseAskAttention({ source: getActiveVault() });
+        raiseAskAttention({ source: vault });
       }
       notify();
       return;
@@ -675,7 +698,7 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
   // the DOM renderer (NOT WebGL) on purpose: it renders real text nodes that get
   // macOS-native anti-aliasing, so glyph edges are soft — not the WebGL atlas's hard,
   // "sharp" rasterisation the user found eye-tiring.
-  function ensureOpen() {
+  function ensureOpen(opts: { focus?: boolean } = {}) {
     if (session.opened || !container.isConnected) return;
     const doOpen = () => {
       // Must be connected AND visible (offsetParent is null while parked in the
@@ -697,7 +720,9 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
           fitAndResize();
         }
       });
-      term.focus();
+      // Not unconditional: a background project's terminal opening must not steal the
+      // caret from the project the user is looking at (see the `focus` option's note).
+      if (opts.focus !== false) term.focus();
     };
     // Measure with the EXACT mono font (both weights) actually loaded — otherwise
     // xterm builds its cell metrics from a wider fallback advance and every glyph

--- a/dashboard/src/components/sleepy/agentSession.ts
+++ b/dashboard/src/components/sleepy/agentSession.ts
@@ -6,7 +6,7 @@ import '@xterm/xterm/css/xterm.css';
 import { getActiveVault } from '../../api/client';
 import { copyPreservingUnicode } from '../../lib/clipboard';
 import { nextLineShadow } from '../../lib/lineShadow';
-import { playAskChime } from '../../lib/chime';
+import { raiseAskAttention } from '../../lib/attention';
 import {
   readAgentSettings, AGENT_SETTINGS_EVENT, type AgentSettings, type AgentRenderer,
 } from '../../lib/agentSettings';
@@ -443,10 +443,12 @@ export function createSession(bypass: boolean, notify: () => void, claudeId: str
       session.busy = false;
       session.asking = true;
       if (fresh) {
-        // A question is the strongest "needs you" there is: badge it and chime ONCE
-        // per question — redraws can't re-trigger, asking only rises on a fresh edge.
+        // A question is the strongest "needs you" there is: badge it and raise the user
+        // ONCE per question — redraws can't re-trigger, asking only rises on a fresh edge.
+        // No `detail`: all this surface has is a screenful of pixels the regex matched, and
+        // scraping a prompt off the terminal tail would put garbled ANSI in a banner.
         session.attention = true;
-        playAskChime();
+        raiseAskAttention({ source: getActiveVault() });
       }
       notify();
       return;

--- a/dashboard/src/components/sleepy/agentStatus.ts
+++ b/dashboard/src/components/sleepy/agentStatus.ts
@@ -114,3 +114,59 @@ export function orderRows(rows: SessionRow[]): SessionRow[] {
   const asking = rows.filter((r) => r.info.kind === 'asking');
   return asking.length ? [...asking, ...rows.filter((r) => r.info.kind !== 'asking')] : rows;
 }
+
+/**
+ * One project's worth of session rows, rolled up into what the chip strip needs to draw a
+ * single chip: a colour, a live-count badge, and whether it should bounce. This is the
+ * project-level counterpart to the collapsed dock's `rollupKind` — same worst-of urgency
+ * signal, but a chip in a background project also needs to say HOW MANY conversations are
+ * actually live and whether any of them are stuck waiting on the user, which a single kind
+ * can't carry on its own.
+ *
+ * `live` and `alive` look redundant and are NOT — do not collapse them. `live` is a
+ * PRESENTATION count (chats/agents only, shells excluded) for the chip badge. `alive` is a
+ * SAFETY count (every kind, shells included) for the ceiling-eviction decision: a project
+ * whose only live thing is a running shell (a dev server, a build watch) has `live: 0` but
+ * must never read as idle, or the eviction rule kills its PTY mid-process. Only `alive` may
+ * ever gate a teardown decision.
+ */
+export interface ProjectRollup {
+  /** Dot + badge colour: the worst-of across every session in this project. */
+  worst: SessionStatusKind;
+  /** The badge NUMBER — how many chats/agents in this project are actually alive. Excludes
+   *  shells: a plain terminal has no agent behind it and isn't an "active chat". */
+  live: number;
+  /** Drives the chip's one-shot bounce: sessions blocked on the user or flagged since
+   *  you last looked. */
+  waiting: number;
+  /** Eviction safety: how many sessions of ANY kind still hold a live PTY/WebSocket — agent,
+   *  chat AND shell. This is the ONLY field the ceiling rule may consult; `live` must never
+   *  decide whether an instance can be torn down. */
+  alive: number;
+}
+
+/**
+ * Roll a project's session rows up into its chip state. `worst` reuses `rollupKind` rather
+ * than re-deriving the urgency order a second time — one source of truth for "what's the
+ * worst thing happening here". `live` deliberately excludes `saved` (a restored roster
+ * entry with no live session — the dormant "Resume" row) and `ended` (a dead PTY): neither
+ * is a conversation actually happening right now, so counting them would badge a chip for a
+ * project that isn't doing anything. A `shell` row is excluded outright — it's a plain
+ * terminal with no agent behind it (see `SessionRow.kind` above), so it can never ask a
+ * question and never belongs in an "active chat" count. `alive` counts the same `saved`/
+ * `ended` exclusion but WITHOUT the shell exclusion — a shell still holds a real PTY/
+ * WebSocket the ceiling rule must not tear down. `waiting` counts a row once even when it
+ * is both `asking` and flagged for `attention` — one row, one interruption.
+ */
+export function rollupProject(rows: SessionRow[]): ProjectRollup {
+  let live = 0;
+  let waiting = 0;
+  let alive = 0;
+  for (const r of rows) {
+    const holdsSession = r.info.kind !== 'saved' && r.info.kind !== 'ended';
+    if (holdsSession && r.kind !== 'shell') live++;
+    if (holdsSession) alive++;
+    if (r.info.kind === 'asking' || r.attention) waiting++;
+  }
+  return { worst: rollupKind(rows), live, waiting, alive };
+}

--- a/dashboard/src/components/sleepy/chat/BoardEmbed.tsx
+++ b/dashboard/src/components/sleepy/chat/BoardEmbed.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { api } from '../../../api/client';
+import { useApi } from '../../../context/VaultContext';
 import { ExcalidrawPreview } from '../../core/ExcalidrawPreview';
 import { FullscreenOverlay } from '../../layout/FullscreenOverlay';
 
@@ -36,6 +36,7 @@ interface BoardScene {
  * backed) asset resolve entirely.
  */
 export function useBoardScene(path: string): BoardScene {
+  const api = useApi();
   const [scene, setScene] = useState<BoardScene>({
     content: null, assets: undefined, assetsLoading: false, failed: false,
   });
@@ -60,7 +61,7 @@ export function useBoardScene(path: string): BoardScene {
       .catch(() => { if (!cancelled) setScene({ content: null, assets: {}, assetsLoading: false, failed: true }); });
 
     return () => { cancelled = true; };
-  }, [path]);
+  }, [api, path]);
 
   return scene;
 }

--- a/dashboard/src/components/sleepy/chat/ChatViews.tsx
+++ b/dashboard/src/components/sleepy/chat/ChatViews.tsx
@@ -1,4 +1,4 @@
-import { getActiveVault } from '../../../api/client';
+import { useVault } from '../../../context/VaultContext';
 import { isDesktop, openChecklistWindow } from '../../../lib/desktop';
 import { writeEnvelope } from '../../../lib/checklistStore';
 import type { ChatViewSpec, ChecklistViewSpec } from '../../../lib/chatViewSpec';
@@ -89,14 +89,16 @@ function PendingViewPill() {
  *
  * `writeEnvelope` is the single authority for `conversationId` (§1.10): the checklist
  * window's URL carries only `checklist`+`vault`, and reads `conversationId` back out of
- * the envelope this writes. `getActiveVault()` returns `string | null` — off-desktop, or
+ * the envelope this writes. The vault comes from THIS subtree's `useVault()` (never a module
+ * global — several projects are live in one window) and is `string | null`: off-desktop, or
  * with no vault pinned (shouldn't happen for a mounted Chat view, but never assumed), the
  * button is disabled rather than falling back to an invented vault, which would risk
  * writing into the wrong project's checklist (the exact defect this design fixed).
  */
 function ChecklistCard({ spec, conversationId }: { spec: ChecklistViewSpec; conversationId: string }) {
   const desktop = isDesktop();
-  const vault = desktop ? getActiveVault() : null;
+  const { vault: activeVault } = useVault();
+  const vault = desktop ? activeVault : null;
   const itemCount = spec.items.length;
 
   const handleOpen = () => {

--- a/dashboard/src/components/sleepy/chat/Composer.tsx
+++ b/dashboard/src/components/sleepy/chat/Composer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { pickFiles, pickFolders } from '../../../lib/desktop';
+import { useVault } from '../../../context/VaultContext';
 import { uploadAgentFile } from '../../../lib/agentDrop';
 import { useAgentSessionStats } from '../../../hooks/useAgentCapabilities';
 import {
@@ -131,6 +132,10 @@ export function Composer({
    *  nothing. The handler opens an interactive terminal Claude tab that CAN run the flow. */
   onSignIn: () => void;
 }) {
+  // Which project a pasted image is uploaded into. From THIS subtree, never a module global:
+  // with several projects live in one window the bytes would otherwise land in the temp dir of
+  // whichever chip the user last touched.
+  const { vault } = useVault();
   // Re-read on every render (the pane re-renders on every applied event — see ChatPane): this
   // is the live conversation model, not a snapshot.
   const conv = session.getModel();
@@ -254,7 +259,7 @@ export function Composer({
       // and the unmount cleanup read, and it must know about this chip before the next render.
       attachmentsRef.current = [...attachmentsRef.current, chip];
       setAttachments((prev) => [...prev, chip]);
-      const job = uploadAgentFile(file, name).then((path) => {
+      const job = uploadAgentFile(vault, file, name).then((path) => {
         const settle = (list: Attachment[]) => list.map((a) => (a.id === id
           ? { ...a, path: path ?? undefined, uploading: false, failed: !path }
           : a));

--- a/dashboard/src/components/sleepy/chat/FileActions.tsx
+++ b/dashboard/src/components/sleepy/chat/FileActions.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { useApi } from '../../../context/VaultContext';
 import { revealPath } from './chatEntities';
 
 /**
@@ -36,13 +37,14 @@ export function FileActions({
   /** Icon-and-short-label form, for a viewer's chrome rather than a panel's toolbar. */
   compact?: boolean;
 }) {
+  const api = useApi();
   const [note, setNote] = useState<string | null>(null);
   const [busy, setBusy] = useState<'open' | 'reveal' | null>(null);
 
   const handoff = (mode: 'auto' | 'reveal') => {
     setNote(null);
     setBusy(mode === 'auto' ? 'open' : 'reveal');
-    void revealPath(path, mode).then((err) => {
+    void revealPath(api, path, mode).then((err) => {
       setBusy(null);
       setNote(err);
     });

--- a/dashboard/src/components/sleepy/chat/PageView.tsx
+++ b/dashboard/src/components/sleepy/chat/PageView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { agentFileUrl } from '../../../api/client';
+import { useVault } from '../../../context/VaultContext';
 import { MarkdownPreview } from '../../core/MarkdownPreview';
 import { holdsItsWidth } from '../../../lib/markdownTables';
 import { ActionRow } from './ActionRow';
@@ -42,10 +43,11 @@ const REMOTE_SRC_RE = /^https:\/\//i;
 /** An image src coming out of `sanitizeImageSrc` is always either an `https:` URL or a
  *  project-relative path — nothing else survives validation. Local paths need the
  *  vault-aware file endpoint; remote ones are used exactly as written (query/fragment
- *  already stripped upstream). */
-function resolveImage(src: string): { url: string; remote: boolean } {
+ *  already stripped upstream). A module function, not a component — the vault comes from
+ *  whichever component calls it. */
+function resolveImage(vault: string | null, src: string): { url: string; remote: boolean } {
   const remote = REMOTE_SRC_RE.test(src);
-  return { url: remote ? src : agentFileUrl(src, { raw: true }), remote };
+  return { url: remote ? src : agentFileUrl(vault, src, { raw: true }), remote };
 }
 
 function prefersReducedMotion(): boolean {
@@ -175,9 +177,10 @@ function Rail({ widget, onAction, onOpenFile }: { widget: RailWidgetSpec } & Wid
 // ─── card — the owner's whole named list: photo, price, badges, specs, body, actions ─────
 
 function CardImage({ image }: { image: { src: string; alt: string } }) {
+  const { vault } = useVault();
   const [failed, setFailed] = useState(false);
   if (failed) return null;
-  const { url } = resolveImage(image.src);
+  const { url } = resolveImage(vault, image.src);
   return (
     <div className="chat-pv-card-media">
       <img
@@ -302,9 +305,10 @@ function Stat({ widget }: { widget: StatWidgetSpec }) {
 // ─── image — a standalone photo; local ones zoom into the existing lightbox ───────────────
 
 function ImageWidget({ widget, onOpenFile }: { widget: ImageWidgetSpec; onOpenFile?: (path: string) => void }) {
+  const { vault } = useVault();
   const [failed, setFailed] = useState(false);
   if (failed) return null;
-  const { url, remote } = resolveImage(widget.src);
+  const { url, remote } = resolveImage(vault, widget.src);
   const img = (
     <img
       src={url}

--- a/dashboard/src/components/sleepy/chat/PdfViewer.tsx
+++ b/dashboard/src/components/sleepy/chat/PdfViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { api, agentFileUrl } from '../../../api/client';
+import { agentFileUrl } from '../../../api/client';
+import { useApi, useVault } from '../../../context/VaultContext';
 import { FileActions } from './FileActions';
 
 /**
@@ -52,10 +53,12 @@ export function PdfViewer({
   src?: string;
   onClose: () => void;
 }) {
+  const api = useApi();
+  const { vault } = useVault();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [probe, setProbe] = useState<Probe>({ state: 'checking' });
   const [granting, setGranting] = useState(false);
-  const src = srcOverride ?? agentFileUrl(path, { raw: true });
+  const src = srcOverride ?? agentFileUrl(vault, path, { raw: true });
 
   // Ask the endpoint BEFORE embedding. An `<iframe>`/`<object>` reports nothing useful when it
   // fails — no status, no reason — so a file that merely needs consent would render as a blank

--- a/dashboard/src/components/sleepy/chat/SlideOver.tsx
+++ b/dashboard/src/components/sleepy/chat/SlideOver.tsx
@@ -1,5 +1,6 @@
 import { Component, useEffect, useState, type ReactNode } from 'react';
-import { api, agentFileUrl } from '../../../api/client';
+import { agentFileUrl } from '../../../api/client';
+import { useApi, useVault } from '../../../context/VaultContext';
 import { MarkdownPreview } from '../../core/MarkdownPreview';
 import { ItemView } from './TranscriptItem';
 import {
@@ -91,8 +92,9 @@ function NumberedText({ content }: { content: string }) {
  * is where that consent is asked, so this points back at it instead of duplicating it.
  */
 function MediaPreview({ path, kind }: { path: string; kind: 'image' | 'video' | 'audio' }) {
+  const { vault } = useVault();
   const [failed, setFailed] = useState(false);
-  const src = agentFileUrl(path, { raw: true });
+  const src = agentFileUrl(vault, path, { raw: true });
   if (failed) {
     return (
       <p className="chat-slideover-status error">
@@ -150,6 +152,7 @@ function DirListing({
 }
 
 function FileSlideOver({ path, reference, onClose, onNavApp, onOpenPath }: SlideOverFileProps) {
+  const api = useApi();
   const [state, setState] = useState<{ loading: boolean; data: FileContent | null; error: string | null }>(
     { loading: true, data: null, error: null },
   );
@@ -167,7 +170,7 @@ function FileSlideOver({ path, reference, onClose, onNavApp, onOpenPath }: Slide
       .then((data) => { if (!cancelled) setState({ loading: false, data, error: null }); })
       .catch((err: Error) => { if (!cancelled) setState({ loading: false, data: null, error: err.message || 'Failed to load file.' }); });
     return () => { cancelled = true; };
-  }, [path, mediaKind]);
+  }, [api, path, mediaKind]);
 
   return (
     <>
@@ -262,6 +265,7 @@ function usageLine(usage: SubAgentRun['usage']): string | null {
 }
 
 function SubAgentSlideOver({ run, conversationId, onClose }: SlideOverSubAgentProps) {
+  const api = useApi();
   const [state, setState] = useState<{ loading: boolean; items: ChatItem[] }>({ loading: true, items: [] });
 
   useEffect(() => {
@@ -279,7 +283,7 @@ function SubAgentSlideOver({ run, conversationId, onClose }: SlideOverSubAgentPr
     return () => { cancelled = true; };
     // Refetch when the run's lifecycle advances (e.g. task-updated/task-notification
     // landed after the drill-in was already open) or a different run is opened.
-  }, [conversationId, run.taskId, run.status, run.endedAt]);
+  }, [api, conversationId, run.taskId, run.status, run.endedAt]);
 
   const usage = usageLine(run.usage);
 
@@ -349,6 +353,7 @@ function SubAgentSlideOver({ run, conversationId, onClose }: SlideOverSubAgentPr
 const SHELL_POLL_MS = 1200;
 
 function ShellSlideOver({ run, conversationId, onStop, onClose }: SlideOverShellProps) {
+  const api = useApi();
   const [state, setState] = useState<{
     loading: boolean; content: string; truncated: boolean; exists: boolean; error: string | null;
   }>({ loading: true, content: '', truncated: false, exists: true, error: null });
@@ -394,7 +399,7 @@ function ShellSlideOver({ run, conversationId, onStop, onClose }: SlideOverShell
     poll();
 
     return () => { cancelled = true; if (timer) clearTimeout(timer); };
-  }, [conversationId, run.taskId, isRunning, run.status]);
+  }, [api, conversationId, run.taskId, isRunning, run.status]);
 
   return (
     <>

--- a/dashboard/src/components/sleepy/chat/TranscriptItem.tsx
+++ b/dashboard/src/components/sleepy/chat/TranscriptItem.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo, useRef, useState } from 'react';
 import { MarkdownPreview } from '../../core/MarkdownPreview';
-import { api, agentFileUrl } from '../../../api/client';
+import { agentFileUrl, type ApiClient } from '../../../api/client';
+import { useApi, useVault } from '../../../context/VaultContext';
 import {
   useCopyableCodeBlocks, useInlineMedia, useClickablePaths, estimateTokens,
   inlineMediaKind, splitUserMedia, revealPath,
@@ -33,8 +34,9 @@ function copyText(text: string): void {
 }
 
 /** The user allowing ONE file outside the project root to be shown inline. Resolves false
- *  when the server refused (gone, or not a file), so the card can stay put and say so. */
-function grantFile(path: string): Promise<boolean> {
+ *  when the server refused (gone, or not a file), so the card can stay put and say so. A
+ *  module function, not a component — the caller passes its own vault-bound client. */
+function grantFile(api: ApiClient, path: string): Promise<boolean> {
   return api.post('/agent/grant', { path }).then(() => true, () => false);
 }
 
@@ -49,6 +51,8 @@ function grantFile(path: string): Promise<boolean> {
  * image icon.
  */
 function UserMediaItem({ path, onOpenFile }: { path: string; onOpenFile?: (path: string) => void }) {
+  const { vault } = useVault();
+  const api = useApi();
   const [failed, setFailed] = useState(false);
   // Why the OS opener refused, if it did. The chip promised "still opens" and used to break
   // that promise in silence — a refusal now shows next to it (owner report 07-28).
@@ -62,7 +66,7 @@ function UserMediaItem({ path, onOpenFile }: { path: string; onOpenFile?: (path:
         <button
           type="button"
           className="chat-msg-user-media-gone"
-          onClick={() => { setRevealError(null); void revealPath(path).then(setRevealError); }}
+          onClick={() => { setRevealError(null); void revealPath(api, path).then(setRevealError); }}
           title={path}
         >
           <span aria-hidden>{kind === 'video' ? '🎬' : kind === 'audio' ? '🎵' : '🖼'}</span> {name}
@@ -75,7 +79,7 @@ function UserMediaItem({ path, onOpenFile }: { path: string; onOpenFile?: (path:
     return (
       <video
         className="chat-msg-user-media-el"
-        src={agentFileUrl(path, { raw: true })}
+        src={agentFileUrl(vault, path, { raw: true })}
         controls
         preload="metadata"
         onError={() => setFailed(true)}
@@ -85,7 +89,7 @@ function UserMediaItem({ path, onOpenFile }: { path: string; onOpenFile?: (path:
   return (
     <img
       className="chat-msg-user-media-el"
-      src={agentFileUrl(path, { raw: true })}
+      src={agentFileUrl(vault, path, { raw: true })}
       alt={name}
       title={name}
       loading="lazy"
@@ -174,6 +178,7 @@ function AssistantMessage({
   conversationId?: string;
   readOnly: boolean;
 }) {
+  const api = useApi();
   const [confirming, setConfirming] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
@@ -190,7 +195,7 @@ function AssistantMessage({
   // chatEntities.ts — keying them to the message's own text is what let a whole answer revert
   // to raw markdown, `<a href="…mp4">` and all, on somebody else's re-render.
   useCopyableCodeBlocks(bodyRef);
-  useInlineMedia(bodyRef, { onOpen: onOpenFile, onReveal: revealPath, onGrant: grantFile });
+  useInlineMedia(bodyRef, { onOpen: onOpenFile, onReveal: (path) => revealPath(api, path), onGrant: (path) => grantFile(api, path) });
   useClickablePaths(bodyRef, (path) => onOpenFile?.(path));
 
   // Nothing left to show: an empty finished text block, or one that was ONLY a fence/board

--- a/dashboard/src/components/sleepy/chat/chatEntities.ts
+++ b/dashboard/src/components/sleepy/chat/chatEntities.ts
@@ -1,5 +1,7 @@
 import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
-import { api, agentFileUrl, RequestError } from '../../../api/client';
+import { agentFileUrl, RequestError, type ApiClient } from '../../../api/client';
+import { useVault } from '../../../context/VaultContext';
+import { readScopedRaw, writeScopedRaw } from '../../../lib/scopedStorage';
 
 /**
  * Pure, framework-light logic shared by the Agent Chat (beta) redesign's card
@@ -2019,59 +2021,84 @@ const MEDIA_KEEP_MAX = 8;
 // A stale entry (the file was overwritten at a different aspect) costs one ordinary
 // correction — the same one an unreserved image costs today — and is repaired on load.
 
-/** Remembered `naturalWidth`/`naturalHeight` per referenced path. */
-const mediaBoxes = new Map<string, { w: number; h: number }>();
-const MEDIA_BOX_KEY = 'dreamcontext.chat.mediaBoxes';
-/** Bound on what is persisted. Oldest out — a vault's screenshots are read newest-first. */
-const MEDIA_BOX_MAX = 400;
-let mediaBoxesLoaded = false;
+// Everything below is PER VAULT — the map, the load latch and the LRU bound, not merely the
+// storage key. A reference is a bare relative path (`shots/a.png`), so two projects that both
+// keep screenshots under the same folder name are talking about different files with the same
+// key. Scoping only the key would leave three sharper bugs behind: one shared latch means the
+// FIRST project to hydrate marks the cache loaded and the second one never reads its own key
+// at all; one shared map means project B's `rememberMediaBox` serialises project A's entries
+// into B's key; and one shared 400-entry bound means a busy project evicts a quiet one's boxes.
 
-/** Hydrate the remembered boxes once per page. Any failure leaves the map empty, which is
- *  simply the behaviour that existed before this cache — never an exception into a render. */
-function loadMediaBoxes(): void {
-  if (mediaBoxesLoaded) return;
-  mediaBoxesLoaded = true;
+/** Remembered `naturalWidth`/`naturalHeight` per referenced path, per vault. */
+type MediaBox = { w: number; h: number };
+const mediaBoxesByVault = new Map<string, Map<string, MediaBox>>();
+const MEDIA_BOX_KEY = 'dreamcontext.chat.mediaBoxes';
+/** Bound on what is persisted, applied PER VAULT. Oldest out — a vault's screenshots are
+ *  read newest-first. */
+const MEDIA_BOX_MAX = 400;
+/** Which vaults have already been hydrated from storage this page. */
+const hydratedVaults = new Set<string>();
+
+/** Bucket key for the per-vault maps. `null` and `''` both mean launcher/browser, which is
+ *  exactly how `scopedKey` reads them, so they must share one bucket. */
+function bucketOf(vault: string | null): string {
+  return vault || '';
+}
+
+/**
+ * This vault's box map, hydrated from storage on first touch. Any failure leaves the map
+ * empty, which is simply the behaviour that existed before this cache — never an exception
+ * into a render.
+ */
+function boxesFor(vault: string | null): Map<string, MediaBox> {
+  const bucket = bucketOf(vault);
+  let boxes = mediaBoxesByVault.get(bucket);
+  if (!boxes) {
+    boxes = new Map<string, MediaBox>();
+    mediaBoxesByVault.set(bucket, boxes);
+  }
+  if (hydratedVaults.has(bucket)) return boxes;
+  hydratedVaults.add(bucket);
   try {
-    const raw = localStorage.getItem(MEDIA_BOX_KEY);
-    if (!raw) return;
+    const raw = readScopedRaw(vault, MEDIA_BOX_KEY);
+    if (!raw) return boxes;
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return boxes;
     for (const [path, box] of Object.entries(parsed as Record<string, unknown>)) {
       const b = box as { w?: unknown; h?: unknown };
       // Only a pair of finite positive numbers is an aspect ratio. Anything else would put
       // a NaN into an attribute and reserve a box of unpredictable height.
       if (typeof b?.w === 'number' && typeof b?.h === 'number'
         && Number.isFinite(b.w) && Number.isFinite(b.h) && b.w > 0 && b.h > 0) {
-        mediaBoxes.set(path, { w: b.w, h: b.h });
+        boxes.set(path, { w: b.w, h: b.h });
       }
     }
   } catch { /* unreadable/disabled storage — reserve nothing, exactly as before */ }
+  return boxes;
 }
 
-/** Remember one image's natural size, and mirror the map to storage. */
-export function rememberMediaBox(path: string, w: number, h: number): void {
+/** Remember one image's natural size in `vault`, and mirror that vault's map to storage. */
+export function rememberMediaBox(vault: string | null, path: string, w: number, h: number): void {
   if (!(w > 0 && h > 0) || !Number.isFinite(w) || !Number.isFinite(h)) return;
-  const known = mediaBoxes.get(path);
+  const boxes = boxesFor(vault);
+  const known = boxes.get(path);
   // Re-insert at the END so eviction is least-recently-SEEN rather than insertion order: a
   // screenshot the reader keeps scrolling past must outlive images they only ever passed once.
-  mediaBoxes.delete(path);
-  mediaBoxes.set(path, { w, h });
-  while (mediaBoxes.size > MEDIA_BOX_MAX) {
-    mediaBoxes.delete(mediaBoxes.keys().next().value as string);
+  boxes.delete(path);
+  boxes.set(path, { w, h });
+  while (boxes.size > MEDIA_BOX_MAX) {
+    boxes.delete(boxes.keys().next().value as string);
   }
   // Seeing a known image again reorders the queue but writes nothing: `load` fires for every
   // image on every mount, and serializing the whole map each time would put a few hundred
   // entries through `JSON.stringify` on a scroll.
   if (known && known.w === w && known.h === h) return;
-  try {
-    localStorage.setItem(MEDIA_BOX_KEY, JSON.stringify(Object.fromEntries(mediaBoxes)));
-  } catch { /* quota/disabled — the in-memory map still serves this page */ }
+  writeScopedRaw(vault, MEDIA_BOX_KEY, JSON.stringify(Object.fromEntries(boxes)));
 }
 
-/** The remembered box for a path, or null when this image has never been displayed. */
-export function knownMediaBox(path: string): { w: number; h: number } | null {
-  loadMediaBoxes();
-  return mediaBoxes.get(path) ?? null;
+/** The box `vault` remembers for a path, or null when this image has never been displayed. */
+export function knownMediaBox(vault: string | null, path: string): MediaBox | null {
+  return boxesFor(vault).get(path) ?? null;
 }
 
 // ─── Folders (the file panel's directory listing) ────────────────────────────────────
@@ -2185,9 +2212,11 @@ function isLocalRef(href: string): boolean {
 
 /** Bytes for a referenced path. Built through the api client, NOT by hand: the vault has to
  *  ride in the URL because the browser fetches an element `src` itself and sends no headers
- *  (see `agentFileUrl`). Hand-building this is what made every clip 400 in launcher mode. */
-function rawUrl(path: string): string {
-  return agentFileUrl(path, { raw: true });
+ *  (see `agentFileUrl`). Hand-building this is what made every clip 400 in launcher mode.
+ *  `vault` is a parameter — this is a module function with no React above it, and with several
+ *  projects live in one window the wrong one would serve another project's file. */
+function rawUrl(vault: string | null, path: string): string {
+  return agentFileUrl(vault, path, { raw: true });
 }
 
 function basenameOf(path: string): string {
@@ -2213,8 +2242,12 @@ function basenameOf(path: string): string {
  * and what every inline card uses) lets the route decide, which for anything executable is a
  * reveal regardless: that downgrade is a SUCCESS, not something to report. The file manager
  * comes to the front with the file selected, which is the honest answer to the click.
+ *
+ * `api` is a PARAMETER, not a module read: `/agent/reveal` is per-vault (not on the server's
+ * agnostic list), and this is a plain function called from event handlers, not a hook — it
+ * can't read `useVault()` itself, so every caller passes the client bound to ITS OWN project.
  */
-export function revealPath(path: string, mode: 'auto' | 'reveal' = 'auto'): Promise<string | null> {
+export function revealPath(api: ApiClient, path: string, mode: 'auto' | 'reveal' = 'auto'): Promise<string | null> {
   return api.post('/agent/reveal', { path, mode }).then(
     () => null,
     (err: unknown) => {
@@ -2259,6 +2292,10 @@ export function useInlineMedia(
     onGrant?: (path: string) => Promise<boolean>;
   } = {},
 ): void {
+  // Which project's files these references name. Read here, in the hook, and threaded into the
+  // module-level `rawUrl` below — the effect it feeds runs on every render, so it always builds
+  // its `src` against the project whose transcript is on screen.
+  const { vault } = useVault();
   // The elements this pass has built, by path. A media element that is merely DETACHED still
   // holds its decoded frames and its buffer, so putting the same one back is free where
   // building a new one costs a fresh request for the whole clip. That is the difference the
@@ -2384,12 +2421,12 @@ export function useInlineMedia(
         // reader who has scrolled up (see `mediaBoxes`). The attributes only supply an aspect
         // ratio here — `.chat-md-image` keeps `width/height: auto` under its two caps, so the
         // used size is still decided by the column and `max-height`, exactly as before.
-        const box = knownMediaBox(path);
+        const box = knownMediaBox(vault, path);
         if (box) { el.width = box.w; el.height = box.h; }
-        // First sight of this image (or a file that changed shape) teaches the cache, so the
-        // next transcript that mounts it reserves the right box from the start.
+        // First sight of this image (or a file that changed shape) teaches THIS project's
+        // cache, so the next transcript that mounts it reserves the right box from the start.
         el.addEventListener('load', () => {
-          rememberMediaBox(path, el.naturalWidth, el.naturalHeight);
+          rememberMediaBox(vault, path, el.naturalWidth, el.naturalHeight);
         });
         el.addEventListener('click', () => live.current.onOpen?.(path));
       }
@@ -2404,7 +2441,7 @@ export function useInlineMedia(
         // consent. One byte costs nothing even for a large clip.
         // The 403 body also carries the file the server RESOLVED the reference to, which is
         // what "Allow access" has to grant — see `buildFallback`.
-        void fetch(rawUrl(path), { headers: { Range: 'bytes=0-0' } })
+        void fetch(rawUrl(vault, path), { headers: { Range: 'bytes=0-0' } })
           .then(async (r): Promise<{ reason: 'grant' | 'open'; grantPath: string }> => {
             if (r.status !== 403) return { reason: 'open', grantPath: path };
             const body = await r.json().catch(() => null) as { path?: unknown } | null;
@@ -2418,7 +2455,7 @@ export function useInlineMedia(
             if (el.isConnected) el.replaceWith(buildFallback(path, reason, grantPath));
           });
       }, { once: true });
-      el.src = rawUrl(path);
+      el.src = rawUrl(vault, path);
       // Cap what a single message can keep alive: a detached clip still holds its buffer, and
       // an answer with two dozen screenshots should not pin all of them off-screen. Oldest out.
       if (cache.current.size >= MEDIA_KEEP_MAX) {

--- a/dashboard/src/components/sleepy/chatSession.ts
+++ b/dashboard/src/components/sleepy/chatSession.ts
@@ -1,4 +1,4 @@
-import { api, getActiveVault } from '../../api/client';
+import { ApiClient } from '../../api/client';
 import { contextLimitFor } from '../../lib/agentComposer';
 import { raiseAskAttention } from '../../lib/attention';
 import {
@@ -402,7 +402,15 @@ let chatSessionSeq = 0;
  * ALWAYS delivered server-side (submitted as the first user frame, or parked for the
  * UserPromptSubmit hook when deferred) — there is no client-side injection path here.
  */
+/**
+ * Spawn one chat session against `vault` — the project this conversation belongs to, passed in
+ * rather than read from a module global. One window now holds several live projects, so an
+ * "active vault" module read would open the stream in whichever project the user last clicked;
+ * the vault also names this session's alarm source, which is what lets a background project's
+ * chip raise the user (see `pushAsk` below). Empty string = no project pinned.
+ */
 export function createChatSession(
+  vault: string,
   bypass: boolean,
   notify: () => void,
   claudeId: string,
@@ -416,11 +424,14 @@ export function createChatSession(
   const id = `chat-${++chatSessionSeq}`;
   const container = document.createElement('div');
   container.className = 'agent-pane-chat';
+  // `/agent/chat-history` is per-vault (not on the server's agnostic list), and this factory
+  // is framework-free — no `useApi()` here — so the client is built once from the vault this
+  // session was spawned against, exactly as its own WS URL below is.
+  const api = new ApiClient(vault);
 
   // ── WS URL (contract C2) — same param conventions as agentSession.ts:268-305, plus
   //    `effort` (chat sets it at spawn via `--effort`; the terminal only ever switches it
   //    live via `/effort`, so it never appears in the terminal's own URL builder). ──
-  const vault = getActiveVault();
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const idParam = resume ? `&resume=${encodeURIComponent(claudeId)}` : `&sessionId=${encodeURIComponent(claudeId)}`;
   const modelParam = model ? `&model=${encodeURIComponent(model)}` : '';
@@ -433,7 +444,7 @@ export function createChatSession(
       ? `&promptToken=${encodeURIComponent(promptToken)}`
       : `&prompt=${encodeURIComponent(initialPrompt)}`;
   const deferParam = serverSubmitsPrompt && deferPrompt ? '&deferPrompt=1' : '';
-  const url = `${proto}://${location.host}/api/agent/chat?vault=${encodeURIComponent(vault ?? '')}`
+  const url = `${proto}://${location.host}/api/agent/chat?vault=${encodeURIComponent(vault)}`
     + `&bypass=${bypassParam}${idParam}${modelParam}${effortParam}${promptParam}${deferParam}`;
   const ws = new WebSocket(url);
 
@@ -586,7 +597,9 @@ export function createChatSession(
       session.attention = true;
       // Chat is the one surface that can put the actual words in the banner: the ask
       // arrives as structured JSON, so what the notification shows is what the card shows.
-      raiseAskAttention({ source: getActiveVault(), detail: askSummary(entry) });
+      // `source` is this session's own VAULT: it is what the chip strip keys a background
+      // project's alarm off, so a title here would silence the wrong project's chip.
+      raiseAskAttention({ source: vault, detail: askSummary(entry) });
     }
   }
 

--- a/dashboard/src/components/sleepy/chatSession.ts
+++ b/dashboard/src/components/sleepy/chatSession.ts
@@ -1,6 +1,6 @@
 import { api, getActiveVault } from '../../api/client';
 import { contextLimitFor } from '../../lib/agentComposer';
-import { playAskChime } from '../../lib/chime';
+import { raiseAskAttention } from '../../lib/attention';
 import {
   parseChatLine, buildQuestionAnswer, isUrgentChatEvent,
   type ChatEvent, type QuestionSpec, type ClientControl,
@@ -375,6 +375,20 @@ export interface ChatSession {
   setTranscriptRepin: (fn: (() => void) | null) => void;
 }
 
+/**
+ * One line describing what an ask actually WANTS, for the OS notification banner that
+ * fires when the user is in another app (see lib/attention.ts).
+ *
+ * A question gives its first `question` (the `header` is a 12-char chip like "Auth method"
+ * — too terse to act on from a banner); a plan review has no question text at all, so it
+ * says what the card says. Multi-question asks name only the first: the banner exists to
+ * get you back to the app, not to reproduce the card.
+ */
+function askSummary(entry: PendingQuestion | PendingPlan): string {
+  if (entry.kind === 'plan') return 'A plan is waiting for your approval.';
+  return entry.questions[0]?.question ?? '';
+}
+
 // ─── Session factory ────────────────────────────────────────────────────────────────
 
 let chatSessionSeq = 0;
@@ -557,7 +571,7 @@ export function createChatSession(
 
   /**
    * Push a card that ASKS the user something directly — a question or a plan to approve —
-   * onto `pending`, chiming only on the edge where none was pending before.
+   * onto `pending`, raising the user only on the edge where none was pending before.
    *
    * `others` is `pending` already stripped of this `requestId` (a re-sent request replaces
    * its own card rather than stacking a twin). Shared by both arms so the two can never
@@ -570,7 +584,9 @@ export function createChatSession(
     session.asking = conv.pending.length > 0;
     if (!hadAskBefore) {
       session.attention = true;
-      playAskChime();
+      // Chat is the one surface that can put the actual words in the banner: the ask
+      // arrives as structured JSON, so what the notification shows is what the card shows.
+      raiseAskAttention({ source: getActiveVault(), detail: askSummary(entry) });
     }
   }
 

--- a/dashboard/src/components/tasks/AuthorTaskComposer.tsx
+++ b/dashboard/src/components/tasks/AuthorTaskComposer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useVault } from '../../context/VaultContext';
 import { authorTaskWithAgent } from '../../lib/authorTaskAgent';
 import { SparkIcon } from '../sleepy/TypeIcons';
 import { PRIO_ORDER, STATUS_ORDER, STATUS_META, levelLabel } from './boardModel';
@@ -25,6 +26,8 @@ interface AuthorTaskComposerProps {
  * the manual `TaskCreateModal` stays the fallback on web (A6).
  */
 export function AuthorTaskComposer({ onClose, onStarted, initialStatus }: AuthorTaskComposerProps) {
+  // The board this composer was opened from names the project the new task belongs to.
+  const { vault, bus } = useVault();
   const [idea, setIdea] = useState('');
   const [status, setStatus] = useState(initialStatus && (STATUS_ORDER as readonly string[]).includes(initialStatus) ? initialStatus : '');
   const [priority, setPriority] = useState('');
@@ -48,7 +51,7 @@ export function AuthorTaskComposer({ onClose, onStarted, initialStatus }: Author
   const submit = () => {
     if (!canSend) return;
     setSending(true);
-    void authorTaskWithAgent({ idea, hints: { status, priority }, bypass })
+    void authorTaskWithAgent(bus, vault, { idea, hints: { status, priority }, bypass })
       .then((accepted) => {
         // Report what REALLY happened — the surface gates on its own capabilities snapshot,
         // which can disagree with the one that made this affordance visible. An optimistic

--- a/dashboard/src/components/tasks/DelegateComposer.tsx
+++ b/dashboard/src/components/tasks/DelegateComposer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Task } from '../../hooks/useTasks';
 import { useAgentModelConfig } from '../../hooks/useAgentCapabilities';
+import { useVault } from '../../context/VaultContext';
 import { delegateTaskToAgent } from '../../lib/delegateAgent';
 import {
   DELEGATE_MODES, DEFAULT_DELEGATE_MODE, delegateMode, delegateTitle,
@@ -38,6 +39,9 @@ interface Replaced { mode: DelegateModeId; prompt: string; bypass: boolean; }
  * modal + field CSS.
  */
 export function DelegateComposer({ task, onClose, onDelegated, reveal }: DelegateComposerProps) {
+  // The board this composer was opened from names the project the task belongs to — the prompt
+  // token has to be minted against THAT project, not against whichever chip is active.
+  const { vault, bus } = useVault();
   // ONE source for the title: the prompt's "Task:" line and the delegated tab's title both
   // come from this call, so they can't drift.
   const title = taskName(task);
@@ -108,7 +112,7 @@ export function DelegateComposer({ task, onClose, onDelegated, reveal }: Delegat
     // Hand the prompt over WHOLE — `delegateTaskToAgent` picks a transport that can carry it
     // (inline for a short prompt, a POSTed token for a long one), so what is shown above is
     // exactly what the agent receives. Nothing is trimmed behind the user's back.
-    void delegateTaskToAgent({
+    void delegateTaskToAgent(bus, vault, {
       title: delegateTitle(mode, title),
       prompt,
       bypass,

--- a/dashboard/src/components/tasks/detail/useSectionCollapse.ts
+++ b/dashboard/src/components/tasks/detail/useSectionCollapse.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { getActiveVault } from '../../../api/client';
+import { useVault } from '../../../context/VaultContext';
 
 /**
  * Which property sections are open, remembered per user.
@@ -18,13 +18,16 @@ const KEY_PREFIX = 'dreamcontext:task-sections:';
 
 type CollapseMap = Record<string, boolean>;
 
-function storageKey(): string {
-  return `${KEY_PREFIX}${getActiveVault() ?? ''}`;
+/** The vault travels as a PARAMETER because these two are module functions called at read/write
+ *  time, not from React — `useVault()` cannot be called inside them, and with several projects
+ *  live in one window a module-level read would give one project's accordions to another. */
+function storageKey(vault: string | null): string {
+  return `${KEY_PREFIX}${vault ?? ''}`;
 }
 
-function read(): CollapseMap {
+function read(vault: string | null): CollapseMap {
   try {
-    const raw = localStorage.getItem(storageKey());
+    const raw = localStorage.getItem(storageKey(vault));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
     // Defensive: a hand-edited or half-written value must not crash the whole task view.
@@ -73,7 +76,10 @@ export interface SectionCollapse {
 }
 
 export function useSectionCollapse(): SectionCollapse {
-  const [map, setMap] = useState<CollapseMap>(read);
+  const { vault } = useVault();
+  // Seeded from THIS subtree's vault once, exactly as the module-global read did at mount: a
+  // mounted task panel belongs to one project for its whole life.
+  const [map, setMap] = useState<CollapseMap>(() => read(vault));
 
   // The default is looked up here rather than passed in by the caller: a caller that could pass
   // the fallback could pass the WRONG one, and then a section's default would depend on which
@@ -85,10 +91,10 @@ export function useSectionCollapse(): SectionCollapse {
       // The stored value is the user's explicit choice, so flip against what they SEE. Defaults
       // can change per release; only explicit overrides persist.
       const next = { ...prev, [id]: !(prev[id] ?? DEFAULTS[id]) };
-      try { localStorage.setItem(storageKey(), JSON.stringify(next)); } catch { /* best-effort */ }
+      try { localStorage.setItem(storageKey(vault), JSON.stringify(next)); } catch { /* best-effort */ }
       return next;
     });
-  }, []);
+  }, [vault]);
 
   return { isOpen, toggle };
 }

--- a/dashboard/src/context/ProjectContext.tsx
+++ b/dashboard/src/context/ProjectContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { api } from '../api/client';
+import { useApi } from './VaultContext';
 
 interface HealthResponse {
   ok: boolean;
@@ -29,6 +29,7 @@ type LoadState =
   | { kind: 'ready'; value: ProjectContextValue };
 
 export function ProjectProvider({ children }: { children: ReactNode }) {
+  const api = useApi();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
 
   useEffect(() => {
@@ -44,7 +45,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
       // Fallback: no project scoping (still render the app)
       setState({ kind: 'ready', value: { projectId: '', contextRoot: '' } });
     });
-  }, []);
+  }, [api]);
 
   if (state.kind === 'loading') {
     return (

--- a/dashboard/src/context/VaultContext.tsx
+++ b/dashboard/src/context/VaultContext.tsx
@@ -1,0 +1,104 @@
+import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { ApiClient } from '../api/client';
+
+/**
+ * Which project a subtree belongs to — the identity every per-instance surface reads.
+ *
+ * One OS window now holds several LIVE projects at once (a chip strip, not a window each),
+ * so "the vault" stopped being a property of the window and became a property of a subtree.
+ * Everything that used to be a module-level global — the API client's vault header, the
+ * localStorage key namespace, the window events one project fires at itself — hangs off this
+ * context instead, because with N instances mounted in one JS realm a module-level global is
+ * shared state between unrelated projects.
+ */
+export interface VaultContextValue {
+  /** The project name, or null in the launcher / browser build where none is pinned. */
+  vault: string | null;
+  /** Stable per mounted `ProjectInstance`, e.g. `inst-1`. Namespaces anything that would
+   *  otherwise collide between two instances of the same component (overlay ids). */
+  instanceId: string;
+  /** Whether this instance is the chip the user is looking at. Hidden instances stay MOUNTED
+   *  and LIVE — this only gates cosmetics and polling, never a WebSocket. */
+  isActive: boolean;
+  /** Replaces `window` for the events one project fires at itself (navigate, delegate, run
+   *  sleep, …). On `window` every mounted instance hears them and the wrong project acts. */
+  bus: EventTarget;
+}
+
+/**
+ * The bus handed to consumers rendered outside any provider. A module singleton rather than
+ * a fresh EventTarget per call so that an emit and a listen from two such consumers still
+ * meet — off-instance surfaces (launcher, capture bar, perch, checklist window) are a single
+ * logical "instance" and must keep behaving exactly as they do on `window` today.
+ */
+const FALLBACK_BUS: EventTarget = new EventTarget();
+
+/**
+ * What `useVault()` answers with NO provider above it — load-bearing, not a placeholder.
+ *
+ * `vault: null` makes `useApi()` return a client identical to the module `api`, so the
+ * launcher, `CaptureBar`, `SleepyPerch` and the checklist window are byte-identical to
+ * today. `isActive: true` so nothing outside a provider ever believes it is hidden and
+ * quietly stops rendering or polling.
+ */
+export const DEFAULT_VAULT_CONTEXT: VaultContextValue = {
+  vault: null,
+  instanceId: '',
+  isActive: true,
+  bus: FALLBACK_BUS,
+};
+
+const VaultContext = createContext<VaultContextValue>(DEFAULT_VAULT_CONTEXT);
+
+export function VaultProvider({ vault, instanceId, isActive, bus, children }: VaultContextValue & { children: ReactNode }) {
+  // Memoized on the four fields, not rebuilt per render: `useApi()` derives its client from
+  // `vault` and callers list that client in `useCallback` deps, so a fresh context object
+  // every render would invalidate those callbacks on every parent re-render.
+  const value = useMemo<VaultContextValue>(
+    () => ({ vault, instanceId, isActive, bus }),
+    [vault, instanceId, isActive, bus],
+  );
+  return <VaultContext.Provider value={value}>{children}</VaultContext.Provider>;
+}
+
+/** This subtree's project identity, or {@link DEFAULT_VAULT_CONTEXT} outside a provider. */
+export function useVault(): VaultContextValue {
+  return useContext(VaultContext);
+}
+
+/**
+ * The API client bound to THIS subtree's vault. Stable identity per vault (memoized), which
+ * is what lets call sites put `api` in a `useCallback`/`useEffect` dependency array without
+ * re-running on every render.
+ */
+export function useApi(): ApiClient {
+  const { vault } = useVault();
+  return useMemo(() => new ApiClient(vault), [vault]);
+}
+
+/** Fire an instance-scoped event — the bus twin of `window.dispatchEvent(new CustomEvent(…))`. */
+export function emitInstance<T>(bus: EventTarget, type: string, detail?: T): void {
+  bus.dispatchEvent(new CustomEvent<T | undefined>(type, { detail }));
+}
+
+/**
+ * Subscribe to an instance-scoped event for as long as the component is mounted.
+ *
+ * `handler` is held in a ref so a caller may pass an inline closure without resubscribing on
+ * every render; the subscription itself is re-established only when the bus or the event
+ * type actually changes.
+ */
+export function useInstanceEvent<T>(type: string, handler: (detail: T) => void): void {
+  const { bus } = useVault();
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const listener = (event: Event) => handlerRef.current((event as CustomEvent<T>).detail);
+    bus.addEventListener(type, listener);
+    return () => bus.removeEventListener(type, listener);
+  }, [bus, type]);
+}

--- a/dashboard/src/hooks/useAgentCapabilities.ts
+++ b/dashboard/src/hooks/useAgentCapabilities.ts
@@ -1,9 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 import type { Capabilities } from '../components/sleepy/agentSession';
 import { FALLBACK_MODEL_CONFIG, type ModelConfig, type SessionStats } from '../lib/agentComposer';
 import type { GoalLiveResponse } from '../lib/goalLive';
 import type { CouncilLiveResponse } from '../lib/councilLive';
+
+/**
+ * Every query below pins its own `refetchInterval` rather than inheriting one. That's
+ * load-bearing, not incidental: a backgrounded project's `QueryClient` defaults
+ * `refetchInterval` to `false` (`lib/instanceQueryClient.ts`) so idle page data stops
+ * polling, but session-stats/goal-live/council-live back a background chip's live badge —
+ * they must keep polling while `enabled`, independent of whether the project is the
+ * foreground chip. Do not drop their explicit `refetchInterval` in favor of the default.
+ */
 
 /**
  * Agent prerequisite probe (`GET /api/agent/capabilities`) — desktop gate + node-pty
@@ -12,6 +21,7 @@ import type { CouncilLiveResponse } from '../lib/councilLive';
  * Used by the header's Sleep tracker to enable/disable "Run sleep agent".
  */
 export function useAgentCapabilities() {
+  const api = useApi();
   return useQuery({
     queryKey: ['agent-capabilities'],
     queryFn: () => api.get<Capabilities>('/agent/capabilities'),
@@ -45,6 +55,7 @@ export function isSleepAgentReady(caps: Capabilities | undefined, chatView = fal
  * composer strip's model/effort pickers.
  */
 export function useAgentModelConfig() {
+  const api = useApi();
   return useQuery({
     queryKey: ['agent-model-config'],
     queryFn: () => api.get<ModelConfig>('/agent/model-config'),
@@ -65,6 +76,7 @@ const EMPTY_STATS: SessionStats = { contextTokens: null, contextLimit: null, cos
  * a dormant tab, or before a claudeId exists. Consumed per pane by {@link AgentComposerBar}.
  */
 export function useAgentSessionStats(claudeId: string | undefined, enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['agent-session-stats', claudeId],
     queryFn: () => api.get<SessionStats>(`/agent/session-stats?claudeId=${encodeURIComponent(claudeId!)}`),
@@ -86,6 +98,7 @@ const GOAL_LIVE_INACTIVE: GoalLiveResponse = { active: false };
  * server just reads one small JSON file.
  */
 export function useAgentGoalLive(claudeId: string | undefined, enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['agent-goal-live', claudeId],
     queryFn: () => api.get<GoalLiveResponse>(`/agent/goal-live?claudeId=${encodeURIComponent(claudeId!)}`),
@@ -107,6 +120,7 @@ const COUNCIL_LIVE_INACTIVE: CouncilLiveResponse = { active: false };
  * panel and the dock badge dedupe into one poll per conversation.
  */
 export function useAgentCouncilLive(claudeId: string | undefined, enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['agent-council-live', claudeId],
     queryFn: () => api.get<CouncilLiveResponse>(`/agent/council-live?claudeId=${encodeURIComponent(claudeId!)}`),

--- a/dashboard/src/hooks/useAutomations.ts
+++ b/dashboard/src/hooks/useAutomations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * Automations — the dashboard's read + "run now" + approve surface over
@@ -199,6 +199,7 @@ export interface AutomationRunJob {
 
 /** List every automation (for the board). Empty on an older backend / no route. */
 export function useAutomations() {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations'],
     queryFn: () => api.get<{ automations: AutomationSummary[] }>('/automations').then((r) => r.automations),
@@ -208,6 +209,7 @@ export function useAutomations() {
 
 /** Full manifest (every hashed field for review) + approval state + cache/history. */
 export function useAutomation(slug: string | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations', slug],
     queryFn: () => api.get<AutomationDetail>(`/automations/${slug}`),
@@ -225,6 +227,7 @@ export function useAutomation(slug: string | null) {
  * same run free.
  */
 export function useAutomationSession(slug: string | null, runNumber: number | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations', slug, 'session', runNumber],
     queryFn: () =>
@@ -241,6 +244,7 @@ export function useAutomationSession(slug: string | null, runNumber: number | nu
  *  sync-job precedent, `useTasks.ts`'s `useSyncJob`), idle otherwise — a
  *  headless `claude -p` run can take up to an hour, so idle polling must stop. */
 export function useAutomationRunJob() {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations-run-job'],
     queryFn: () => api.get<{ job: AutomationRunJob | null }>('/automations/runs').then((r) => r.job),
@@ -254,6 +258,7 @@ export function useAutomationRunJob() {
  *  runner (server-side) — this mutation carries no prompt and no bypass. */
 export function useRunAutomation() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (slug: string) =>
       api.post<{ job: AutomationRunJob; started: boolean }>(`/automations/${slug}/run`, {}),
@@ -304,6 +309,7 @@ export interface DispatcherInstallResult {
 }
 
 export function useAutomationDispatcher() {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations-dispatcher'],
     queryFn: () => api.get<{ dispatcher: AutomationDispatcher }>('/automations/dispatcher').then((r) => r.dispatcher),
@@ -326,6 +332,7 @@ export function useAutomationDispatcher() {
  */
 export function useInstallDispatcher() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (opts: { force?: boolean } = {}) =>
       api.post<DispatcherInstallResult>('/automations/dispatcher/install', { force: opts.force === true }),
@@ -339,6 +346,7 @@ export function useInstallDispatcher() {
 /** Turn the scheduler back off. Manifests, approvals and run history all stay. */
 export function useUninstallDispatcher() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: () =>
       api.post<{ bootedOut: boolean; removedNotifier: boolean; dispatcher: AutomationDispatcher }>(
@@ -357,6 +365,7 @@ export function useUninstallDispatcher() {
  *  blocks an already-approved automation. */
 export function useSetAutomationEnabled() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, enabled }: { slug: string; enabled: boolean }) =>
       api.post<{ automation: AutomationSummary }>(`/automations/${slug}/${enabled ? 'enable' : 'disable'}`, {}),
@@ -373,6 +382,7 @@ export function useSetAutomationEnabled() {
  *  fires). */
 export function useApproveAutomation() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (slug: string) =>
       api.post<{ slug: string; approval: { manifestSha256: string; approvedAt: string; payloadVersion: string } }>(
@@ -432,6 +442,7 @@ export interface ReviewCard {
  * but showing it is better than catching it.
  */
 export function useReviewQueue() {
+  const api = useApi();
   return useQuery({
     queryKey: ['automations-review'],
     queryFn: () => api.get<{ cards: ReviewCard[] }>('/automations/review').then((r) => r.cards),
@@ -458,6 +469,7 @@ export interface ReviewAnswerResult {
  */
 export function useAnswerReviewCard() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ id, verdict, steer }: { id: string; verdict?: 'approve' | 'discard' | 'drop'; steer?: string }) =>
       api.post<ReviewAnswerResult>(`/automations/review/${id}`, verdict ? { verdict } : { steer }),

--- a/dashboard/src/hooks/useBoard.ts
+++ b/dashboard/src/hooks/useBoard.ts
@@ -14,7 +14,8 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
+import type { ApiClient } from '../api/client';
 import {
   type BoardFilters, type BoardView, type CardProps, type Dim, type LocalBoard,
   type SaveScope, type SharedBoard, type SortKey, type SortDir, type ViewConfig, type Layout,
@@ -26,6 +27,7 @@ import {
 interface BoardResponse { shared: unknown; local: unknown; }
 
 function useBoardQuery() {
+  const api = useApi();
   return useQuery({
     queryKey: ['board'],
     queryFn: () => api.get<BoardResponse>('/board'),
@@ -33,10 +35,10 @@ function useBoardQuery() {
   });
 }
 
-function putShared(board: SharedBoard): Promise<unknown> {
+function putShared(api: ApiClient, board: SharedBoard): Promise<unknown> {
   return api.put('/board/shared', { board });
 }
-function putLocal(board: LocalBoard): Promise<unknown> {
+function putLocal(api: ApiClient, board: LocalBoard): Promise<unknown> {
   return api.put('/board/local', { board });
 }
 
@@ -91,6 +93,7 @@ export interface BoardState {
 
 export function useBoardState(): BoardState {
   const { data, isSuccess } = useBoardQuery();
+  const api = useApi();
 
   const [shared, setShared] = useState<SharedBoard>(defaultSharedBoard);
   const [local, setLocal] = useState<LocalBoard>(defaultLocalBoard);
@@ -102,8 +105,8 @@ export function useBoardState(): BoardState {
   const localTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flushLocal = useCallback((next: LocalBoard) => {
     if (localTimer.current) clearTimeout(localTimer.current);
-    localTimer.current = setTimeout(() => { void putLocal(next).catch(() => {}); }, 500);
-  }, []);
+    localTimer.current = setTimeout(() => { void putLocal(api, next).catch(() => {}); }, 500);
+  }, [api]);
   useEffect(() => () => { if (localTimer.current) clearTimeout(localTimer.current); }, []);
 
   // Seed runtime state once the server blobs arrive.
@@ -131,8 +134,8 @@ export function useBoardState(): BoardState {
   // ── persistence helpers ────────────────────────────────────────────────────
   const persistShared = useCallback((next: SharedBoard) => {
     setShared(next);
-    void putShared(next).catch(() => {});
-  }, []);
+    void putShared(api, next).catch(() => {});
+  }, [api]);
   const persistLocal = useCallback((updater: (l: LocalBoard) => LocalBoard) => {
     setLocal((prev) => { const next = updater(prev); flushLocal(next); return next; });
   }, [flushLocal]);

--- a/dashboard/src/hooks/useBrainStatus.ts
+++ b/dashboard/src/hooks/useBrainStatus.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * Thin react-query layer over the M2 brain cloud-sync endpoints
@@ -145,6 +145,7 @@ function invalidateBrain(queryClient: ReturnType<typeof useQueryClient>): void {
 
 /** Resolved brain-repo status for the active vault. Polls on the app's default 15s tick. */
 export function useBrainStatus() {
+  const api = useApi();
   return useQuery({
     queryKey: BRAIN_KEYS.status,
     queryFn: () => api.get<BrainStatus>('/brain/status'),
@@ -152,6 +153,7 @@ export function useBrainStatus() {
 }
 
 export function useBrainSettings() {
+  const api = useApi();
   return useQuery({
     queryKey: BRAIN_KEYS.settings,
     queryFn: () => api.get<BrainSettings>('/brain/settings'),
@@ -165,6 +167,7 @@ export function useBrainSettings() {
  */
 export function useUpdateBrainSettings() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (enabled: boolean) => api.post<BrainSettings>('/brain/settings', { enabled }),
     onSuccess: (data) => {
@@ -205,6 +208,7 @@ export interface CreateOriginArgs {
 
 /** Preview a repo URL before attaching (no mutation). Returns `{ reachable, reason }`. */
 export function usePreviewOrigin() {
+  const api = useApi();
   return useMutation({
     mutationFn: (url: string) => api.post<OriginPreview>('/brain/origin/preview', { url }),
   });
@@ -213,6 +217,7 @@ export function usePreviewOrigin() {
 /** Create a new GitHub repo as the project's origin, then enable + first-sync. */
 export function useCreateOrigin() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (args: CreateOriginArgs = {}) => api.post<OriginSetupResult>('/brain/origin/create', args),
     // Settled, not success: even when the request errors mid-flight, the repo may
@@ -224,6 +229,7 @@ export function useCreateOrigin() {
 /** Attach an existing GitHub repo as the project's origin, then enable + first-sync. */
 export function useAttachOrigin() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (url: string) => api.post<OriginSetupResult>('/brain/origin/attach', { url }),
     onSettled: () => invalidateBrain(queryClient),
@@ -238,6 +244,7 @@ export function useAttachOrigin() {
  */
 export function useUpdateOrigin() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (url: string) => api.post<OriginSetupResult>('/brain/origin/update', { url }),
     onSuccess: () => invalidateBrain(queryClient),
@@ -247,6 +254,7 @@ export function useUpdateOrigin() {
 /** Remove the origin + revert cloud sync to in-tree (connected-card "Disconnect"). */
 export function useDetachOrigin() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<{ ok: boolean; remote: null }>('/brain/origin/detach', {}),
     onSuccess: () => invalidateBrain(queryClient),
@@ -256,6 +264,7 @@ export function useDetachOrigin() {
 // ─── GitHub sign-in (app-global — device flow + PAT fallback) ────────────────
 
 export function useAuthStatus() {
+  const api = useApi();
   return useQuery({
     queryKey: BRAIN_KEYS.authStatus,
     queryFn: () => api.get<AuthStatus>('/brain/auth/status'),
@@ -263,6 +272,7 @@ export function useAuthStatus() {
 }
 
 export function useDeviceStart() {
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<DeviceStartResult>('/brain/auth/device/start', {}),
   });
@@ -270,6 +280,7 @@ export function useDeviceStart() {
 
 /** One poll tick. The CALLER drives the loop timing off the server-returned interval. */
 export function useDevicePoll() {
+  const api = useApi();
   return useMutation({
     mutationFn: (sessionId: string) => api.post<DevicePollResult>('/brain/auth/device/poll', { sessionId }),
   });
@@ -277,6 +288,7 @@ export function useDevicePoll() {
 
 export function useSubmitPatToken() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (token: string) => api.post<AuthStatus>('/brain/auth/token', { token }),
     onSuccess: (data) => queryClient.setQueryData(BRAIN_KEYS.authStatus, data),
@@ -285,6 +297,7 @@ export function useSubmitPatToken() {
 
 export function useLogoutGitHub() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<AuthStatus>('/brain/auth/logout', {}),
     onSuccess: (data) => queryClient.setQueryData(BRAIN_KEYS.authStatus, data),
@@ -299,6 +312,7 @@ export interface RunBrainSyncArgs {
 
 export function useRunBrainSync() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     // Every dashboard-initiated sync is FOREGROUND (a human is watching): WARN
     // scrub hits stay non-blocking, only real secrets stop it.
@@ -313,6 +327,7 @@ export function useRunBrainSync() {
 /** One-click "add <path> to .gitignore" for a scrub-blocked local secret file (item 6). */
 export function useAddScrubIgnore() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (path: string) => api.post<{ ok: boolean; added: string[]; path: string }>('/brain/scrub/ignore', { path }),
     onSuccess: () => invalidateBrain(queryClient),
@@ -323,6 +338,7 @@ export function useAddScrubIgnore() {
 
 /** Cache-only — zero network in the request path. Polls on the default 15s tick. */
 export function useTeamUpdates() {
+  const api = useApi();
   return useQuery({
     queryKey: BRAIN_KEYS.teamUpdates,
     queryFn: () => api.get<{ vaults: TeamVaultUpdate[] }>('/brain/team/updates'),
@@ -333,6 +349,7 @@ export function useTeamUpdates() {
 /** "Check now" — an in-process pull-only sync across vaults (or one, if `vault` is given). */
 export function useTeamFetch() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (vault?: string) =>
       api.post<{ results: TeamFetchVaultResult[] }>('/brain/team/fetch', vault ? { vault } : {}),

--- a/dashboard/src/hooks/useChangelog.ts
+++ b/dashboard/src/hooks/useChangelog.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /** One entry from core/CHANGELOG.json (newest-first). */
 export interface ChangelogEntry {
@@ -18,6 +18,7 @@ interface ChangelogResponse {
 
 /** Project ship-narrative changelog — written during the RemSleep cycle. */
 export function useChangelog() {
+  const api = useApi();
   return useQuery({
     queryKey: ['changelog'],
     queryFn: () => api.get<ChangelogResponse>('/changelog'),

--- a/dashboard/src/hooks/useConfig.ts
+++ b/dashboard/src/hooks/useConfig.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 // ─── Types (duplicated client-side — can't import from src/lib) ───────────────
 
@@ -53,6 +53,7 @@ export interface ConfigPatch {
 // ─── Hooks ────────────────────────────────────────────────────────────────────
 
 export function useConfig() {
+  const api = useApi();
   return useQuery({
     queryKey: ['config'],
     queryFn: () => api.get<ConfigResponse>('/config'),
@@ -62,6 +63,7 @@ export function useConfig() {
 
 export function useUpdateConfig() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (patch: ConfigPatch) =>
       api.patch<ConfigUpdateResponse>('/config', patch),

--- a/dashboard/src/hooks/useConnections.ts
+++ b/dashboard/src/hooks/useConnections.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 // ─── Types (duplicated client-side — can't import from src/lib) ───────────────
 
@@ -40,6 +40,7 @@ export interface ConnectPayload {
 
 /** Registered vaults + which one is the current project. */
 export function useVaults() {
+  const api = useApi();
   return useQuery({
     queryKey: ['vaults'],
     queryFn: () => api.get<VaultsResponse>('/vaults'),
@@ -48,6 +49,7 @@ export function useVaults() {
 
 /** This vault's federation connections. */
 export function useConnections() {
+  const api = useApi();
   return useQuery({
     queryKey: ['connections'],
     queryFn: () => api.get<ConnectionsResponse>('/connections'),
@@ -58,6 +60,7 @@ export function useConnections() {
 /** Add or upsert a connection (direction change / topics edit reuse this). */
 export function useAddConnection() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (payload: ConnectPayload) =>
       api.post<ConnectionsResponse>('/connections', payload),
@@ -76,6 +79,7 @@ export function useAddConnection() {
 /** Remove a connection. NOTE: the api client's DELETE method is `api.del`. */
 export function useRemoveConnection() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (vault: string) =>
       api.del<ConnectionsResponse>(`/connections/${encodeURIComponent(vault)}`),

--- a/dashboard/src/hooks/useCouncil.ts
+++ b/dashboard/src/hooks/useCouncil.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface DebateIndexEntry {
   id: string;
@@ -75,6 +75,7 @@ interface CouncilDebateResponse {
 }
 
 export function useCouncilList() {
+  const api = useApi();
   return useQuery({
     queryKey: ['council'],
     queryFn: () => api.get<CouncilListResponse>('/council'),
@@ -83,6 +84,7 @@ export function useCouncilList() {
 }
 
 export function useCouncilDebate(debateId: string | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['council', debateId],
     queryFn: () => api.get<CouncilDebateResponse>(`/council/${debateId}`),

--- a/dashboard/src/hooks/useEmbeddingModel.ts
+++ b/dashboard/src/hooks/useEmbeddingModel.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /** Mirrors EmbedModelState in src/lib/embeddings/embedder.ts. */
 export type EmbedModelState = 'not_downloaded' | 'downloading' | 'ready' | 'error';
@@ -34,6 +34,7 @@ export interface EmbedModelStatus {
  * polling for users who never touch Hybrid mode.
  */
 export function useEmbeddingModelStatus(enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['embedding-model-status'],
     queryFn: () => api.get<EmbedModelStatus>('/embeddings/status'),
@@ -51,6 +52,7 @@ export function useEmbeddingModelStatus(enabled: boolean) {
  */
 export function useDownloadEmbeddingModel() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<EmbedModelStatus & { ok: boolean }>('/embeddings/download', {}),
     onSuccess: (data) => queryClient.setQueryData(['embedding-model-status'], data),
@@ -77,6 +79,7 @@ export interface EmbedIndexStatus {
  * idles. Enabled only while the Hybrid card is visible.
  */
 export function useEmbeddingIndexStatus(enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['embedding-index-status'],
     queryFn: () => api.get<EmbedIndexStatus>('/embeddings/index/status'),
@@ -94,6 +97,7 @@ export function useEmbeddingIndexStatus(enabled: boolean) {
  */
 export function useBuildEmbeddingIndex() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<EmbedIndexStatus & { ok: boolean }>('/embeddings/index', {}),
     onSuccess: (data) => queryClient.setQueryData(['embedding-index-status'], data),

--- a/dashboard/src/hooks/useFederation.ts
+++ b/dashboard/src/hooks/useFederation.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 // ─── Types (duplicated client-side — can't import from src/lib) ───────────────
 
@@ -49,6 +49,7 @@ interface SyncPreviewResponse {
 
 /** Pending + consumed federation inbox entries (read-only). */
 export function useFederationInbox() {
+  const api = useApi();
   return useQuery({
     queryKey: ['federation', 'inbox'],
     queryFn: () => api.get<InboxResponse>('/federation/inbox'),
@@ -61,6 +62,7 @@ export function useFederationInbox() {
  * mutation never mutates server state.
  */
 export function useSyncPreview() {
+  const api = useApi();
   return useMutation({
     mutationFn: () => api.post<SyncPreviewResponse>('/federation/sync', {}),
   });

--- a/dashboard/src/hooks/useGraph.ts
+++ b/dashboard/src/hooks/useGraph.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export type GraphGroup =
   | 'soul'
@@ -47,6 +47,7 @@ export interface Graph {
 }
 
 export function useGraph() {
+  const api = useApi();
   return useQuery({
     queryKey: ['graph'],
     queryFn: () => api.get<Graph>('/graph'),

--- a/dashboard/src/hooks/useGraphSettings.ts
+++ b/dashboard/src/hooks/useGraphSettings.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { usePersistedState } from './usePersistedState';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface GraphColorGroup {
   id: string;
@@ -89,6 +89,7 @@ function mergeSettings(server: Partial<GraphSettings>): GraphSettings {
 }
 
 export function useGraphSettings() {
+  const api = useApi();
   const [settings, setSettings] = usePersistedState<GraphSettings>(
     'brain:settings:v1',
     DEFAULT_SETTINGS,
@@ -131,7 +132,7 @@ export function useGraphSettings() {
         /* best-effort; localStorage already has it */
       });
     }, 600);
-  }, []);
+  }, [api]);
 
   const update = useCallback(
     (updater: (prev: GraphSettings) => GraphSettings) => {

--- a/dashboard/src/hooks/useKnowledge.ts
+++ b/dashboard/src/hooks/useKnowledge.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface KnowledgeEntry {
   slug: string;
@@ -27,6 +27,7 @@ interface KnowledgeResponse {
 }
 
 export function useKnowledgeList() {
+  const api = useApi();
   return useQuery({
     queryKey: ['knowledge'],
     queryFn: () => api.get<KnowledgeListResponse>('/knowledge'),
@@ -35,6 +36,7 @@ export function useKnowledgeList() {
 }
 
 export function useKnowledge(slug: string) {
+  const api = useApi();
   return useQuery({
     queryKey: ['knowledge', slug],
     queryFn: () => api.get<KnowledgeResponse>(`/knowledge/${slug}`),
@@ -62,6 +64,7 @@ interface KnowledgeAssetsResponse {
  * the global 15s refetch — images only change when the board is reopened.
  */
 export function useKnowledgeAssets(slug: string, enabled: boolean) {
+  const api = useApi();
   return useQuery({
     queryKey: ['knowledge-assets', slug],
     queryFn: () => api.get<KnowledgeAssetsResponse>(`/knowledge-assets/${slug}`),
@@ -102,6 +105,7 @@ export function useKnowledgeLiveRefresh(
 
 export function useToggleKnowledgePin() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, pinned }: { slug: string; pinned: boolean }) =>
       api.patch<KnowledgeResponse>(`/knowledge/${slug}`, { pinned }),

--- a/dashboard/src/hooks/useLab.ts
+++ b/dashboard/src/hooks/useLab.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 import type { FunnelCacheEntry, FunnelPrev, FunnelSnapshot } from '../components/lab/funnel/funnelModel';
 import type { InsightSize, Render } from '../components/lab/chartRegistry';
 
@@ -116,6 +116,7 @@ export interface SyncResult {
 
 /** List every insight (for the board). Empty on an older backend / no route. */
 export function useLabInsights() {
+  const api = useApi();
   return useQuery({
     queryKey: ['lab'],
     queryFn: () => api.get<{ insights: InsightSummary[] }>('/lab').then((r) => r.insights),
@@ -125,6 +126,7 @@ export function useLabInsights() {
 
 /** Full manifest + cached series for one insight. */
 export function useLabInsight(slug: string | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['lab', slug],
     queryFn: () => api.get<InsightDetail>(`/lab/${slug}`),
@@ -136,6 +138,7 @@ export function useLabInsight(slug: string | null) {
 /** Sync one insight (always forces a refetch — the explicit user action). */
 export function useSyncInsight() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (slug: string) =>
       api.post<{ results: SyncResult[]; failed: SyncResult[] }>('/lab/sync', { slug, force: true }),
@@ -169,6 +172,7 @@ export interface LabSyncJob {
 }
 
 export function useLabSyncJob() {
+  const api = useApi();
   return useQuery({
     queryKey: ['lab-sync-job'],
     queryFn: () => api.get<{ job: LabSyncJob | null }>('/lab/sync-jobs/current'),
@@ -183,6 +187,7 @@ export function useLabSyncJob() {
 /** Start (or adopt) the bulk sync job. Returns immediately — watch `useLabSyncJob`. */
 export function useStartLabSyncJob() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (force: boolean = true) =>
       api.post<{ job: LabSyncJob; started: boolean }>('/lab/sync-jobs', { force }),
@@ -200,6 +205,7 @@ export function useStartLabSyncJob() {
  *  roadmap queries are invalidated too. */
 export function useUpdateBinding() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, binding }: { slug: string; binding: Binding | null }) =>
       api.patch<{ insight: PublicManifest; unbound: string[]; seededCurrent: number | null }>(`/lab/${slug}/binding`, { binding }),
@@ -221,6 +227,7 @@ export interface CredentialKeyStatus {
 
 /** Required-credential status for the board's missing-credentials banner. */
 export function useLabCredentials() {
+  const api = useApi();
   return useQuery({
     queryKey: ['lab-credentials'],
     queryFn: () => api.get<{ keys: CredentialKeyStatus[] }>('/lab/credentials').then((r) => r.keys),
@@ -233,6 +240,7 @@ export function useLabCredentials() {
  *  unblock syncs, so the board's error badges may change too. */
 export function useSetLabCredential() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ key, value }: { key: string; value: string }) =>
       api.post<{ keys: CredentialKeyStatus[] }>('/lab/credentials', { key, value }),
@@ -246,6 +254,7 @@ export function useSetLabCredential() {
 /** Persist edited tweak values for one insight. */
 export function useUpdateTweaks() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, tweaks }: { slug: string; tweaks: Record<string, string> }) =>
       api.patch<{ insight: PublicManifest }>(`/lab/${slug}/tweaks`, { tweaks }),

--- a/dashboard/src/hooks/useLabPrefs.ts
+++ b/dashboard/src/hooks/useLabPrefs.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { usePersistedState } from './usePersistedState';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * Insights (Lab) board preferences — per-group card order + collapsed groups.
@@ -69,6 +69,7 @@ interface LabPrefsResponse {
 }
 
 export function useLabPrefs() {
+  const api = useApi();
   const [stored, setPrefs] = usePersistedState<LabPrefs>('lab:prefs:v1', DEFAULT_LAB_PREFS);
   const prefs = useMemo(() => mergePrefs(stored), [stored]);
 
@@ -105,7 +106,7 @@ export function useLabPrefs() {
     writeTimer.current = setTimeout(() => {
       api.put('/lab-prefs', { settings: next }).catch(() => { /* best-effort */ });
     }, 600);
-  }, []);
+  }, [api]);
 
   const update = useCallback((updater: (prev: LabPrefs) => LabPrefs) => {
     setPrefs((prev) => {

--- a/dashboard/src/hooks/useLinkedRepos.ts
+++ b/dashboard/src/hooks/useLinkedRepos.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * Thin react-query layer over `/api/linked-repos/*` (src/server/routes/
@@ -19,6 +19,7 @@ const LINKED_REPOS_KEY = ['linked-repos'] as const;
 
 /** Present/missing status for every linked repo — reads local files only, no net/git. */
 export function useLinkedRepos() {
+  const api = useApi();
   return useQuery({
     queryKey: LINKED_REPOS_KEY,
     queryFn: () => api.get<{ repos: LinkedRepo[] }>('/linked-repos'),
@@ -36,6 +37,7 @@ export interface LinkRepoArgs {
 /** Bind a local checkout of a linked repo (records name+URL shared, path machine-local). */
 export function useLinkRepo() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (args: LinkRepoArgs) => api.post<{ ok: boolean; repos: LinkedRepo[] }>('/linked-repos/link', args),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: LINKED_REPOS_KEY }),
@@ -45,6 +47,7 @@ export function useLinkRepo() {
 /** Clone a MISSING linked repo. `confirmed` is the trust gate (the URL is team-writable). */
 export function useCloneLinkedRepo() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (name: string) =>
       api.post<{ ok: boolean; path: string; repos: LinkedRepo[] }>('/linked-repos/clone', { name, confirmed: true }),
@@ -55,6 +58,7 @@ export function useCloneLinkedRepo() {
 /** Unlink a repo — removes the shared config entry; keeps the machine-local path. */
 export function useUnlinkRepo() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (name: string) => api.post<{ ok: boolean; repos: LinkedRepo[] }>('/linked-repos/unlink', { name }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: LINKED_REPOS_KEY }),

--- a/dashboard/src/hooks/useNodeContent.ts
+++ b/dashboard/src/hooks/useNodeContent.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 import type { GraphNode } from './useGraph';
 
 export interface NodeContentMarkdown {
@@ -25,6 +25,7 @@ export interface NodeContentText {
 export type NodeContent = NodeContentMarkdown | NodeContentJson | NodeContentText;
 
 export function useNodeContent(node: GraphNode | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['graph', 'content', node?.path ?? null],
     queryFn: () => {

--- a/dashboard/src/hooks/useObjectives.ts
+++ b/dashboard/src/hooks/useObjectives.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * A Key Result metric — outcome-based progress source (e.g. MRR, customers). When set
@@ -99,6 +99,7 @@ export interface RoadmapModel {
  * start_date/impact/effort) by slug in the board. Empty on an older backend.
  */
 export function useRoadmap() {
+  const api = useApi();
   return useQuery({
     queryKey: ['roadmap'],
     queryFn: () => api.get<RoadmapModel>('/roadmap'),
@@ -108,6 +109,7 @@ export function useRoadmap() {
 
 /** List every objective. Empty array when none / the route is absent (older backend). */
 export function useObjectives() {
+  const api = useApi();
   return useQuery({
     queryKey: ['objectives'],
     queryFn: () => api.get<{ objectives: Objective[] }>('/objectives').then((r) => r.objectives),
@@ -118,6 +120,7 @@ export function useObjectives() {
 
 export function useCreateObjective() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (input: CreateObjectiveInput) => api.post<{ objective: Objective }>('/objectives', input),
     onSuccess: () => {
@@ -143,6 +146,7 @@ export interface UpdateObjectivePatch {
 /** PATCH one objective — persists timeline drag-to-reschedule and inline edits. */
 export function useUpdateObjective() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, patch }: { slug: string; patch: UpdateObjectivePatch }) =>
       api.patch<{ objective: Objective }>(`/objectives/${slug}`, patch),
@@ -156,6 +160,7 @@ export function useUpdateObjective() {
 /** Declare `slug` depends on `to` (drag-to-connect). Cycle rejections surface as errors. */
 export function useAddDependency() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, to }: { slug: string; to: string }) =>
       api.post<{ objective: Objective }>(`/objectives/${slug}/dependencies`, { to }),
@@ -169,6 +174,7 @@ export function useAddDependency() {
 /** Delete an objective. Fully self-heals server-side (strips it from deps + tasks). */
 export function useDeleteObjective() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (slug: string) => api.del<{ deleted: string; unhealedTasks: string[] }>(`/objectives/${slug}`),
     onSuccess: () => {
@@ -183,6 +189,7 @@ export function useDeleteObjective() {
 /** Remove the `to → slug` dependency edge. */
 export function useRemoveDependency() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, to }: { slug: string; to: string }) =>
       api.del<{ objective: Objective }>(`/objectives/${slug}/dependencies/${to}`),

--- a/dashboard/src/hooks/usePacks.ts
+++ b/dashboard/src/hooks/usePacks.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 // ─── Types (duplicated client-side — can't import from src/lib) ───────────────
 
@@ -41,6 +41,7 @@ interface PacksResponse {
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 export function usePacks() {
+  const api = useApi();
   return useQuery({
     queryKey: ['packs'],
     queryFn: () => api.get<PacksResponse>('/packs'),
@@ -65,6 +66,7 @@ interface UninstallResponse {
 /** Install a pack/standalone skill, then refresh the packs list so pills flip. */
 export function useInstallPack() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (name: string) =>
       api.post<InstallResponse>(`/packs/${encodeURIComponent(name)}/install`, {}),
@@ -77,6 +79,7 @@ export function useInstallPack() {
 /** Uninstall a pack/standalone skill, then refresh the packs list. */
 export function useUninstallPack() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (name: string) =>
       api.del<UninstallResponse>(`/packs/${encodeURIComponent(name)}`),

--- a/dashboard/src/hooks/useRecall.ts
+++ b/dashboard/src/hooks/useRecall.ts
@@ -1,5 +1,6 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
+import type { ApiClient } from '../api/client';
 
 /**
  * A single recall hit as returned by GET /api/recall.
@@ -45,6 +46,7 @@ export interface RecallResponse {
  * the list doesn't flash empty between keystrokes.
  */
 export function useRecall(query: string, types: string[], topK = 12, minLevel?: number) {
+  const api = useApi();
   const trimmed = query.trim();
   const typeParam = types.length ? types.join(',') : '';
   return useQuery<RecallResponse>({
@@ -64,7 +66,7 @@ export function useRecall(query: string, types: string[], topK = 12, minLevel?: 
 }
 
 /** Imperative one-shot recall (used by Ask to ground an answer in top hits). */
-export async function recallOnce(query: string, types: string[], topK = 4, minLevel?: number): Promise<RecallHit[]> {
+export async function recallOnce(api: ApiClient, query: string, types: string[], topK = 4, minLevel?: number): Promise<RecallHit[]> {
   const trimmed = query.trim();
   if (!trimmed) return [];
   const params = new URLSearchParams({ q: trimmed, top: String(topK) });
@@ -92,7 +94,7 @@ export interface HaikuRecallResponse {
  * this costs a few seconds and tokens, so callers should show a loading state.
  * Falls back to BM25 server-side when the claude CLI isn't available.
  */
-export async function haikuRecallOnce(query: string, types: string[], minLevel?: number): Promise<HaikuRecallResponse> {
+export async function haikuRecallOnce(api: ApiClient, query: string, types: string[], minLevel?: number): Promise<HaikuRecallResponse> {
   const trimmed = query.trim();
   if (!trimmed) return { query: '', mode: 'haiku', skip: false, tookMs: 0, hits: [] };
   const params = new URLSearchParams({ q: trimmed });

--- a/dashboard/src/hooks/useRoadmapPrefs.ts
+++ b/dashboard/src/hooks/useRoadmapPrefs.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { usePersistedState } from './usePersistedState';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 import type { RoadmapLayout, RoadmapSortKey } from '../components/roadmap/chrome';
 import type { RoadmapFilters, RoadmapCardProps } from '../components/roadmap/RoadmapToolbar';
 
@@ -55,6 +55,7 @@ interface RoadmapPrefsResponse {
 }
 
 export function useRoadmapPrefs() {
+  const api = useApi();
   const [stored, setPrefs] = usePersistedState<RoadmapPrefs>('roadmap:prefs:v1', DEFAULT_ROADMAP_PREFS);
   // Normalize on read: a prefs blob saved before a new field existed (e.g. a new
   // card property) would be missing that key. Merging over the defaults backfills
@@ -94,7 +95,7 @@ export function useRoadmapPrefs() {
     writeTimer.current = setTimeout(() => {
       api.put('/roadmap-prefs', { settings: next }).catch(() => { /* best-effort */ });
     }, 600);
-  }, []);
+  }, [api]);
 
   const update = useCallback((updater: (prev: RoadmapPrefs) => RoadmapPrefs) => {
     setPrefs((prev) => {

--- a/dashboard/src/hooks/useSidebarCollapse.ts
+++ b/dashboard/src/hooks/useSidebarCollapse.ts
@@ -25,6 +25,13 @@ function readUserPref(): boolean {
  *
  * `collapsed` = the user's explicit preference OR a forced auto-collapse at
  * ≤1024px viewport. The toggle only mutates the persisted user preference.
+ *
+ * CALL THIS FROM EXACTLY ONE OWNER — `WindowChrome`, which passes `collapsed` and `toggle`
+ * down to every mounted project instance. The KEY above stays app-global on purpose (one
+ * rail width per window is right; two rails of different widths side by side would read as
+ * broken), but the STATE is per-hook-call: a second caller reads the key at mount and then
+ * never hears about the first one's toggle, so N callers in one window silently diverge.
+ * Scoping the key per vault would be the wrong fix for the same reason.
  */
 export function useSidebarCollapse() {
   const [userPref, setUserPref] = useState<boolean>(readUserPref);

--- a/dashboard/src/hooks/useSleep.ts
+++ b/dashboard/src/hooks/useSleep.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 interface SessionRecord {
   session_id: string;
@@ -117,6 +117,7 @@ export function displayDebt(sleep: Pick<SleepState, 'debt' | 'effective_debt'>):
 }
 
 export function useSleep() {
+  const api = useApi();
   return useQuery({
     queryKey: ['sleep'],
     queryFn: () => api.get<SleepState>('/sleep'),
@@ -136,6 +137,7 @@ export function useRecallMode(): RecallMode {
 /** PATCH /api/sleep — partial update (recall_mode, manual debt). Returns the fresh state. */
 export function useUpdateSleep() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (patch: { recall_mode?: RecallMode; debt?: number }) =>
       api.patch<SleepState>('/sleep', patch),

--- a/dashboard/src/hooks/useSleepyChat.ts
+++ b/dashboard/src/hooks/useSleepyChat.ts
@@ -1,5 +1,16 @@
 import { api } from '../api/client';
 
+/**
+ * UNREFERENCED — grep confirms zero consumers of `getChatHistory`/`resetChat`/`startChat`/
+ * `streamChat` anywhere in `dashboard/src`. Left on the singleton `api` deliberately (not
+ * migrated to `useApi()`) because there is no call site to thread a vault through.
+ *
+ * `/api/sleepy/chat` IS per-vault server-side (it writes `<contextRoot>/state/.sleepy-chat.json`
+ * — see `src/server/routes/sleepy-chat.ts`), so this is NOT vault-agnostic. Whoever wires this
+ * up must take an `ApiClient` (or `vault: string | null`) as a parameter and pass it through —
+ * do not just start calling these against the singleton `api` above.
+ */
+
 /** UI tiers — the underlying model (sonnet/opus) is intentionally hidden. */
 export type ChatTier = 'normal' | 'intelligent';
 

--- a/dashboard/src/hooks/useTasks.ts
+++ b/dashboard/src/hooks/useTasks.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface RiceFields {
   reach: number | null;
@@ -103,6 +103,7 @@ interface InsertTaskSectionInput {
 }
 
 export function useTasks() {
+  const api = useApi();
   return useQuery({
     queryKey: ['tasks'],
     queryFn: () => api.get<TasksResponse>('/tasks'),
@@ -111,6 +112,7 @@ export function useTasks() {
 }
 
 export function useTask(slug: string) {
+  const api = useApi();
   return useQuery({
     queryKey: ['tasks', slug],
     queryFn: () => api.get<TaskResponse>(`/tasks/${slug}`),
@@ -121,6 +123,7 @@ export function useTask(slug: string) {
 
 export function useCreateTask() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (input: CreateTaskInput) => api.post<TaskResponse>('/tasks', input),
     onSuccess: () => {
@@ -131,6 +134,7 @@ export function useCreateTask() {
 
 export function useUpdateTask() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, updates }: UpdateTaskInput) =>
       api.patch<TaskResponse>(`/tasks/${slug}`, updates),
@@ -155,6 +159,7 @@ export function useUpdateTask() {
 
 export function useDeleteTask() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (slug: string) => api.del<{ success: boolean }>(`/tasks/${slug}`),
     onSuccess: () => {
@@ -173,6 +178,7 @@ export interface RemoteMember {
 }
 
 export function useTaskMembers() {
+  const api = useApi();
   return useQuery({
     queryKey: ['task-members'],
     queryFn: () => api.get<{ members: RemoteMember[] }>('/tasks/members'),
@@ -190,6 +196,7 @@ export interface SyncStatus {
 }
 
 export function useSyncStatus() {
+  const api = useApi();
   return useQuery({
     queryKey: ['tasks-sync-status'],
     queryFn: () => api.get<{ status: SyncStatus }>('/tasks/sync-status'),
@@ -232,6 +239,7 @@ export interface SyncJob {
 }
 
 export function useSyncJob() {
+  const api = useApi();
   return useQuery({
     queryKey: ['tasks-sync-job'],
     queryFn: () => api.get<{ job: SyncJob | null }>('/tasks/sync-jobs/current'),
@@ -244,6 +252,7 @@ export function useSyncJob() {
 
 export function useStartSyncJob() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (vars?: { hard?: boolean }) =>
       api.post<{ job: SyncJob; started: boolean }>('/tasks/sync-jobs', { direction: 'both', hard: !!vars?.hard }),
@@ -257,6 +266,7 @@ export function useStartSyncJob() {
 
 /** The active task custom-field schema (from overrides/task.md). Empty when none. */
 export function useTaskOverrides() {
+  const api = useApi();
   return useQuery({
     queryKey: ['task-overrides'],
     queryFn: () => api.get<{ present: boolean; customFields: CustomFieldDef[] }>('/task-overrides'),
@@ -274,6 +284,7 @@ export interface TaskOverrideDoc {
 
 /** The RAW override markdown (for the Settings editor). */
 export function useTaskOverrideDoc() {
+  const api = useApi();
   return useQuery({
     queryKey: ['task-override-doc'],
     queryFn: () => api.get<TaskOverrideDoc>('/task-overrides/doc'),
@@ -289,6 +300,7 @@ function invalidateOverrides(queryClient: ReturnType<typeof useQueryClient>) {
 /** Save the RAW override markdown. */
 export function useSaveTaskOverrideDoc() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (raw: string) =>
       api.put<{ present: boolean; customFields: CustomFieldDef[]; warnings: string[] }>('/task-overrides/doc', { raw }),
@@ -299,6 +311,7 @@ export function useSaveTaskOverrideDoc() {
 /** Add or replace one custom-field definition (project-wide schema). */
 export function useAddCustomFieldDef() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (input: AddCustomFieldInput) =>
       api.post<{ customFields: CustomFieldDef[]; warnings: string[] }>('/task-overrides/fields', input),
@@ -309,6 +322,7 @@ export function useAddCustomFieldDef() {
 /** Remove a custom-field definition by id/key. */
 export function useRemoveCustomFieldDef() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (key: string) =>
       api.del<{ customFields: CustomFieldDef[] }>(`/task-overrides/fields/${encodeURIComponent(key)}`),
@@ -326,6 +340,7 @@ export function useRemoveCustomFieldDef() {
  * folder-qualified slug round-trips unchanged.)
  */
 export function useFeatureOptions() {
+  const api = useApi();
   return useQuery({
     queryKey: ['knowledge'],
     queryFn: () => api.get<{ entries: Array<{ slug: string; name?: string; type?: string }> }>('/knowledge'),
@@ -343,6 +358,7 @@ export function useFeatureOptions() {
 
 export function useAddTaskChangelog() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, content }: { slug: string; content: string }) =>
       api.post<{ success: boolean }>(`/tasks/${slug}/changelog`, { content }),
@@ -354,6 +370,7 @@ export function useAddTaskChangelog() {
 
 export function useInsertTaskSection() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, section, content }: InsertTaskSectionInput) =>
       api.post<{ success: boolean }>(`/tasks/${slug}/insert`, { section, content }),

--- a/dashboard/src/hooks/useTaxonomy.ts
+++ b/dashboard/src/hooks/useTaxonomy.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface TaxonomyVocabulary {
   facetTags: Record<string, string[]>;
@@ -27,6 +27,7 @@ export interface TaxonomyResponse {
 }
 
 export function useTaxonomy() {
+  const api = useApi();
   return useQuery({
     queryKey: ['taxonomy'],
     queryFn: () => api.get<TaxonomyResponse>('/taxonomy'),

--- a/dashboard/src/hooks/useTheses.ts
+++ b/dashboard/src/hooks/useTheses.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 /**
  * Theses (proactive learning layer) — dashboard hooks. Mirrors useObjectives.ts
@@ -145,6 +145,7 @@ export interface SetStatusInput {
  * mirrors the server's "still readable, just hinted" disabled-layer behavior.
  */
 export function useTheses() {
+  const api = useApi();
   return useQuery({
     queryKey: ['theses'],
     queryFn: () => api.get<ThesesListResult>('/theses'),
@@ -154,6 +155,7 @@ export function useTheses() {
 
 /** One thesis — full manifest + confidence breakdown + parsed changelog. */
 export function useThesis(slug: string | null) {
+  const api = useApi();
   return useQuery({
     queryKey: ['theses', slug],
     queryFn: () => api.get<ThesisShowResult>(`/theses/${slug}`),
@@ -164,6 +166,7 @@ export function useThesis(slug: string | null) {
 
 export function useCreateThesis() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (input: CreateThesisInput) => api.post<{ thesis: ThesisView }>('/theses', input),
     onSuccess: () => {
@@ -174,6 +177,7 @@ export function useCreateThesis() {
 
 export function useAddEvidence() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, input }: { slug: string; input: AddEvidenceInput }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/evidence`, input),
@@ -185,6 +189,7 @@ export function useAddEvidence() {
 
 export function useAddPrediction() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, text }: { slug: string; text: string }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/predictions`, { text }),
@@ -196,6 +201,7 @@ export function useAddPrediction() {
 
 export function useSetStatus() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, input }: { slug: string; input: SetStatusInput }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/status`, input),
@@ -208,6 +214,7 @@ export function useSetStatus() {
 /** Link a thesis to an insight/objective/task (target must already exist). */
 export function useLinkThesis() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, kind, target }: { slug: string; kind: ThesisLinkKind; target: string }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/links`, { kind, slug: target }),
@@ -220,6 +227,7 @@ export function useLinkThesis() {
 
 export function useUnlinkThesis() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, kind, target }: { slug: string; kind: ThesisLinkKind; target: string }) =>
       api.del<{ thesis: ThesisView }>(`/theses/${slug}/links/${kind}/${target}`),
@@ -233,6 +241,7 @@ export function useUnlinkThesis() {
 /** Append a per-cycle understanding-changelog entry (LIFO, store-capped). */
 export function useAppendChangelog() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, text, cycle, condensed }: { slug: string; text: string; cycle?: number | null; condensed?: boolean }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/changelog`, { text, cycle, condensed }),
@@ -245,6 +254,7 @@ export function useAppendChangelog() {
 /** Record the knowledge doc a validated/invalidated thesis promoted into; optionally retires it. */
 export function usePromoteThesis() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ slug, knowledgePath, retire }: { slug: string; knowledgePath: string; retire?: boolean }) =>
       api.post<{ thesis: ThesisView }>(`/theses/${slug}/promote`, { knowledgePath, retire }),
@@ -257,6 +267,7 @@ export function usePromoteThesis() {
 /** The one-command switch: POST /api/learning/enable or /disable. */
 export function useSetLearningEnabled() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (enabled: boolean) =>
       api.post<{ enabled: boolean }>(enabled ? '/learning/enable' : '/learning/disable', {}),

--- a/dashboard/src/hooks/useVersionCheck.ts
+++ b/dashboard/src/hooks/useVersionCheck.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 // ─── Types (duplicated client-side — can't import from src/lib) ───────────────
 
@@ -40,6 +40,7 @@ export interface VersionCheck {
  * could be added if live polling is desired in the future.
  */
 export function useVersionCheck() {
+  const api = useApi();
   return useQuery({
     queryKey: ['version-check'],
     queryFn: () => api.get<VersionCheck>('/version-check'),

--- a/dashboard/src/hooks/useVersions.ts
+++ b/dashboard/src/hooks/useVersions.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 
 export interface Version {
   id: string;
@@ -21,6 +21,7 @@ interface ReleaseResponse {
 }
 
 export function useVersions() {
+  const api = useApi();
   return useQuery({
     queryKey: ['releases'],
     queryFn: () => api.get<ReleasesResponse>('/releases'),
@@ -32,6 +33,7 @@ export function useVersions() {
 }
 
 export function usePlanningVersions() {
+  const api = useApi();
   return useQuery({
     queryKey: ['releases'],
     queryFn: () => api.get<ReleasesResponse>('/releases'),
@@ -43,6 +45,7 @@ export function usePlanningVersions() {
 
 export function useCreateVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (input: { version: string; summary?: string }) =>
       api.post<ReleaseResponse>('/releases', { ...input, status: 'planning' }),
@@ -54,6 +57,7 @@ export function useCreateVersion() {
 
 export function useUpdateVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ version, updates }: { version: string; updates: { status?: string; summary?: string } }) =>
       api.patch<ReleaseResponse>(`/releases/${encodeURIComponent(version)}`, updates),
@@ -71,6 +75,7 @@ export function useUpdateVersion() {
  */
 export function useRenameVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ from, to }: { from: string; to: string }) =>
       api.patch<ReleaseResponse>(`/releases/${encodeURIComponent(from)}`, { version: to }),
@@ -95,6 +100,7 @@ interface DeleteVersionResponse {
  */
 export function useDeleteVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (version: string) =>
       api.del<DeleteVersionResponse>(`/releases/${encodeURIComponent(version)}`),
@@ -111,6 +117,7 @@ interface ActiveVersionResponse {
 
 /** The active planning version ("current sprint"), or null if none is set. */
 export function useActiveVersion() {
+  const api = useApi();
   return useQuery({
     queryKey: ['releases', 'active'],
     queryFn: () => api.get<ActiveVersionResponse>('/releases/active'),
@@ -126,6 +133,7 @@ export function useActiveVersion() {
  */
 export function useSetActiveVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: (version: string | null) =>
       api.put<ActiveVersionResponse>('/releases/active', { version }),
@@ -142,6 +150,7 @@ export function useSetActiveVersion() {
  */
 export function useCompleteVersion() {
   const queryClient = useQueryClient();
+  const api = useApi();
   return useMutation({
     mutationFn: ({ version, exists }: { version: string; exists: boolean }) =>
       exists

--- a/dashboard/src/lib/agentDrop.ts
+++ b/dashboard/src/lib/agentDrop.ts
@@ -1,5 +1,3 @@
-import { getActiveVault } from '../api/client';
-
 /**
  * The one way raw bytes from the page reach the agent: write the blob into the vault's
  * gitignored temp dir (`POST /api/agent/drop`) and hand back the absolute path, which is
@@ -11,14 +9,16 @@ import { getActiveVault } from '../api/client';
  * thumbnail the user can see and the agent cannot.
  *
  * Binary can't go through `api.post` (JSON-only), so this uses raw `fetch` and carries the
- * pinned vault as a header the same way the api client does.
+ * vault as a header the same way the api client does. `vault` is a PARAMETER rather than a
+ * module read: one window now holds several live projects, and a module-level "active vault"
+ * would write one project's dropped file into whichever project the user last touched. The
+ * React caller takes it from `useVault()`; null means launcher/browser, exactly as before.
  *
  * Resolves null on ANY refusal (not desktop, over the 25 MB cap, write failed) rather than
  * throwing — a caller shows the attachment as un-sendable; nothing about a failed upload
  * should take a message down with it.
  */
-export async function uploadAgentFile(file: File | Blob, name: string): Promise<string | null> {
-  const vault = getActiveVault();
+export async function uploadAgentFile(vault: string | null, file: File | Blob, name: string): Promise<string | null> {
   try {
     const body = await file.arrayBuffer();
     const res = await fetch('/api/agent/drop', {

--- a/dashboard/src/lib/agentPrompt.ts
+++ b/dashboard/src/lib/agentPrompt.ts
@@ -1,5 +1,4 @@
 import { api } from '../api/client';
-import { getActiveVault } from '../api/client';
 
 /**
  * How an initial prompt gets from the dashboard to a freshly-spawned `claude`.
@@ -59,9 +58,12 @@ interface PromptTokenResponse { ok: boolean; token: string; expiresInMs: number 
  * sanitization) — callers must surface that rather than degrade to a truncated inline
  * prompt, because a session seeded with a silently-shortened brief is the exact failure this
  * whole path exists to remove.
+ *
+ * `vault` is a PARAMETER, not a module read: one window now holds several live projects, so
+ * a module-level "active vault" would mint a token against whichever project the user last
+ * touched and hand another project's agent the wrong brief.
  */
-export async function mintPromptToken(prompt: string): Promise<string> {
-  const vault = getActiveVault();
+export async function mintPromptToken(vault: string | null, prompt: string): Promise<string> {
   if (!vault) throw new Error('No vault is active — cannot hand a prompt to an agent.');
   const res = await api.post<PromptTokenResponse>('/agent/prompt', { vault, prompt });
   if (!res?.ok || !res.token) throw new Error('The server did not return a prompt token.');
@@ -85,8 +87,8 @@ export interface PreparedPrompt {
  *
  * Rejects rather than degrading: see {@link mintPromptToken}.
  */
-export async function preparePrompt(prompt: string): Promise<PreparedPrompt> {
+export async function preparePrompt(vault: string | null, prompt: string): Promise<PreparedPrompt> {
   if (!prompt) return { inline: '', token: '' };
   if (promptFitsInline(prompt)) return { inline: prompt, token: '' };
-  return { inline: '', token: await mintPromptToken(prompt) };
+  return { inline: '', token: await mintPromptToken(vault, prompt) };
 }

--- a/dashboard/src/lib/agentSettings.ts
+++ b/dashboard/src/lib/agentSettings.ts
@@ -7,8 +7,14 @@
  * These are surface preferences shared by every project window, so they're
  * app-global (not vault-scoped). The Settings page writes them; the persistent
  * AgentSurface reads them and re-applies live via the window event below.
+ *
+ * ONE field is deliberately NOT in this blob: `chatPermissionMode`. It is a permission
+ * gate, not a surface preference — see {@link readChatPermissionMode} at the bottom of
+ * this file.
  */
 import { api } from '../api/client';
+import { SCOPE_PREFIX } from './scopedStorage';
+import { emitInstance } from '../context/VaultContext';
 
 /** localStorage key (versioned so a shape change can invalidate cleanly). */
 const CONFIG_KEY = 'agent:settings:v1';
@@ -59,14 +65,6 @@ export interface AgentSettings {
    *  onto Chat; from the first coerce onward the marker rides along, so a DELIBERATE
    *  switch back to Terminal (legacy) in Settings sticks forever after. */
   screenMigrated: boolean;
-  /** Remembered default permission mode for Chat (BETA) sessions (redesign task
-   *  agent-chat-view-beta-…, state 6's top-right dropdown): `'auto'` maps to the CLI's
-   *  `auto` mode (NOT `acceptEdits` — that one asks on every non-edit command), `'bypass'`
-   *  to `bypassPermissions` — identical mapping to `permissionModeFor` in
-   *  `src/server/routes/agent-chat.ts`. Selecting a mode here applies to the NEXT chat
-   *  session spawned (new, split, resume, sleep/brain/delegate, skill-insert fallback) AND
-   *  to every running one (`changeChatPermissionMode` → `set_permission_mode`). */
-  chatPermissionMode: 'auto' | 'bypass';
 }
 
 export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
@@ -78,7 +76,6 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
   renderer: 'webgl',
   chatView: true,
   screenMigrated: true,
-  chatPermissionMode: 'auto',
 };
 
 /** Coerce an arbitrary blob to a valid AgentSettings (defaults fill gaps). `enabled`
@@ -104,9 +101,8 @@ export function coerceAgentSettings(raw: Partial<AgentSettings> | null | undefin
     // blob → Chat (that IS the migration); migrated blob → whatever the user picked.
     chatView: r.screenMigrated === true ? r.chatView !== false : true,
     screenMigrated: true,
-    // Only an explicit 'bypass' opts into the caution mode; anything else (absent key,
-    // old blob, garbage) lands on the safer 'auto' default.
-    chatPermissionMode: r.chatPermissionMode === 'bypass' ? 'bypass' : 'auto',
+    // NOTE: a legacy blob's `chatPermissionMode` is dropped here, on purpose — it is no
+    // longer part of this shape. See {@link readChatPermissionMode}.
   };
 }
 
@@ -167,6 +163,77 @@ export async function initAgentSettingsFromServer(): Promise<AgentSettings> {
   } catch {
     return readAgentSettings();
   }
+}
+
+// ─── Chat permission mode — PER VAULT, split out of the global blob ─────────────
+//
+// `'auto'` maps to the CLI's `auto` mode (NOT `acceptEdits` — that one asks on every
+// non-edit command), `'bypass'` to `bypassPermissions` — the same mapping as
+// `permissionModeFor` in `src/server/routes/agent-chat.ts`. The chosen mode applies to the
+// NEXT chat session spawned (new, split, resume, sleep/brain/delegate, skill-insert
+// fallback) AND to every running one (`changeChatPermissionMode` → `set_permission_mode`).
+//
+// WHY IT LEFT THE BLOB. Everything else above is a surface preference that is genuinely the
+// same in every project. This one is a permission gate: it decides whether an agent
+// auto-approves everything it is asked to do, against one project's files and one project's
+// git. It could not cross projects while each vault owned an OS window (one JS realm per
+// project). With several live projects in ONE window it would: flipping bypass while looking
+// at project A rewrites the remembered default for B, and every session B spawns afterwards
+// runs auto-approved in a project the user never touched. So the value is stored per vault
+// and its change notification rides the INSTANCE BUS, never `window`.
+
+export type ChatPermissionMode = 'auto' | 'bypass';
+
+/** Storage key. Namespaced per vault by {@link permissionModeStorageKey}, never read bare. */
+export const CHAT_PERMISSION_MODE_KEY = 'agent:settings:chatPermissionMode';
+
+/** Change notification. Dispatched on the INSTANCE BUS (`useVault().bus`), not `window` —
+ *  a permission change must reach only the project it was made in. */
+export const CHAT_PERMISSION_MODE_EVENT = 'dc-chat-permission-mode';
+
+/**
+ * The one key in the app that is namespaced by hand rather than through
+ * `scopedStorage`'s `readScopedRaw`/`writeScopedRaw`.
+ *
+ * MIGRATION IS THE REASON, and it is deliberate. `readScopedRaw` MOVES a value found at the
+ * bare legacy key into the first vault that reads it — the right default for a preference,
+ * and precisely wrong for this one: the pre-split value must be DROPPED, not carried forward,
+ * because a `'bypass'` set once when it meant "this window's project" would otherwise fan out
+ * to a project the user never opted in for. Relying on "the key is new so nothing is at the
+ * bare name" would make that safety an accident of history — an old build, a hand-edited
+ * store or a future rename would silently resurrect it, and a permission gate must not fail
+ * open on a coincidence. So the bare name is never read, for a null vault either.
+ *
+ * `SCOPE_PREFIX` is still imported rather than re-spelled, so the namespace stays
+ * single-sourced with the rest of the scoped keys.
+ */
+function permissionModeStorageKey(vault: string | null): string {
+  return `${SCOPE_PREFIX}${vault ?? ''}:${CHAT_PERMISSION_MODE_KEY}`;
+}
+
+/**
+ * This vault's remembered chat permission mode.
+ *
+ * Only an exact `'bypass'` opts into the caution mode; absent, stale, malformed or unreadable
+ * storage all read as `'auto'` — the same posture the old `coerceAgentSettings` held, and the
+ * only safe direction for a value that decides whether an agent auto-approves everything.
+ * Every vault therefore starts at `'auto'` and the user re-opts-in per project: a one-time
+ * reset of a permission toggle, which is the correct trade.
+ */
+export function readChatPermissionMode(vault: string | null): ChatPermissionMode {
+  try {
+    return localStorage.getItem(permissionModeStorageKey(vault)) === 'bypass' ? 'bypass' : 'auto';
+  } catch {
+    return 'auto'; // storage unavailable (private mode) — fail safe, never open
+  }
+}
+
+/** Persist this vault's mode and tell THIS instance's surfaces about it. */
+export function writeChatPermissionMode(bus: EventTarget, vault: string | null, mode: ChatPermissionMode): void {
+  try {
+    localStorage.setItem(permissionModeStorageKey(vault), mode);
+  } catch { /* quota/disabled — the live sessions below still get the change */ }
+  emitInstance<ChatPermissionMode>(bus, CHAT_PERMISSION_MODE_EVENT, mode);
 }
 
 /**

--- a/dashboard/src/lib/attention.ts
+++ b/dashboard/src/lib/attention.ts
@@ -7,28 +7,44 @@
  * you are looking AT dreamcontext; these three reach you when you are not:
  *
  *   1. the chime   — you're in the app but on another page
- *   2. a banner    — you're in another app entirely
+ *   2. a banner    — you're in another app, or on another PROJECT's chip
  *   3. a Dock bounce — you're in another app and banners are muted / already scrolled by
  *
- * They fire together, through one throttle, because they are one interruption. Called from
- * the ask EDGE in both session engines (`pushAsk` in chatSession.ts, `onSettle` in
- * agentSession.ts) — never on a redraw, never per pending card.
+ * They fire from the ask EDGE in both session engines (`pushAsk` in chatSession.ts,
+ * `onSettle` in agentSession.ts) — never on a redraw, never per pending card.
+ *
+ * One window now holds several LIVE projects, which splits "one interruption" in two. The
+ * banner and the bounce are throttled per PROJECT (`alarm.source`, the asking session's
+ * vault) and gated on whether that project's chip is the one on screen — two projects asking
+ * a second apart are two separate interruptions, and under a single window-wide gate the
+ * second one was dropped on the floor unheard. The chime keeps ONE window-wide floor,
+ * because `chime.ts` plays through a single shared AudioContext and two chimes 200 ms apart
+ * are a klaxon no matter which project rang.
  */
 import { playAskChime } from './chime';
 import { bounceDockIcon, sendDesktopNotification } from './desktop';
 
-/** Several agents asking in the same breath must not stack into a klaxon — or into three
- *  banners and a Dock that never stops jumping. One gate for the whole alarm. */
+/** Several agents in ONE project asking in the same breath must not stack into three banners
+ *  and a Dock that never stops jumping. Scoped per source rather than per app: a different
+ *  project asking is a different interruption and has its own bucket. */
 const MIN_INTERVAL_MS = 1500;
-let lastRaise = 0;
+const lastRaiseBySource = new Map<string, number>();
+
+/** The chime's own floor, deliberately GLOBAL — see the module header. Kept here, next to
+ *  the alarm, rather than inside `chime.ts`, which stays a dumb un-throttled voice. */
+let lastChime = 0;
 
 /** A notification body has to be scannable from the corner of your eye; past roughly this
  *  much text macOS truncates it anyway, and a wall of prose in a banner reads as spam. */
 const MAX_BODY = 180;
 
 export interface AskAlarm {
-  /** Who is asking — a session tab title, falling back to the vault name. Omitted when the
-   *  caller has neither (the banner then just says dreamcontext is asking). */
+  /** Who is asking — the asking session's VAULT NAME; both engines pass their own `vault`.
+   *  Load-bearing past the banner's title: it is also the throttle bucket AND the key the
+   *  chip probe answers on, so a per-session tab title here would attribute the alarm to a
+   *  project that does not exist and the question would never reach the user. Empty/omitted
+   *  when no project is pinned (launcher, browser build) — read as "unattributable" below,
+   *  never as a project named "". */
   source?: string | null;
   /** The question itself, when the surface actually has the words for it. Chat does (the
    *  AskUserQuestion payload is structured); the terminal surface only has pixels on a
@@ -45,11 +61,12 @@ function oneLine(text: string): string {
 /**
  * True when this window is the one the user is literally looking at right now.
  *
- * The banner and the bounce are for reaching someone who is ELSEWHERE, so they are skipped
- * in that case — a system banner sliding over the very chat that raised it is noise, and
- * AppKit no-ops a bounce for the active app regardless. The chime is not skipped: within a
- * focused window you can still be on the Roadmap page with the asking session minimized to
- * the dock, which is exactly the case it exists for.
+ * Necessary but no longer SUFFICIENT to suppress the banner — see {@link isAlarmChipOnScreen}.
+ * A focused window can still be showing a different project than the one that is asking.
+ *
+ * The chime is never skipped on either count: within a focused window on the right project
+ * you can still be on the Roadmap page with the asking session minimized to the dock, which
+ * is exactly the case it exists for.
  *
  * Note this is per-WINDOW, not per-app: with a vault window in the background and the
  * launcher up front, the background window's document reports no focus and correctly gets
@@ -61,6 +78,42 @@ function isWatchingThisWindow(): boolean {
   } catch {
     return false; // no document (test env) — err toward raising the alarm
   }
+}
+
+/**
+ * Answers "is the project that raised this alarm the chip currently on screen?" — registered
+ * by `WindowChrome`, the only thing that knows which of its live projects is visible.
+ *
+ * INJECTED, not imported. This module is framework-free and is loaded by surfaces that have
+ * no chips at all (the launcher window, the plain browser build, these tests); reaching into
+ * React state from here would couple the alarm to a component that may not exist.
+ */
+let chipActiveProbe: ((vault: string) => boolean) | null = null;
+
+/** Register the window's "which chip is visible?" answer, or `null` to unregister it. */
+export function setChipActiveProbe(probe: ((vault: string) => boolean) | null): void {
+  chipActiveProbe = probe;
+}
+
+/**
+ * Is the alarm's own project the one on screen?
+ *
+ * The banner and the bounce are for reaching someone who is ELSEWHERE — a system banner
+ * sliding over the very chat that raised it is noise, and AppKit no-ops a bounce for the
+ * active app anyway. Before tabs, "elsewhere" was answered entirely by window focus. It no
+ * longer is: the window can be focused while the asking project sits in a BACKGROUND chip,
+ * which is precisely the case the chip strip exists to surface. Left to window focus alone
+ * the user would get nothing at all.
+ *
+ * Two fallbacks, both deliberately `true` (= "on screen", suppress as before), so this stays
+ * byte-identical to the pre-tabs alarm wherever chips do not apply:
+ *   - no probe registered — the launcher, the browser build, tests;
+ *   - no source on the alarm — it cannot be attributed to any chip, and firing a banner over
+ *     the window the user is already looking at is the noise the guard exists to prevent.
+ */
+function isAlarmChipOnScreen(source: string): boolean {
+  if (!source) return true;
+  return chipActiveProbe?.(source) ?? true;
 }
 
 /** Post the banner through the desktop shell, falling back to the browser's own
@@ -85,14 +138,20 @@ async function postBanner(title: string, body: string): Promise<void> {
  */
 export function raiseAskAttention(alarm: AskAlarm = {}): void {
   const now = Date.now();
-  if (now - lastRaise < MIN_INTERVAL_MS) return;
-  lastRaise = now;
+  const source = alarm.source?.trim() ?? '';
+  const lastForSource = lastRaiseBySource.get(source) ?? 0;
+  if (now - lastForSource < MIN_INTERVAL_MS) return;
+  lastRaiseBySource.set(source, now);
 
-  playAskChime();
-  if (isWatchingThisWindow()) return;
+  // The one gate that stays window-wide: N projects asking at once is still one voice.
+  if (now - lastChime >= MIN_INTERVAL_MS) {
+    lastChime = now;
+    playAskChime();
+  }
+
+  if (isWatchingThisWindow() && isAlarmChipOnScreen(source)) return;
 
   void bounceDockIcon();
-  const source = alarm.source?.trim();
   const detail = alarm.detail?.trim();
   void postBanner(
     source ? `Claude is asking · ${oneLine(source)}` : 'Claude is asking',

--- a/dashboard/src/lib/attention.ts
+++ b/dashboard/src/lib/attention.ts
@@ -1,0 +1,101 @@
+/**
+ * The "Claude is asking" alarm — the ONE place a session raises the user off the app.
+ *
+ * A question is the strongest "needs you" signal an agent produces: the turn is stopped
+ * dead until you answer, so the cost of missing it is a run that sits idle for an hour.
+ * The in-app signals (dock chip shake, "?" bubble, attention badge) only reach you while
+ * you are looking AT dreamcontext; these three reach you when you are not:
+ *
+ *   1. the chime   — you're in the app but on another page
+ *   2. a banner    — you're in another app entirely
+ *   3. a Dock bounce — you're in another app and banners are muted / already scrolled by
+ *
+ * They fire together, through one throttle, because they are one interruption. Called from
+ * the ask EDGE in both session engines (`pushAsk` in chatSession.ts, `onSettle` in
+ * agentSession.ts) — never on a redraw, never per pending card.
+ */
+import { playAskChime } from './chime';
+import { bounceDockIcon, sendDesktopNotification } from './desktop';
+
+/** Several agents asking in the same breath must not stack into a klaxon — or into three
+ *  banners and a Dock that never stops jumping. One gate for the whole alarm. */
+const MIN_INTERVAL_MS = 1500;
+let lastRaise = 0;
+
+/** A notification body has to be scannable from the corner of your eye; past roughly this
+ *  much text macOS truncates it anyway, and a wall of prose in a banner reads as spam. */
+const MAX_BODY = 180;
+
+export interface AskAlarm {
+  /** Who is asking — a session tab title, falling back to the vault name. Omitted when the
+   *  caller has neither (the banner then just says dreamcontext is asking). */
+  source?: string | null;
+  /** The question itself, when the surface actually has the words for it. Chat does (the
+   *  AskUserQuestion payload is structured); the terminal surface only has pixels on a
+   *  screen, so it passes nothing and gets the generic line. */
+  detail?: string | null;
+}
+
+/** Collapse whitespace and clip to a banner-sized line. */
+function oneLine(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > MAX_BODY ? flat.slice(0, MAX_BODY - 1).trimEnd() + '…' : flat;
+}
+
+/**
+ * True when this window is the one the user is literally looking at right now.
+ *
+ * The banner and the bounce are for reaching someone who is ELSEWHERE, so they are skipped
+ * in that case — a system banner sliding over the very chat that raised it is noise, and
+ * AppKit no-ops a bounce for the active app regardless. The chime is not skipped: within a
+ * focused window you can still be on the Roadmap page with the asking session minimized to
+ * the dock, which is exactly the case it exists for.
+ *
+ * Note this is per-WINDOW, not per-app: with a vault window in the background and the
+ * launcher up front, the background window's document reports no focus and correctly gets
+ * the full alarm.
+ */
+function isWatchingThisWindow(): boolean {
+  try {
+    return document.visibilityState === 'visible' && document.hasFocus();
+  } catch {
+    return false; // no document (test env) — err toward raising the alarm
+  }
+}
+
+/** Post the banner through the desktop shell, falling back to the browser's own
+ *  Notification API for the dev/web build (where there is no Tauri to ask). */
+async function postBanner(title: string, body: string): Promise<void> {
+  if (await sendDesktopNotification(title, body)) return;
+  try {
+    // WKWebView has no `window.Notification` until the Tauri plugin injects one, so this
+    // arm is genuinely browser-only — inside the shell the call above already handled it.
+    if (typeof Notification === 'undefined') return;
+    if (Notification.permission === 'denied') return;
+    if (Notification.permission !== 'granted' && (await Notification.requestPermission()) !== 'granted') return;
+    new Notification(title, { body, tag: 'dreamcontext-ask' });
+  } catch { /* blocked / unsupported — the chime already carried the signal */ }
+}
+
+/**
+ * Raise the user: chime, native banner, Dock bounce. Fire-and-forget — the transports are
+ * async but no caller waits on them, and every one of them swallows its own failure, so a
+ * denied notification permission or a missing audio context can never break the reducer
+ * that called it.
+ */
+export function raiseAskAttention(alarm: AskAlarm = {}): void {
+  const now = Date.now();
+  if (now - lastRaise < MIN_INTERVAL_MS) return;
+  lastRaise = now;
+
+  playAskChime();
+  if (isWatchingThisWindow()) return;
+
+  void bounceDockIcon();
+  const source = alarm.source?.trim();
+  const detail = alarm.detail?.trim();
+  void postBanner(
+    source ? `Claude is asking · ${oneLine(source)}` : 'Claude is asking',
+    detail ? oneLine(detail) : 'A question is waiting for your answer.',
+  );
+}

--- a/dashboard/src/lib/authorTaskAgent.ts
+++ b/dashboard/src/lib/authorTaskAgent.ts
@@ -72,13 +72,19 @@ export function buildAuthorPrompt(idea: string, hints: AuthorTaskHints = {}): st
  * Bypass defaults to the caller's choice; authoring is low-risk (it writes a task file), so the
  * composer arms it ON by default — the agent can run `tasks create` / `tasks doctor` without an
  * approval prompt per command, while still interviewing you for the content.
+ *
+ * `vault` names the project the new task belongs to and is threaded into `preparePrompt`: the
+ * seed prompt must be minted against the project whose board the composer was opened from.
+ * `bus` names the same project for the hand-off itself — see `requestDelegateAgent`.
  */
 export async function authorTaskWithAgent(
+  bus: EventTarget,
+  vault: string | null,
   args: { idea: string; hints?: AuthorTaskHints; bypass: boolean },
 ): Promise<boolean> {
   const prompt = buildAuthorPrompt(args.idea, args.hints);
-  const { inline, token } = await preparePrompt(prompt);
-  return requestDelegateAgent({
+  const { inline, token } = await preparePrompt(vault, prompt);
+  return requestDelegateAgent(bus, {
     title: AUTHOR_TASK_TITLE, prompt: inline, promptToken: token, bypass: args.bypass,
     // reveal:false — start minimized (A3). It surfaces as a corner chip; click it to answer
     // the agent's interview questions, and the chip raises an attention badge when it's done.

--- a/dashboard/src/lib/automationRunChat.ts
+++ b/dashboard/src/lib/automationRunChat.ts
@@ -1,11 +1,20 @@
+import { emitInstance } from '../context/VaultContext';
+
 /**
  * The "open this automation run as a chat" bridge.
  *
  * An automation's run history lives on the Automations page, deep in the page router. The
  * Agent surface that owns Claude sessions is mounted ONCE, above that router, so it never
- * remounts on navigation — the two cannot share a ref. Same decoupled window-event pattern
- * as `delegateAgent.ts` / the Sleep + brain-resolve agents: the panel dispatches, the
- * always-mounted `AgentSurface` listens.
+ * remounts on navigation — the two cannot share a ref. Same decoupled event pattern as
+ * `delegateAgent.ts` / the Sleep + brain-resolve agents: the panel fires on its project's
+ * instance bus, that project's `AgentSurface` listens.
+ *
+ * The bus, not `window`, and the ACK is the sharp edge again (as in `delegateAgent.ts`): the
+ * listener writes `accepted` back synchronously, so broadcast, the first surface to run wins
+ * the flag while every other one ALSO `--resume`s the same conversation uuid. Two live CLIs
+ * attached to one transcript interleave their appends and neither sees the other's turns —
+ * the exact dual-attach this file's own bring-forward guard exists to prevent, arrived at
+ * from the outside. A run belongs to one project's automation; one surface opens it.
  *
  * What makes this different from every other spawn-from-elsewhere bridge: nothing is being
  * STARTED here. The conversation already happened — headless, on a schedule, while nobody
@@ -51,15 +60,19 @@ export interface AutomationRunChatDetail extends AutomationRunRef {
 }
 
 /**
- * Ask the agent surface to open this run's conversation. Returns whether it did.
+ * Ask THIS project's agent surface to open this run's conversation. Returns whether it did.
  *
  * Synchronous by construction: `dispatchEvent` runs every listener before it returns, so
  * the ACK is readable on the next line. Nothing async may be introduced between the
  * dispatch and the read, or the ACK stops meaning anything.
+ *
+ * Returns `boolean`, not `void`: the ACK is the whole reason this is a function rather than a
+ * bare emit — the panel reports what actually happened ("Couldn't open the run") instead of
+ * optimistically claiming success, exactly like `requestDelegateAgent`.
  */
-export function requestAutomationRunChat(run: AutomationRunRef): boolean {
+export function openAutomationRunChat(bus: EventTarget, run: AutomationRunChatDetail): boolean {
   const detail: AutomationRunChatDetail = { ...run, accepted: false };
-  window.dispatchEvent(new CustomEvent<AutomationRunChatDetail>(AUTOMATION_RUN_CHAT_EVENT, { detail }));
+  emitInstance<AutomationRunChatDetail>(bus, AUTOMATION_RUN_CHAT_EVENT, detail);
   return detail.accepted === true;
 }
 

--- a/dashboard/src/lib/brainResolveAgent.ts
+++ b/dashboard/src/lib/brainResolveAgent.ts
@@ -1,10 +1,17 @@
+import { emitInstance } from '../context/VaultContext';
+
 /**
  * The "Resolve with AI" bridge (github-cloud-collaboration-brain-repo-sync, item 1).
  * The sidebar's teammate-conflict banner lives in the page tree; the Agent surface
  * (which actually spawns Claude Code sessions) is mounted once, ABOVE the router, so
- * they can't share a ref. The banner asks for a resolve session by dispatching a
- * window event and the always-mounted `AgentSurface` listens for it — the same
- * decoupled pattern `sleepAgent.ts` uses for "Run sleep agent".
+ * they can't share a ref. The banner asks for a resolve session by firing an event on
+ * THIS project's instance bus and the always-mounted `AgentSurface` listens for it —
+ * the same decoupled pattern `sleepAgent.ts` uses for "Run sleep agent".
+ *
+ * The bus rather than `window` because a merge resolution is per-brain: `/dream-sync`
+ * reconciles ONE vault's deferred team merge and pushes it. Broadcast, a single click on
+ * one project's banner would launch a resolve agent inside every project the window holds,
+ * each one rewriting a brain repo whose merge nobody asked it to touch.
  *
  * This is the REAL one-click resolve: in the desktop app it launches an in-app agent
  * running `/dream-sync` (which drives `brain sync --resume` → resolves the deferred
@@ -31,9 +38,9 @@ export const BRAIN_RESOLVE_PROMPT =
   '`dreamcontext brain sync --continue` to commit and push. When finished, reply with a SHORT ' +
   'Markdown summary of what you reconciled.';
 
-/** Ask the always-mounted Agent surface to open + run a "/dream-sync" resolve session. */
-export function requestBrainResolveAgent(): void {
-  window.dispatchEvent(new CustomEvent(RUN_BRAIN_RESOLVE_EVENT));
+/** Ask THIS project's Agent surface to open + run a "/dream-sync" resolve session. */
+export function runBrainResolveAgent(bus: EventTarget): void {
+  emitInstance(bus, RUN_BRAIN_RESOLVE_EVENT);
 }
 
 /**

--- a/dashboard/src/lib/brainSyncPrefs.ts
+++ b/dashboard/src/lib/brainSyncPrefs.ts
@@ -2,33 +2,43 @@
  * Machine-local dashboard preferences for brain cloud-sync (github-cloud-collaboration-brain-repo-sync).
  * These are PER-MACHINE UI preferences (not team-shared config), so they live in
  * localStorage — the same place `aboutSeen` / agent settings live.
+ *
+ * PER MACHINE **and** PER VAULT: this preference decides whether opening a project
+ * auto-COMMITS its uncommitted work. That is real git behaviour against one specific repo,
+ * so it cannot be one value shared by every project in the window.
  */
+import { readScopedRaw, writeScopedRaw } from './scopedStorage';
 
 const AUTO_CHECKPOINT_KEY = 'dreamcontext.dashboard.autoCheckpointOnOpen';
 
-/** Cross-window notify so an open sidebar reflects a Settings toggle immediately. */
+/** Cross-window notify so an open sidebar reflects a Settings toggle immediately.
+ *
+ *  DEAD CODE, kept deliberately: nothing in `dashboard/src` listens for it (verified — zero
+ *  `addEventListener` for this name). It stays on `window` exactly as it is; moving a no-op
+ *  event onto the instance bus would be work with no behaviour attached. Wire a listener
+ *  before relying on it. */
 export const AUTO_CHECKPOINT_EVENT = 'dreamcontext-auto-checkpoint-pref';
 
 /**
- * Whether opening the dashboard auto-CHECKPOINTS (commits) uncommitted local edits
- * before the on-open pull. Default ON — the safe behavior (nothing is ever lost to a
+ * Whether opening the dashboard auto-CHECKPOINTS (commits) THIS vault's uncommitted local
+ * edits before the on-open pull. Default ON — the safe behavior (nothing is ever lost to a
  * merge). When OFF, the on-open pull passes `noCheckpoint` and skips a dirty tree
  * entirely, leaving WIP untouched (the user syncs manually when ready).
+ *
+ * `keepLegacy` is MANDATORY here and the reason is the default-ON fallback above. Under
+ * `scopedStorage`'s ordinary copy-once-then-delete policy, a user who deliberately turned
+ * auto-checkpoint OFF would keep that intent for exactly ONE vault: every other vault would
+ * find no scoped key, fall back to ON, and silently start auto-committing their work-in-
+ * progress. Copy-once-then-delete is only safe when the unset fallback is the safe
+ * direction, and here it is not — so the legacy key survives and every vault seeds from the
+ * user's real choice.
  */
-export function readAutoCheckpointOnOpen(): boolean {
-  try {
-    return window.localStorage.getItem(AUTO_CHECKPOINT_KEY) !== '0';
-  } catch {
-    return true;
-  }
+export function readAutoCheckpointOnOpen(vault: string | null): boolean {
+  return readScopedRaw(vault, AUTO_CHECKPOINT_KEY, { keepLegacy: true }) !== '0';
 }
 
-export function writeAutoCheckpointOnOpen(enabled: boolean): void {
-  try {
-    window.localStorage.setItem(AUTO_CHECKPOINT_KEY, enabled ? '1' : '0');
-  } catch {
-    /* storage blocked — ignore */
-  }
+export function writeAutoCheckpointOnOpen(vault: string | null, enabled: boolean): void {
+  writeScopedRaw(vault, AUTO_CHECKPOINT_KEY, enabled ? '1' : '0');
   try {
     window.dispatchEvent(new CustomEvent(AUTO_CHECKPOINT_EVENT, { detail: enabled }));
   } catch {

--- a/dashboard/src/lib/checklistBridge.ts
+++ b/dashboard/src/lib/checklistBridge.ts
@@ -12,10 +12,25 @@
  * used in BOTH directions; plain `emit()` broadcasts to every open window, which would hand
  * a checklist's plaintext markdown (which may hold a pasted API key) to every open vault's
  * Chat surface, including an unrelated project's — filtering at the receiver is not
- * isolation. `vaultWindowLabel`/`checklistWindowLabel` are single-sourced (`desktop.ts` /
- * `checklistStore.ts`) so this file never re-derives a label of its own.
+ * isolation.
+ *
+ * The two directions find their target differently, and the asymmetry is the point:
+ *   - the ACK goes to `checklistWindowLabel(vault, id)` (`checklistStore.ts`), which is
+ *     INJECTIVE over both parts and names a window that hosts exactly one checklist. It
+ *     needs no lookup, and it carries no secret anyway;
+ *   - the SUBMIT — the direction that carries the markdown — can no longer DERIVE its
+ *     target at all. A window now holds SEVERAL projects, so the vault-name-derived window
+ *     label in `desktop.ts` names a window instead of finding one. The submit resolves the
+ *     real Tauri label through `windowRegistry.ts`, CORROBORATED against the live window
+ *     list, and refuses to send when it cannot be.
+ *
+ * No derived label may ever reappear on the submit path — that is why this file imports
+ * nothing label-shaped from `desktop.ts`, and why a grep for one here should stay empty. A
+ * derived label is a guess, and a wrong guess now reaches a window full of unrelated live
+ * projects rather than one empty one.
  */
-import { isDesktop, vaultWindowLabel } from './desktop';
+import { isDesktop } from './desktop';
+import { resolveLiveWindowForVault } from './windowRegistry';
 import { checklistWindowLabel } from './checklistStore';
 
 export const CHECKLIST_SUBMIT_EVENT = 'dream://checklist-submit';
@@ -51,12 +66,20 @@ function eventApi(): Promise<typeof import('@tauri-apps/api/event')> {
 
 /**
  * Fired from the checklist window's Submit button. Resolves `true` ONLY on a real ack from
- * the target vault window. A thrown `emitTo`/`listen` (ACL denial, non-desktop) and a
- * silent non-delivery (the vault window was closed, or the label derivation is wrong) are
- * indistinguishable to the caller and both mean "couldn't reach the chat" — so both resolve
- * `false`, and the caller (`ChecklistWindow`) renders the same failure strip either way.
- * The ack listener is registered BEFORE `emitTo` fires (so a fast ack can never race ahead
- * of our own subscription) and is torn down on every exit path — ack, timeout, or thrown.
+ * the target vault window. A thrown `emitTo`/`listen` (ACL denial, non-desktop), an
+ * uncorroborated target, and a silent non-delivery all mean the same thing to the caller —
+ * "couldn't reach the chat" — so all of them resolve `false` and `ChecklistWindow` renders
+ * the same failure strip. The ack listener is registered BEFORE `emitTo` fires (so a fast
+ * ack can never race ahead of our own subscription) and is torn down on every exit path —
+ * ack, timeout, refusal, or thrown.
+ *
+ * FAILS CLOSED. `resolveLiveWindowForVault` returning null means "no window I can prove is
+ * both alive and holding this project", and the answer to that is to send nothing. There is
+ * deliberately no fall back to a label derived from the vault name: the registry is eventually
+ * consistent, so a stale row can name the wrong window, and a wrong window now hosts several
+ * unrelated live projects — each with its own `listen(CHECKLIST_SUBMIT_EVENT)` callback that
+ * would receive this plaintext markdown before checking whose it is. An undelivered submit
+ * costs the user one retry; a mis-delivered one hands another project a pasted API key.
  */
 export async function submitChecklist(p: ChecklistSubmitPayload): Promise<boolean> {
   if (!isDesktop()) return false;
@@ -68,7 +91,9 @@ export async function submitChecklist(p: ChecklistSubmitPayload): Promise<boolea
     unlisten = await listen<ChecklistAckPayload>(CHECKLIST_ACK_EVENT, (event) => {
       if (event.payload?.checklistId === p.checklistId) resolveAck(true);
     });
-    await emitTo(vaultWindowLabel(p.vault), CHECKLIST_SUBMIT_EVENT, p);
+    const label = await resolveLiveWindowForVault(p.vault);
+    if (!label) return false; // the caller already renders its own failure strip
+    await emitTo(label, CHECKLIST_SUBMIT_EVENT, p);
     const timeoutPromise = new Promise<boolean>((resolve) => {
       setTimeout(() => resolve(false), CHECKLIST_ACK_TIMEOUT_MS);
     });
@@ -83,11 +108,17 @@ export async function submitChecklist(p: ChecklistSubmitPayload): Promise<boolea
 /**
  * Registered once by `AgentSurface` — the durable session registry, mounted for the whole
  * app's lifetime (a `ChatPane` is per-visible-pane and can be garaged, so it cannot be the
- * listener's home). `vault` scopes the incoming submit: a plain `listen()` here only ever
- * sees events `emitTo` addressed to THIS window, but `vaultWindowLabel`'s sanitizer is
- * DELIBERATELY lossy (`vault-a.b` and `vault-a-b` collide — an accepted pre-existing quirk,
- * §1.12), so this equality check is the belt-and-braces catch for that collision rather
- * than a redundant no-op. `handler` returns whether it CLAIMED the submit (resolved a live
+ * listener's home). `vault` scopes the incoming submit, and that check is now what ROUTES
+ * it: a plain `listen()` here only ever sees events `emitTo` addressed to THIS window, but
+ * a window holds SEVERAL projects, each mounting its own `AgentSurface` and so its own
+ * listener. All of them fire for every submit this window receives; the equality check is
+ * how the one project the checklist actually belongs to is the one that claims it. It used
+ * to be belt-and-braces against the lossy sanitizer behind the old derived window label — it
+ * is now the instance selector, and deleting it would hand the payload to whichever
+ * project's listener happened to be registered first. It remains the SECOND line of defence,
+ * not the first:
+ * the sender refuses to emit at all unless it can corroborate this window (see
+ * {@link submitChecklist}). `handler` returns whether it CLAIMED the submit (resolved a live
  * chat session in this vault and posted the message to it); the ack fires only on `true`,
  * so an unmatched or vault-mismatched submit leaves the checklist window's timeout path to
  * render its own failure strip — never a silent success.

--- a/dashboard/src/lib/chime.ts
+++ b/dashboard/src/lib/chime.ts
@@ -4,13 +4,13 @@
  * (no asset, no network) and soft: short envelope, low gain. A shared AudioContext is
  * created lazily on first play; if the webview's autoplay policy blocks audio before any
  * user gesture, the play is silently skipped (the visual signals still fire).
+ *
+ * Deliberately un-throttled: this is one voice of the three-part alarm in `attention.ts`
+ * (chime + notification + Dock bounce), and the rate limit lives THERE so all three stay
+ * one interruption. Don't call this directly from a session — call `raiseAskAttention`.
  */
 
 let ctx: AudioContext | null = null;
-let lastPlay = 0;
-
-/** Several agents asking in the same breath must not stack into a klaxon. */
-const MIN_INTERVAL_MS = 1500;
 
 function note(at: number, freq: number, dur: number) {
   if (!ctx) return;
@@ -27,9 +27,6 @@ function note(at: number, freq: number, dur: number) {
 }
 
 export function playAskChime(): void {
-  const now = Date.now();
-  if (now - lastPlay < MIN_INTERVAL_MS) return;
-  lastPlay = now;
   try {
     ctx ??= new AudioContext();
     if (ctx.state === 'suspended') void ctx.resume();

--- a/dashboard/src/lib/claudeAuth.ts
+++ b/dashboard/src/lib/claudeAuth.ts
@@ -1,4 +1,5 @@
 import type { Capabilities } from '../components/sleepy/agentSession';
+import { emitInstance } from '../context/VaultContext';
 
 /**
  * What the System doctor says about Claude Code's sign-in state, and the bridge that
@@ -58,11 +59,17 @@ export function claudeAuthRow(auth: ClaudeAuthInfo | undefined): ClaudeAuthRow |
 /**
  * Settings → the agent surface. The sign-in flow needs an interactive terminal, which only
  * `AgentSurface` can open (it owns every session), and Settings is a page BELOW it in the
- * tree with no handle on it — so the request travels as a window event, the same
+ * tree with no handle on it — so the request travels as an event, the same
  * page-dispatches/surface-listens bridge the sleep tracker and Delegate already use.
+ *
+ * It rides the INSTANCE bus, not `window`. Sign-in is one machine-wide act, so N of them is
+ * not dangerous the way N sleeps or N delegates are — it is simply wrong: every project the
+ * window holds would open its own "Sign in" shell tab, and the user would be looking at one
+ * login while three more sat in the dock behind it. The Settings page that asked is inside
+ * exactly one project; exactly one surface should answer.
  */
 export const CLAUDE_SIGNIN_EVENT = 'dreamcontext-claude-signin';
 
-export function requestClaudeSignIn(): void {
-  try { window.dispatchEvent(new CustomEvent(CLAUDE_SIGNIN_EVENT)); } catch { /* SSR/none */ }
+export function requestClaudeSignIn(bus: EventTarget): void {
+  emitInstance(bus, CLAUDE_SIGNIN_EVENT);
 }

--- a/dashboard/src/lib/delegateAgent.ts
+++ b/dashboard/src/lib/delegateAgent.ts
@@ -1,14 +1,25 @@
 import type { Task } from '../hooks/useTasks';
 import { preparePrompt } from './agentPrompt';
+import { emitInstance } from '../context/VaultContext';
 
 /**
  * The "Delegate a task to Claude" bridge. A task card lives deep in the board's React
  * tree; the Agent surface (which actually spawns Claude Code sessions) is mounted once,
  * ABOVE the page router, so it never remounts on navigation. They can't share a ref, so
- * the board's Delegate composer asks for an agent by dispatching a window event and the
- * always-mounted `AgentSurface` listens for it — the same decoupled pattern the surface
- * already uses for `dreamcontext-navigate` / `dreamcontext-zoom` / the Sleep + brain-resolve
- * agents. No prop threading across the tree.
+ * the board's Delegate composer asks for an agent by firing an event and the always-mounted
+ * `AgentSurface` listens for it — the same decoupled pattern the surface already uses for
+ * `dreamcontext-navigate` / the Sleep + brain-resolve agents. No prop threading across the
+ * tree.
+ *
+ * THE ONE THAT MUST NOT BE BROADCAST. Of every bridge in this app, this is the one where
+ * `window` does not merely duplicate an action — it misroutes it. The ACK below is written
+ * back onto the payload SYNCHRONOUSLY by the listener, so with several projects mounted in
+ * one window the FIRST `AgentSurface` to run its listener claims the delegate and sets
+ * `accepted`. The composer then reports "Delegated ✓" while the task is being worked on in
+ * a project it does not belong to, against the wrong repo, by an agent reading a
+ * `_dream_context/state/<slug>.md` that is not there. Every other listener spawns its own
+ * duplicate agent on top. The bus is what makes the ACK mean "the project I delegated FROM
+ * took it", which is the only thing it was ever supposed to mean.
  */
 export const DELEGATE_AGENT_EVENT = 'dreamcontext-delegate-agent';
 
@@ -128,23 +139,46 @@ export function taskContextBlock(task: Task, title: string): string {
  * `accepted` is already visible by the time it returns — no async plumbing needed. That is
  * exactly why the prompt must be transport-prepared BEFORE this call, never inside the
  * listener: an await in there would make the ack a lie again.
+ *
+ * `bus` names WHICH project is being asked (`useVault().bus`). It is not plumbing: it is what
+ * makes the ack answer for the project the composer was opened from rather than for whichever
+ * surface in the window happened to run its listener first — see this module's header.
  */
-export function requestDelegateAgent(detail: DelegateAgentDetail): boolean {
+export function requestDelegateAgent(bus: EventTarget, detail: DelegateAgentDetail): boolean {
   const payload: DelegateAgentDetail = { ...detail, accepted: false };
-  window.dispatchEvent(new CustomEvent<DelegateAgentDetail>(DELEGATE_AGENT_EVENT, { detail: payload }));
+  emitInstance<DelegateAgentDetail>(bus, DELEGATE_AGENT_EVENT, payload);
   return payload.accepted === true;
+}
+
+/** What a composer hands {@link delegateTaskToAgent}: the tab title, the prompt as the user
+ *  last saw it, the bypass choice, and the optional model / reveal overrides. */
+export interface DelegateAgentArgs {
+  title: string;
+  prompt: string;
+  bypass: boolean;
+  model?: string;
+  reveal?: boolean;
 }
 
 /**
  * Prepare + dispatch in one step: route the prompt to a transport that can carry it, then ask
  * the surface for a session. Throws if the prompt can't be handed over (see `preparePrompt`);
  * resolves to the surface's ACK otherwise.
+ *
+ * `vault` names the project the task belongs to and is threaded straight into `preparePrompt`
+ * — the token has to be minted against the project the composer was opened from, not against
+ * whichever of the window's live projects happened to be touched last. `bus` names the same
+ * project for the hand-off itself, and both must come from the SAME `useVault()`: a token
+ * minted against project A and redeemed by project B's surface is the misroute this bridge
+ * exists to prevent.
  */
 export async function delegateTaskToAgent(
-  args: { title: string; prompt: string; bypass: boolean; model?: string; reveal?: boolean },
+  bus: EventTarget,
+  vault: string | null,
+  args: DelegateAgentArgs,
 ): Promise<boolean> {
-  const { inline, token } = await preparePrompt(args.prompt.trim());
-  return requestDelegateAgent({
+  const { inline, token } = await preparePrompt(vault, args.prompt.trim());
+  return requestDelegateAgent(bus, {
     title: args.title, prompt: inline, promptToken: token, bypass: args.bypass,
     model: args.model, reveal: args.reveal,
   });

--- a/dashboard/src/lib/desktop.ts
+++ b/dashboard/src/lib/desktop.ts
@@ -153,6 +153,55 @@ export async function toggleMaximizeWindow(target: EventTarget | null): Promise<
 }
 
 /**
+ * Bounce the app's Dock icon to say "something here is blocked on you".
+ *
+ * `Critical` (not `Informational`) because the thing that raises this is a question
+ * Claude cannot proceed past: macOS bounces the icon until you activate the app,
+ * whereas Informational bounces exactly once and is easy to miss while you're in
+ * another window. AppKit itself no-ops the request when dreamcontext is ALREADY the
+ * active app and cancels it the moment you switch back, so there is nothing to
+ * clear afterwards — the bounce only ever exists while you're away.
+ *
+ * macOS-shaped but not macOS-gated: on Windows the same call flashes the taskbar
+ * button, which is the same message in that platform's language. No-op off-desktop.
+ */
+export async function bounceDockIcon(): Promise<void> {
+  if (!isDesktop()) return;
+  try {
+    const { getCurrentWindow, UserAttentionType } = await windowApi();
+    await getCurrentWindow().requestUserAttention(UserAttentionType.Critical);
+  } catch { /* ACL / non-desktop — ignore */ }
+}
+
+/**
+ * Post a native OS notification banner. Resolves `true` only when one was actually
+ * handed to the OS, so callers can fall back to the browser's own Notification API.
+ *
+ * The permission dance is kept even though the plugin's DESKTOP backend answers both
+ * `isPermissionGranted` and `requestPermission` with a flat "granted": macOS has no
+ * per-app opt-in to ask for up front — whether a banner is drawn is decided at delivery
+ * time by System Settings → Notifications for the bundled app. The calls are what the
+ * browser and mobile backends genuinely need, and they cost one IPC round-trip.
+ *
+ * Delivery requires the BUNDLED `.app` (mac-notification-sys resolves the bundle
+ * identifier through LaunchServices), so an unbundled `tauri dev` run may post nothing.
+ * That's why this returns a boolean instead of throwing: the chime and the Dock bounce
+ * still carry the signal on their own.
+ */
+export async function sendDesktopNotification(title: string, body: string): Promise<boolean> {
+  if (!isDesktop()) return false;
+  try {
+    const { isPermissionGranted, requestPermission, sendNotification } =
+      await import('@tauri-apps/plugin-notification');
+    if (!(await isPermissionGranted()) && (await requestPermission()) !== 'granted') return false;
+    sendNotification({ title, body });
+    return true;
+  } catch {
+    return false; // plugin absent (older shell) / ACL — the chime and bounce still fired
+  }
+}
+
+/**
  * Open the native macOS picker via the shell's own `pick_paths` command.
  *
  * NOT `@tauri-apps/plugin-dialog`: that plugin's rfd backend reads

--- a/dashboard/src/lib/desktop.ts
+++ b/dashboard/src/lib/desktop.ts
@@ -359,6 +359,30 @@ export async function openVaultWindow(name: string): Promise<void> {
 }
 
 /**
+ * Focus an already-open window by its REAL Tauri label — the one half of "this project is
+ * already open in another window, surface it instead of opening it twice" that has to happen
+ * over there rather than here. The label comes from `windowRegistry.ts`, not from
+ * {@link vaultWindowLabel}: with several projects per window, a label derived from a vault
+ * name no longer names the window that holds it.
+ *
+ * Resolves `false` on every miss — no such window, an ACL denial, or off-desktop — because
+ * every one of those means the same thing to the caller ("couldn't surface it, do something
+ * else"), and the registry it came from is allowed to be stale by design.
+ */
+export async function focusWindow(label: string): Promise<boolean> {
+  if (!isDesktop() || !label) return false;
+  try {
+    const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+    const win = await WebviewWindow.getByLabel(label);
+    if (!win) return false;
+    await win.setFocus();
+    return true;
+  } catch {
+    return false; // ACL / window died between the lookup and the focus
+  }
+}
+
+/**
  * Open the pinned checklist window for one project's checklist `id`. Mirrors
  * `openVaultWindow` exactly: focus an already-open window instead of spawning a
  * duplicate, otherwise build a new always-on-top window at the same dashboard
@@ -433,13 +457,46 @@ export async function openLauncherHome(): Promise<void> {
   window.location.assign(`${window.location.origin}/`);
 }
 
+/** How a window that can hold chips takes over {@link goToProject}. */
+type GoToProjectHandler = (vault: string) => Promise<void>;
+
 /**
- * Go to a project from the ⌘P switcher. Every project keeps its OWN window, so
- * this always opens/focuses the target's window (see `openVaultWindow`) and never
- * touches the current window — switching from project B to A leaves B open, and
- * re-picking an already-open project just surfaces its existing window.
+ * Set by whichever `WindowChrome` is mounted in THIS window; null in the launcher, the
+ * capture bar, the perch and the checklist window, none of which hold projects.
+ */
+let goToProjectHandler: GoToProjectHandler | null = null;
+
+/**
+ * Register (or clear, with `null`) the in-window handler for {@link goToProject}.
+ *
+ * A registration seam rather than a direct call because this module is deliberately not
+ * React: it is imported by plain libraries and by the launcher bundle, so it cannot reach
+ * `useChrome()` — and importing chrome state here would drag the whole instance tree into
+ * every file that just wants to open a folder picker. `WindowChrome` registers on mount and
+ * clears on unmount; a window that registers nothing keeps the old behaviour untouched.
+ */
+export function setGoToProjectHandler(fn: GoToProjectHandler | null): void {
+  goToProjectHandler = fn;
+}
+
+/**
+ * Go to a project from the ⌘P switcher.
+ *
+ * The default INVERTED when one window started holding several projects: going to a project
+ * now means adding a chip HERE (the registered handler), not spawning a second OS window for
+ * it. A separate window is still reachable — it is just an explicit choice now (⇧-click in the
+ * switcher, or a chip's "Open in New Window"), both of which call {@link openVaultWindow}
+ * directly rather than coming through here.
+ *
+ * With no handler registered — the launcher window, and any surface that holds no projects —
+ * this falls back to exactly what it always did, which is what the launcher needs: it has no
+ * chip strip to add to, so picking a project there must open that project's own window.
  */
 export async function goToProject(name: string): Promise<void> {
+  if (goToProjectHandler) {
+    await goToProjectHandler(name);
+    return;
+  }
   await openVaultWindow(name);
 }
 

--- a/dashboard/src/lib/instanceQueryClient.ts
+++ b/dashboard/src/lib/instanceQueryClient.ts
@@ -1,0 +1,72 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * One `QueryClient` per LIVE PROJECT, instead of one per window.
+ *
+ * The cache is keyed by query key alone, so a single window-wide client would serve project
+ * B's `['tasks']` entry to project A the moment both are mounted — same key, different vault,
+ * one cache. Giving every `ProjectInstance` its own client is what keeps N projects' page data
+ * genuinely separate, and it also makes teardown total: closing a chip drops that project's
+ * whole cache with it rather than leaving orphaned entries behind.
+ */
+
+/**
+ * How often a VISIBLE instance re-pulls its page data. Background instances stop polling
+ * entirely (see {@link setInstanceActive}) — with six projects mounted, six 15-second polls
+ * against one local server is five projects' worth of work nobody is looking at.
+ */
+const ACTIVE_REFETCH_MS = 15_000;
+
+/**
+ * A fresh client with the defaults the app has always used — this is a MOVE of `App.tsx`'s
+ * former module-level `queryClient`, not a new policy.
+ */
+export function createInstanceQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5000,
+        retry: 1,
+        refetchOnWindowFocus: true,
+        // Live-update while the app stays open (sleep debt, tasks, knowledge all
+        // go stale as the agent works). Polls only when the tab is visible, and
+        // react-query's structural sharing skips re-renders when nothing changed,
+        // so this is cheap against the local server. The Header also exposes a
+        // manual refresh button for an immediate pull.
+        refetchInterval: ACTIVE_REFETCH_MS,
+        refetchIntervalInBackground: false,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+}
+
+/**
+ * Follow one instance's visibility with its PAGE-DATA polling — and nothing else.
+ *
+ * A hidden instance is still mounted and still live: its chats keep streaming, its WebSockets
+ * are never touched, its agent surface keeps its own polling. The only thing that pauses is
+ * the react-query refetch loop behind the pages the user cannot currently see, which is pure
+ * cost while they are hidden and is re-armed the instant the chip comes forward.
+ *
+ * Written through `setDefaultOptions` rather than per-query so it covers every existing and
+ * future query at once; mounted observers pick the new interval up on their next update.
+ * Queries that must keep polling in the background (a goal-skill run badge, say) override
+ * `refetchInterval` explicitly at their own call site — the audit for that is Wave 3 (T17).
+ *
+ * With a single always-active chip this is behaviour-identical to today: the mechanism lands
+ * now, the behaviour change arrives when a second chip does.
+ */
+export function setInstanceActive(qc: QueryClient, active: boolean): void {
+  const defaults = qc.getDefaultOptions();
+  qc.setDefaultOptions({
+    ...defaults,
+    queries: {
+      ...defaults.queries,
+      refetchInterval: active ? ACTIVE_REFETCH_MS : false,
+      refetchOnWindowFocus: active,
+    },
+  });
+}

--- a/dashboard/src/lib/overlayStack.ts
+++ b/dashboard/src/lib/overlayStack.ts
@@ -7,23 +7,86 @@
  * overlay instead pushes its id while open and its Esc handler acts only when it
  * is topmost — so Esc always closes the front-most overlay, regardless of which
  * listener the browser happens to invoke first.
+ *
+ * ## Why the stack is SCOPED
+ *
+ * That design assumed one project per window, so "front-most" and "the overlay the user
+ * can see" were the same overlay. One window now holds several projects mounted at once,
+ * and the background ones are only `hidden` — their Escape listeners are still registered
+ * on `window` and still fire. A single flat stack breaks in both directions:
+ *
+ *   - open a panel in project A, switch to B, open a panel in B, switch back to A. A's
+ *     panel is the one on screen, but B's entry is topmost, so Esc does NOTHING in A.
+ *   - the same two panels in the other order: Esc pressed in B silently closes A's
+ *     invisible panel and leaves B's open.
+ *
+ * So every entry records the scope (the active instance) it was pushed in, and Esc is
+ * answered per scope: an overlay owns Esc when it is topmost AMONG ITS OWN SCOPE, and a
+ * background project's overlay never owns Esc at all.
+ *
+ * An entry pushed with no scope set (`null` — the launcher, the browser build, a test, any
+ * surface with no `WindowChrome` above it) belongs to every scope. There, one flat stack IS
+ * correct and this behaves exactly as it did before.
  */
-const stack: string[] = [];
+interface Entry {
+  id: string;
+  /** The active instance at push time; `null` outside a `WindowChrome`. */
+  scope: string | null;
+}
+
+const stack: Entry[] = [];
+
+/** The instance whose overlays are on screen. `null` = unscoped (single-surface window). */
+let activeScope: string | null = null;
+
+/**
+ * Point the stack at the project the user is looking at. Called by `WindowChrome` on every
+ * chip switch, and with `null` on unmount so a closed window leaves nothing behind.
+ *
+ * This is deliberately a module-level setter rather than a parameter threaded through every
+ * overlay: the eight `pushOverlay` call sites include popovers that build their own ids from
+ * `useId()` and know nothing about vaults, and an overlay should not have to be vault-aware
+ * to be dismissible.
+ */
+export function setActiveOverlayScope(scope: string | null): void {
+  activeScope = scope;
+}
+
+/** True when the entry answers for the scope currently on screen. */
+function inActiveScope(e: Entry): boolean {
+  return e.scope === null || e.scope === activeScope;
+}
 
 /** Mark an overlay as open and topmost (idempotent — re-pushing moves it to top). */
 export function pushOverlay(id: string): void {
-  const i = stack.indexOf(id);
+  const i = stack.findIndex((e) => e.id === id);
   if (i !== -1) stack.splice(i, 1);
-  stack.push(id);
+  stack.push({ id, scope: activeScope });
 }
 
 /** Mark an overlay as closed. */
 export function popOverlay(id: string): void {
-  const i = stack.indexOf(id);
+  const i = stack.findIndex((e) => e.id === id);
   if (i !== -1) stack.splice(i, 1);
 }
 
-/** True when `id` is the front-most open overlay — the one Esc should close. */
+/**
+ * True when `id` is the front-most open overlay OF THE PROJECT ON SCREEN — the one Esc
+ * should close. An overlay left open in a backgrounded project answers `false`, however
+ * recently it was pushed: it is not on screen, so Esc is not talking to it.
+ */
 export function isTopOverlay(id: string): boolean {
-  return stack.length > 0 && stack[stack.length - 1] === id;
+  const entry = stack.find((e) => e.id === id);
+  if (!entry || !inActiveScope(entry)) return false;
+  for (let i = stack.length - 1; i >= 0; i -= 1) {
+    if (!inActiveScope(stack[i])) continue;
+    return stack[i].id === id;
+  }
+  return false;
+}
+
+/** Test-only: drop every entry and forget the scope. */
+export function resetOverlayStack(): void {
+  stack.length = 0;
+  activeScope = null;
 }

--- a/dashboard/src/lib/scopedStorage.ts
+++ b/dashboard/src/lib/scopedStorage.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-project localStorage, for the keys whose MEANING changes per project.
+ *
+ * `localStorage` is one store shared by every window on this origin — and, now that one
+ * window holds several live projects, by every mounted instance inside it too. A key like
+ * "which page was I on" written by two instances is last-writer-wins; a key like
+ * "auto-commit on open" read by the wrong project flips real git behaviour against a repo
+ * the user never opted in for. Those keys go through here; chrome/habit preferences (zoom,
+ * theme, "I've read the About page") stay global and must NOT be routed through this module.
+ *
+ * A null vault means launcher / plain browser: the key is used VERBATIM and nothing is
+ * migrated, so those surfaces behave byte-identically to before.
+ */
+
+export const SCOPE_PREFIX = 'dreamcontext:';
+
+export interface ScopeOpts {
+  /**
+   * Copy the legacy value into the scoped key WITHOUT deleting the legacy key, so EVERY
+   * vault seeds from it instead of only the first one to read it.
+   *
+   * Required for any key whose UNSET fallback is the unsafe direction. The worked example is
+   * `autoCheckpointOnOpen`, which reads `getItem(KEY) !== '0'` — i.e. absent means ON. Under
+   * the default policy a user who deliberately turned auto-commit OFF would keep that intent
+   * for exactly one vault, and every other vault would find no scoped key, fall back to ON,
+   * and start auto-committing their work.
+   */
+  keepLegacy?: boolean;
+}
+
+/**
+ * `dreamcontext:<vault>:<key>` for a real project; the bare legacy `key` when there is no
+ * vault. An empty-string vault counts as "no vault" — that is what `?vault=` with no value
+ * yields, and `App.tsx` already treats it as launcher mode.
+ */
+export function scopedKey(vault: string | null, key: string): string {
+  return vault ? `${SCOPE_PREFIX}${vault}:${key}` : key;
+}
+
+/**
+ * `vault|key` pairs already considered for migration in this page's lifetime. The latch is
+ * what makes migration run at most once per pair no matter how many components read the key,
+ * and it is why a `removeScoped` cannot be undone by the legacy value coming back on the
+ * next read.
+ */
+const migrated = new Set<string>();
+
+/**
+ * Move a pre-scoping value into its scoped home, once.
+ *
+ * Lives in the RAW layer on purpose: it moves the stored string unchanged, so one code path
+ * serves both the JSON-encoded keys and the `'1'`/`'0'` string keys.
+ *
+ * DOCUMENTED CONSEQUENCE of the default (no `keepLegacy`): the legacy value goes to whichever
+ * project reads it FIRST and the legacy key is then deleted, so a second vault reading the
+ * same key gets the fallback. Copy-without-delete would re-seed every future project from a
+ * value that belonged to whatever project happened to be open last. This mirrors
+ * `hooks/usePersistedState.ts`'s one-time migration. Opt out with `keepLegacy` only for the
+ * keys documented on {@link ScopeOpts}.
+ */
+function migrateLegacyOnce(vault: string, key: string, keepLegacy: boolean): void {
+  const pair = `${vault}|${key}`;
+  if (migrated.has(pair)) return;
+  // Latch BEFORE touching storage: a private-mode throw is not transient, and retrying it on
+  // every read would just repeat the same failure at a cost.
+  migrated.add(pair);
+  try {
+    const scoped = scopedKey(vault, key);
+    if (localStorage.getItem(scoped) !== null) return; // already scoped — nothing to move
+    const legacy = localStorage.getItem(key);
+    if (legacy === null) return;
+    localStorage.setItem(scoped, legacy);
+    if (!keepLegacy) localStorage.removeItem(key);
+  } catch { /* storage unavailable (private mode / quota) — the read below falls back */ }
+}
+
+/** The stored string for a scoped key, migrating a legacy value in on first read. */
+export function readScopedRaw(vault: string | null, key: string, opts: ScopeOpts = {}): string | null {
+  if (vault) migrateLegacyOnce(vault, key, opts.keepLegacy === true);
+  try {
+    return localStorage.getItem(scopedKey(vault, key));
+  } catch {
+    return null; // storage unavailable — indistinguishable from "never set", and both mean fallback
+  }
+}
+
+export function writeScopedRaw(vault: string | null, key: string, value: string): void {
+  try {
+    localStorage.setItem(scopedKey(vault, key), value);
+  } catch { /* quota exceeded or storage disabled — a lost preference must never break a render */ }
+}
+
+/**
+ * JSON layer over {@link readScopedRaw}. Corrupt JSON reads as unset.
+ *
+ * No `ScopeOpts`: `keepLegacy` exists for keys whose unset-fallback is unsafe, and every one
+ * of those is a bare `'1'`/`'0'` flag on the raw layer. Add it here only when that stops
+ * being true.
+ */
+export function readScoped<T>(vault: string | null, key: string, fallback: T): T {
+  const raw = readScopedRaw(vault, key);
+  if (raw === null) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeScoped<T>(vault: string | null, key: string, value: T): void {
+  try {
+    writeScopedRaw(vault, key, JSON.stringify(value));
+  } catch { /* unserialisable value (cycle) — nothing sane to store */ }
+}
+
+/**
+ * Forget a scoped value. Runs the migration first so the legacy key is consumed exactly as a
+ * read would have consumed it — otherwise a remove on a never-yet-read key would leave the
+ * legacy value behind and the NEXT read would resurrect what the caller just deleted.
+ */
+export function removeScoped(vault: string | null, key: string): void {
+  if (vault) migrateLegacyOnce(vault, key, false);
+  try {
+    localStorage.removeItem(scopedKey(vault, key));
+  } catch { /* storage unavailable — nothing was readable anyway */ }
+}

--- a/dashboard/src/lib/sleepAgent.ts
+++ b/dashboard/src/lib/sleepAgent.ts
@@ -1,10 +1,19 @@
+import { emitInstance } from '../context/VaultContext';
+import { readScopedRaw, removeScoped, writeScopedRaw } from './scopedStorage';
+
 /**
  * The "Run sleep agent" bridge. The header's Sleep-debt tracker lives in the page
  * tree; the Agent surface (which actually spawns Claude Code sessions) is mounted
  * once, ABOVE the page router, so it never remounts on navigation. They can't hold a
- * shared ref, so the tracker asks for a sleep agent by dispatching a window event and
- * the always-mounted `AgentSurface` listens for it — the same decoupled pattern the
- * surface already uses for `dreamcontext-navigate` / `dreamcontext-zoom`.
+ * shared ref, so the tracker asks for a sleep agent by firing an event and the
+ * always-mounted `AgentSurface` listens for it — the same decoupled pattern the
+ * surface already uses for `dreamcontext-navigate`.
+ *
+ * ON THE INSTANCE BUS, NOT `window`. A consolidation is the single most project-specific
+ * thing this app can start: it rewrites one vault's tasks, knowledge and changelog. On
+ * `window`, one click would spawn a `sleep` session in EVERY project the window is holding
+ * — several agents consolidating several brains nobody asked about. So the caller passes
+ * the bus of the instance it belongs to (`useVault().bus`) and exactly one surface hears it.
  */
 export const RUN_SLEEP_AGENT_EVENT = 'dreamcontext-run-sleep-agent';
 
@@ -39,9 +48,9 @@ export const SLEEP_AGENT_PROMPT =
   '`dreamcontext migrations pending` has output) — do NOT run those passes inline in your own ' +
   'context. When finished, reply with a SHORT Markdown summary of what was consolidated.';
 
-/** Ask the always-mounted Agent surface to open + run a "Sleep" consolidation session. */
-export function requestSleepAgent(): void {
-  window.dispatchEvent(new CustomEvent(RUN_SLEEP_AGENT_EVENT));
+/** Ask THIS project's Agent surface to open + run a "Sleep" consolidation session. */
+export function runSleepAgent(bus: EventTarget): void {
+  emitInstance(bus, RUN_SLEEP_AGENT_EVENT);
 }
 
 // ── "Waiting to sleep" shim ─────────────────────────────────────────────────────────
@@ -53,8 +62,20 @@ export function requestSleepAgent(): void {
 // with a short-lived, persisted "pending" marker: set on click, cleared the moment a real
 // sleep begins, and self-expiring after a ceiling so a failed spawn never wedges the
 // tracker in "Waiting…" forever. Persisted (not React state) so it survives the tracker
-// unmounting on navigation; broadcast so a live tracker reflects it immediately.
-const SLEEP_PENDING_KEY = 'dreamcontext:sleep-pending-at';
+// unmounting on navigation; announced so a live tracker reflects it immediately.
+//
+// PER VAULT, and the marker's own meaning is why: "a consolidation was just requested" is a
+// fact about ONE project. Held at a single global key, clicking Run sleep agent in project A
+// would put project B's tracker into "Waiting to sleep…" and disable its menu item, for a
+// sleep B never asked for and will never see start. It rides `scopedStorage`, and its
+// notification rides the instance bus, for the same reason.
+//
+// The pre-scoping key was the bare `dreamcontext:sleep-pending-at` and is deliberately NOT
+// migrated: this marker is ephemeral (see the TTL below) and every app launch starts on a
+// fresh origin with empty localStorage, so there is never a legacy value worth adopting —
+// and adopting one would hand project A's "waiting" state to whichever project read first,
+// which is the exact bug the scoping removes.
+const SLEEP_PENDING_KEY = 'sleep-pending-at';
 export const SLEEP_PENDING_EVENT = 'dreamcontext-sleep-pending';
 /** How long "Waiting to sleep" holds before self-clearing if no real sleep ever starts.
  *  Comfortably longer than a normal boot → `sleep start` (a few tens of seconds, plus the
@@ -62,25 +83,25 @@ export const SLEEP_PENDING_EVENT = 'dreamcontext-sleep-pending';
  *  idle-session re-issue path in AgentSurface — within a few minutes. */
 export const SLEEP_PENDING_TTL_MS = 3 * 60_000;
 
-/** Mark a sleep as requested — the tracker shows "Waiting to sleep…" until it truly starts. */
-export function markSleepPending(): void {
-  try { localStorage.setItem(SLEEP_PENDING_KEY, String(Date.now())); } catch { /* storage blocked */ }
-  window.dispatchEvent(new CustomEvent(SLEEP_PENDING_EVENT));
+/** Mark a sleep as requested for `vault` — its tracker shows "Waiting to sleep…" until it
+ *  truly starts. */
+export function markSleepPending(bus: EventTarget, vault: string | null): void {
+  writeScopedRaw(vault, SLEEP_PENDING_KEY, String(Date.now()));
+  emitInstance(bus, SLEEP_PENDING_EVENT);
 }
 
-/** Drop the "Waiting to sleep" marker (real sleep began, or we're giving up on it). */
-export function clearSleepPending(): void {
-  try { localStorage.removeItem(SLEEP_PENDING_KEY); } catch { /* storage blocked */ }
-  window.dispatchEvent(new CustomEvent(SLEEP_PENDING_EVENT));
+/** Drop `vault`'s "Waiting to sleep" marker (real sleep began, or we're giving up on it). */
+export function clearSleepPending(bus: EventTarget, vault: string | null): void {
+  removeScoped(vault, SLEEP_PENDING_KEY);
+  emitInstance(bus, SLEEP_PENDING_EVENT);
 }
 
-/** The epoch (ms) a sleep was requested at, or null if none pending / it expired past the TTL. */
-export function sleepPendingSince(): number | null {
-  try {
-    const raw = localStorage.getItem(SLEEP_PENDING_KEY);
-    if (!raw) return null;
-    const at = Number(raw);
-    if (!Number.isFinite(at) || Date.now() - at > SLEEP_PENDING_TTL_MS) return null;
-    return at;
-  } catch { return null; }
+/** The epoch (ms) a sleep was requested at for `vault`, or null if none pending / it expired
+ *  past the TTL. */
+export function sleepPendingSince(vault: string | null): number | null {
+  const raw = readScopedRaw(vault, SLEEP_PENDING_KEY);
+  if (!raw) return null;
+  const at = Number(raw);
+  if (!Number.isFinite(at) || Date.now() - at > SLEEP_PENDING_TTL_MS) return null;
+  return at;
 }

--- a/dashboard/src/lib/useOverlayId.ts
+++ b/dashboard/src/lib/useOverlayId.ts
@@ -1,0 +1,19 @@
+import { useVault } from '../context/VaultContext';
+
+/**
+ * A per-instance overlay id — `${instanceId}::${local}` — so two project instances open in
+ * the same window never collide on `overlayStack`'s literal ids. `pushOverlay` de-dupes by
+ * id, so two instances pushing the same bare string (e.g. `'command-palette'`) are the SAME
+ * entry: instance A closing its palette pops instance B's, and Esc breaks in B.
+ *
+ * A hook (not a plain function) because it reads `useVault()` — kept out of the
+ * framework-free `overlayStack.ts` so that module stays usable outside React.
+ *
+ * Outside a `VaultProvider` (launcher, browser build, the checklist window) `instanceId` is
+ * `''`, giving e.g. `'::command-palette'` — still unique, because exactly one of each
+ * off-instance surface ever exists at a time.
+ */
+export function useOverlayId(local: string): string {
+  const { instanceId } = useVault();
+  return `${instanceId}::${local}`;
+}

--- a/dashboard/src/lib/windowRegistry.ts
+++ b/dashboard/src/lib/windowRegistry.ts
@@ -1,0 +1,227 @@
+/**
+ * Which OS window currently holds which projects.
+ *
+ * WHY THIS EXISTS: `vaultWindowLabel(name)` (`desktop.ts`) mints a window label from ONE
+ * vault name, which was a complete answer to "where does project X live?" only while a
+ * window held exactly one project. A window now holds several, so a label derived from a
+ * vault name no longer identifies a window at all — it names a window that may not exist,
+ * while the window that DOES have that project answers to some other label entirely. Every
+ * cross-window decision needs a real lookup instead: this registry.
+ *
+ * TRANSPORT: `localStorage` on the one shared origin. That is not a convenience — it is the
+ * same property `checklistStore.ts`'s header establishes and depends on: the desktop app
+ * serves every window from one Node server on one port, so `localStorage` is shared across
+ * every open project. Storage is therefore the one channel a window can use to publish to
+ * windows it holds no handle on.
+ *
+ * WHY A HEARTBEAT WHEN `WebviewWindow.getAll()` EXISTS (it is already used at
+ * `desktop.ts:90-91`): on the desktop that call answers "is this window still alive?"
+ * instantly and authoritatively. But the plain BROWSER dashboard is served from the same
+ * origin and shares this same storage, and there `thisWindowLabel()` is `''` and there is no
+ * Tauri window list to ask at all. The heartbeat is the one liveness mechanism that covers
+ * both surfaces: on desktop it is belt-and-braces, in the browser it is the only belt. Rows
+ * older than {@link STALE_MS} are ignored by every reader, so a window that crashed without
+ * ever running `beforeunload` cannot haunt the registry for longer than three missed beats.
+ *
+ * TWO LOOKUPS, DELIBERATELY NOT ONE. {@link findWindowForVault} is a registry read and may
+ * return a stale label; it is for the cheap "add a chip here or focus another window?"
+ * decision, whose worst case is a focus call at a dead label. {@link resolveLiveWindowForVault}
+ * corroborates that answer against the live window list and returns null when it cannot —
+ * it is the only form allowed for a payload that can carry a secret. Picking the wrong one
+ * on the checklist submit path is how a pasted API key reaches an unrelated project.
+ */
+import { isDesktop } from './desktop';
+
+export const WINDOW_REGISTRY_KEY = 'dc.windows.v1';
+
+/** How often a window should re-publish its row. Owned by the caller (WindowChrome). */
+export const HEARTBEAT_MS = 5_000;
+
+/** A row older than this is treated as a dead window — three missed heartbeats. */
+export const STALE_MS = 15_000;
+
+export interface WindowRegistryEntry {
+  /** The window's REAL Tauri label (`getCurrentWindow().label`) — never a derived one. */
+  label: string;
+  /** The projects live in that window right now. */
+  vaults: string[];
+  /** When the row was last published (`Date.now()`). */
+  ts: number;
+}
+
+/**
+ * This window's label once resolved: a Tauri label on the desktop, `''` in a browser tab or
+ * when the ACL refuses. `null` means "not resolved yet" — distinct from `''`, because an
+ * unresolved window must not be mistaken for an untargetable one.
+ */
+let cachedLabel: string | null = null;
+let labelPromise: Promise<string> | null = null;
+
+async function readWindowLabel(): Promise<string> {
+  if (!isDesktop()) return '';
+  try {
+    const { getCurrentWindow } = await import('@tauri-apps/api/window');
+    return getCurrentWindow().label;
+  } catch {
+    // No Tauri runtime / ACL denial. An unlabelled window can't be an `emitTo` target, which
+    // is exactly what `''` means here — the same answer as a browser tab.
+    return '';
+  }
+}
+
+/**
+ * This window's real Tauri label, cached after the first resolution. `''` off-desktop.
+ * A window's label never changes for the lifetime of the window, so caching is total.
+ */
+export function thisWindowLabel(): Promise<string> {
+  if (cachedLabel !== null) return Promise.resolve(cachedLabel);
+  if (!labelPromise) {
+    labelPromise = readWindowLabel().then((label) => {
+      cachedLabel = label;
+      return label;
+    });
+  }
+  return labelPromise;
+}
+
+function isEntry(value: unknown): value is WindowRegistryEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const row = value as Partial<WindowRegistryEntry>;
+  return typeof row.label === 'string'
+    && typeof row.ts === 'number'
+    && Number.isFinite(row.ts)
+    && Array.isArray(row.vaults)
+    && row.vaults.every((v) => typeof v === 'string');
+}
+
+/**
+ * Every well-formed row. A blob that is missing, unparseable, not an array, or holds rows of
+ * the wrong shape reads as `[]` and the malformed rows are dropped on the next write — a
+ * corrupt registry degrades to "nobody has anything open", never to a throw. That matters
+ * because a throw here would propagate into a submit or a chip click.
+ */
+function readRows(): WindowRegistryEntry[] {
+  try {
+    const raw = window.localStorage.getItem(WINDOW_REGISTRY_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isEntry);
+  } catch {
+    return []; // storage disabled (private mode) or corrupt JSON
+  }
+}
+
+/** Rows from windows that have beaten within {@link STALE_MS}. */
+function readFreshRows(now: number): WindowRegistryEntry[] {
+  return readRows().filter((row) => now - row.ts < STALE_MS);
+}
+
+function writeRows(rows: WindowRegistryEntry[]): void {
+  try {
+    window.localStorage.setItem(WINDOW_REGISTRY_KEY, JSON.stringify(rows));
+  } catch {
+    // Quota / disabled storage. The heartbeat is idempotent, so a dropped write costs one
+    // beat and the next one repairs it.
+  }
+}
+
+/** Drop dead rows, writing only when something actually went away. */
+function pruneStaleRows(): void {
+  const now = Date.now();
+  const all = readRows();
+  const fresh = all.filter((row) => now - row.ts < STALE_MS);
+  if (fresh.length !== all.length) writeRows(fresh);
+}
+
+/**
+ * Publish the projects open in THIS window and refresh its timestamp. Call on every change
+ * and every {@link HEARTBEAT_MS} tick.
+ *
+ * The read-modify-write is unlocked, so two windows publishing in the same instant can lose
+ * one of the two rows. That is the designed-for failure: `setItem` is atomic per key so the
+ * blob can never tear, and the loser re-publishes within one beat — a third of the way to
+ * {@link STALE_MS}. Readers tolerate a missing row (they fall back to "not open anywhere");
+ * nothing in this module tolerates a torn one, which is why the loss is the cheaper mode.
+ */
+export function publishOpenVaults(vaults: string[]): void {
+  if (cachedLabel === null) {
+    // First call: the Tauri label only comes back async. Start that, and let the next
+    // heartbeat publish — one missed beat is invisible at three beats of staleness.
+    void thisWindowLabel();
+    pruneStaleRows();
+    return;
+  }
+  if (!cachedLabel) {
+    // A browser tab. It has no label, so no window could ever address it — claiming a row
+    // would only put an untargetable label in front of readers. It still GCs, because it
+    // shares the blob with every desktop window on this origin.
+    pruneStaleRows();
+    return;
+  }
+  const now = Date.now();
+  const rows = readFreshRows(now).filter((row) => row.label !== cachedLabel);
+  rows.push({ label: cachedLabel, vaults: [...vaults], ts: now });
+  writeRows(rows);
+}
+
+/**
+ * Withdraw this window's row. Call from `beforeunload` — a clean exit removes itself
+ * immediately instead of leaving a lookup pointing at a closing window for up to
+ * {@link STALE_MS}. Staleness GC is the backstop for the unclean exits this cannot cover.
+ */
+export function releaseWindow(): void {
+  if (!cachedLabel) return; // never published — nothing to withdraw
+  writeRows(readFreshRows(Date.now()).filter((row) => row.label !== cachedLabel));
+}
+
+/**
+ * The window holding `vault`, or null.
+ *
+ * REGISTRY ONLY — the answer may name a window that has since closed, because the registry
+ * is eventually consistent. Use this for decisions whose worst case is harmless: "is this
+ * project already open somewhere, or do I add a chip for it?" — a focus call at a dead label
+ * resolves to `false` and the caller falls through. **Never use it to address a payload**;
+ * {@link resolveLiveWindowForVault} exists for that.
+ */
+export function findWindowForVault(vault: string): string | null {
+  if (!vault) return null;
+  const now = Date.now();
+  for (const row of readFreshRows(now)) {
+    // An empty label is a browser tab's row (see publishOpenVaults) — unaddressable. Our own
+    // label is never an answer: "which OTHER window has this?" is the only question asked
+    // here, and the caller has already checked its own instances.
+    if (!row.label || row.label === cachedLabel) continue;
+    if (row.vaults.includes(vault)) return row.label;
+  }
+  return null;
+}
+
+/**
+ * The window holding `vault`, corroborated against the live window list — or null.
+ *
+ * THE ONLY FORM ALLOWED FOR A PAYLOAD THAT CAN CARRY A SECRET, and it FAILS CLOSED: there is
+ * no optimistic fallback anywhere in this function. The registry alone is not good enough for
+ * that job because it is eventually consistent (heartbeat interval, staleness GC, unlocked
+ * read-modify-write), so a stale row can name the wrong window — and a wrong window now hosts
+ * SEVERAL unrelated live projects, each with its own listener, so a mis-addressed payload
+ * lands in all of their callbacks before any of them checks which project it belongs to.
+ * Receiver-side filtering is not isolation.
+ *
+ * Off-desktop there is no window list to corroborate against and no `emitTo` to use the
+ * answer, so this is null by construction.
+ */
+export async function resolveLiveWindowForVault(vault: string): Promise<string | null> {
+  if (!isDesktop()) return null;
+  const label = findWindowForVault(vault);
+  if (!label) return null;
+  try {
+    const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+    const live = await WebviewWindow.getAll();
+    return live.some((win) => win.label === label) ? label : null;
+  } catch {
+    // Could not enumerate windows (ACL / no runtime) — an uncorroborated label is exactly
+    // what this function refuses to hand back.
+    return null;
+  }
+}

--- a/dashboard/src/pages/CorePage.tsx
+++ b/dashboard/src/pages/CorePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '../api/client';
+import { useApi } from '../context/VaultContext';
 import { useFocusTarget, type FocusTarget } from '../hooks/useFocusTarget';
 import { useI18n } from '../context/I18nContext';
 import { SqlPreview } from '../components/core/SqlPreview';
@@ -75,6 +75,7 @@ interface CorePageProps {
 
 export function CorePage({ onNavigateTaxonomy, focus }: CorePageProps = {}) {
   const { t } = useI18n();
+  const api = useApi();
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<Selection | null>(null);
   const [editContent, setEditContent] = useState<string | null>(null);

--- a/dashboard/src/pages/KnowledgePage.tsx
+++ b/dashboard/src/pages/KnowledgePage.tsx
@@ -10,6 +10,7 @@ import { isExcalidrawSlug } from '../lib/excalidraw';
 import { knowledgeLinkTarget, isPdfHref } from '../lib/knowledgeLinks';
 import { PdfViewer } from '../components/sleepy/chat/PdfViewer';
 import { graphContentUrl } from '../api/client';
+import { useVault } from '../context/VaultContext';
 import { tagHue } from '../lib/tagColor';
 import { BrainSearch } from '../components/search/BrainSearch';
 import './KnowledgePage.css';
@@ -193,6 +194,7 @@ interface KnowledgePageProps {
 
 export function KnowledgePage({ focus }: KnowledgePageProps = {}) {
   const { t } = useI18n();
+  const { vault } = useVault();
   const { data: entries, isLoading, isError, error } = useKnowledgeList();
   const togglePin = useToggleKnowledgePin();
   const [selected, setSelected] = useState<string | null>(null);
@@ -360,7 +362,7 @@ export function KnowledgePage({ focus }: KnowledgePageProps = {}) {
     e.preventDefault();
     setPdf({
       path: `_dream_context/${target}`,
-      src: graphContentUrl(target, { raw: true }),
+      src: graphContentUrl(vault, target, { raw: true }),
       label: anchor?.textContent?.trim() || target.split('/').pop() || target,
     });
   };

--- a/dashboard/src/pages/LabPage.tsx
+++ b/dashboard/src/pages/LabPage.tsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from 'react';
 import { LabBoard } from '../components/lab/LabBoard';
 import { FunnelOverviewPage } from '../components/lab/funnel/FunnelOverviewPage';
 import { FunnelDetailPage } from '../components/lab/funnel/FunnelDetailPage';
-import { clearLabPath, pushLabPath, useLabRoute } from '../components/lab/funnel/labRoute';
+import {
+  clearLabPath,
+  flushBufferedRoute,
+  pushLabPath,
+  setLabRouteWritable,
+  useLabRoute,
+} from '../components/lab/funnel/labRoute';
+import { useInstanceEvent, useVault } from '../context/VaultContext';
 import type { FocusTarget } from '../hooks/useFocusTarget';
 import './LabPage.css';
 
@@ -18,6 +25,7 @@ interface LabPageProps {
  * deep links work. Strictly self-contained; no reach into Roadmap.
  */
 export function LabPage({ focus }: LabPageProps = {}) {
+  const { bus, isActive } = useVault();
   const route = useLabRoute();
   const [toast, setToast] = useState<string | null>(null);
 
@@ -29,18 +37,28 @@ export function LabPage({ focus }: LabPageProps = {}) {
 
   // Leaving the Lab page (sidebar/palette navigation unmounts us) resets the
   // path so a reload doesn't resurrect a funnel page under another section.
-  useEffect(() => () => clearLabPath(), []);
+  // Declared BEFORE the address-bar effect on purpose: React runs a component's cleanups in
+  // declaration order, so on unmount this one still runs while we hold the address bar.
+  useEffect(() => () => clearLabPath(bus), [bus]);
+
+  // This page is the only surface that routes, so it is also the one that claims the
+  // window's single address bar for its project — held while this chip is the one you're
+  // looking at, handed back when it isn't. Coming forward restores the route parked on the
+  // way out, which is what makes switching chips land you where you left the funnel.
+  useEffect(() => {
+    if (!isActive) return;
+    setLabRouteWritable(true, bus);
+    flushBufferedRoute();
+    return () => setLabRouteWritable(false, bus);
+  }, [isActive, bus]);
 
   // Re-clicking "Insights" in the sidebar (or palette) while deep in a funnel
-  // page returns to the board — the nav event fires for every navigate().
-  useEffect(() => {
-    const onNavigate = (e: Event) => {
-      const page = (e as CustomEvent<{ page?: string }>).detail?.page;
-      if (page === 'lab') clearLabPath();
-    };
-    window.addEventListener('dreamcontext-navigate', onNavigate);
-    return () => window.removeEventListener('dreamcontext-navigate', onNavigate);
-  }, []);
+  // page returns to the board — the nav event fires for every navigate(). On this instance's
+  // bus, not `window`: `Shell` emits it per project, so on `window` one project's navigation
+  // would reset every other open project's funnel page to its board.
+  useInstanceEvent<{ page?: string } | undefined>('dreamcontext-navigate', (detail) => {
+    if (detail?.page === 'lab') clearLabPath(bus);
+  });
 
   let content;
   if (route.slug && route.funnelId) {
@@ -48,8 +66,8 @@ export function LabPage({ focus }: LabPageProps = {}) {
       <FunnelDetailPage
         slug={route.slug}
         funnelId={route.funnelId}
-        onBack={() => pushLabPath(route.slug, null)}
-        onBackToBoard={() => pushLabPath(null, null)}
+        onBack={() => pushLabPath(route.slug, null, bus)}
+        onBackToBoard={() => pushLabPath(null, null, bus)}
         onToast={setToast}
       />
     );
@@ -57,7 +75,7 @@ export function LabPage({ focus }: LabPageProps = {}) {
     content = (
       <FunnelOverviewPage
         slug={route.slug}
-        onBack={() => pushLabPath(null, null)}
+        onBack={() => pushLabPath(null, null, bus)}
         onToast={setToast}
       />
     );

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useI18n } from '../context/I18nContext';
-import { api } from '../api/client';
+import { useApi, useVault } from '../context/VaultContext';
 import { useConfig, useUpdateConfig, type PlatformId, type SetupConfig } from '../hooks/useConfig';
 import { SearchableSelect } from '../components/tasks/SearchableSelect';
 import { ConnectionsManager } from '../components/settings/ConnectionsManager';
@@ -164,6 +164,7 @@ interface SettingsPageProps {
 
 export function SettingsPage({ focus }: SettingsPageProps) {
   const { t } = useI18n();
+  const api = useApi();
   const queryClient = useQueryClient();
   const { data: config, isLoading: configLoading, isError: configError } = useConfig();
   const updateConfig = useUpdateConfig();
@@ -181,8 +182,11 @@ export function SettingsPage({ focus }: SettingsPageProps) {
   // SW2 — Cloud sync master toggle (Brain Repo & Collaboration section).
   const { data: brainSettings } = useBrainSettings();
   const updateBrainSettings = useUpdateBrainSettings();
-  // Item 7 — machine-local "auto-checkpoint on open" preference (localStorage, not team config).
-  const [autoCheckpoint, setAutoCheckpoint] = useState<boolean>(() => readAutoCheckpointOnOpen());
+  // Item 7 — machine-local "auto-checkpoint on open" preference (localStorage, not team
+  // config), and PER VAULT: it decides whether opening THIS project auto-commits its
+  // uncommitted work, so it is read and written against this instance's vault.
+  const { vault } = useVault();
+  const [autoCheckpoint, setAutoCheckpoint] = useState<boolean>(() => readAutoCheckpointOnOpen(vault));
 
   // Memory recall mode — lives in .sleep.json (not the setup config), so it is
   // persisted immediately via PATCH /api/sleep rather than buffered behind Save.
@@ -874,7 +878,7 @@ export function SettingsPage({ focus }: SettingsPageProps) {
             <input
               type="checkbox"
               checked={autoCheckpoint}
-              onChange={(e) => { setAutoCheckpoint(e.target.checked); writeAutoCheckpointOnOpen(e.target.checked); }}
+              onChange={(e) => { setAutoCheckpoint(e.target.checked); writeAutoCheckpointOnOpen(vault, e.target.checked); }}
             />
             <span>{t('brain.scope.autoCheckpoint.label')}</span>
           </label>

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -246,15 +246,18 @@
   --page-max-width: 1200px;
   --card-padding: 12px;
   /* Left edge of the page content area (= current sidebar width). Flipped to the
-     collapsed width by `:root[data-sidebar="collapsed"]` below so a surface mounted
-     OUTSIDE the Shell (the expanded Agent overlay) can bound itself to the content
-     area, below the header and right of the sidebar. */
+     collapsed width by `.project-instance[data-sidebar="collapsed"]` below so a surface
+     mounted OUTSIDE the Shell (the expanded Agent overlay) can bound itself to the content
+     area, below the header and right of the sidebar. Set here (unconditionally) so a first
+     paint before Shell's effect runs sees the expanded width, not an unset custom property. */
   --app-content-left: var(--sidebar-width);
 }
 
-/* Shell.tsx publishes the sidebar collapse state on <html> so surfaces outside the
-   Shell tree can react to it (the Agent overlay is mounted at the app root). */
-:root[data-sidebar="collapsed"] {
+/* Shell.tsx publishes the sidebar collapse state on the nearest `.project-instance`
+   ancestor (one window can hold several projects, each with a life of its own rail state)
+   so surfaces outside the Shell tree but inside that instance — the expanded Agent overlay —
+   can react to it. */
+.project-instance[data-sidebar="collapsed"] {
   --app-content-left: var(--sidebar-width-collapsed);
 }
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -69,6 +69,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +298,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -400,6 +544,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -752,6 +905,7 @@ dependencies = [
  "tauri-nspanel",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-shell",
 ]
 
@@ -827,6 +981,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +1039,26 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -997,6 +1198,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1401,6 +1615,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1930,6 +2150,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2293,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -2242,6 +2490,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2348,6 +2597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2640,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2488,6 +2753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +2809,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2836,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2666,6 +2965,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3273,6 +3601,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3877,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,6 +4014,30 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3977,7 +4359,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4039,6 +4433,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5192,6 +5597,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5284,4 +5750,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,12 @@ tauri-plugin-global-shortcut = "2"
 # comment. Routing copies through this Rust-side plugin bypasses the WKWebView entirely and
 # round-trips UTF-8 correctly.
 tauri-plugin-clipboard-manager = "2"
+# Native OS notification banners. WKWebView ships no Web Notification API at all
+# (`window.Notification` is simply undefined), so a webview-only implementation is
+# impossible — this plugin both injects the `window.Notification` polyfill the JS
+# side calls and delivers the banner through NSUserNotification. Used by the
+# "Claude is asking" alarm (dashboard/src/lib/attention.ts).
+tauri-plugin-notification = "2"
 # Converts the Sleepy notch window into a non-activating NSPanel so the hotkey
 # summons it OVER whatever app is focused — the user types into it without their
 # current app deactivating, and dismissing it never surfaces the dreamcontext

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for the dreamcontext desktop shell. Grants the tightest permission set needed: core defaults, multi-window creation, native folder dialog, opening external URLs (shell:allow-open — target=_blank links / Open GitHub), and shell spawn/kill scoped to the Node child.",
+  "description": "Default capability for the dreamcontext desktop shell. Grants the tightest permission set needed: core defaults, multi-window creation, native folder dialog, opening external URLs (shell:allow-open — target=_blank links / Open GitHub), Dock-bounce + native notification banners for the \"Claude is asking\" alarm, and shell spawn/kill scoped to the Node child.",
   "windows": ["main", "vault-*", "sleepy", "sleepy-perch"],
   "remote": {
     "urls": ["http://localhost:*", "http://127.0.0.1:*"]
@@ -16,6 +16,7 @@
     "core:window:allow-set-position",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-request-user-attention",
     "core:event:allow-emit",
     "core:event:allow-listen",
     "core:event:allow-unlisten",
@@ -25,6 +26,9 @@
     "global-shortcut:allow-is-registered",
     "allow-pick-paths",
     "clipboard-manager:allow-write-text",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify",
     "shell:allow-open",
     {
       "identifier": "shell:allow-spawn",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -138,6 +138,11 @@ pub fn run() {
         // clipboard mangling non-ASCII as Mac Roman (issue #171). Used by the in-app agent
         // terminal's copy path via @tauri-apps/plugin-clipboard-manager on the loopback origin.
         .plugin(tauri_plugin_clipboard_manager::init())
+        // Native notification banners. Registering the plugin is what injects the
+        // `window.Notification` polyfill into the webview — WKWebView ships none — so
+        // the dashboard's "Claude is asking" alarm has something to call. Sent from JS
+        // via the permitted API (see the capability), so no custom command is needed.
+        .plugin(tauri_plugin_notification::init())
         // Global shortcut for the Sleepy notch quick-capture bar. The hotkey is
         // registered/unregistered from the dashboard JS via the plugin's permitted
         // API (the capability grants global-shortcut on the loopback origin), so

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "verify:automation-run-chat": "node scripts/verify/automation-run-chat.mjs",
     "verify:delegate-modes": "node scripts/verify/delegate-modes.mjs",
     "verify:hypotheses": "node scripts/verify/hypotheses-ui.mjs",
-    "verify:lab-board": "node scripts/verify/lab-board.mjs"
+    "verify:lab-board": "node scripts/verify/lab-board.mjs",
+    "verify:project-tabs": "node scripts/verify/project-tabs.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/verify/project-tabs.mjs
+++ b/scripts/verify/project-tabs.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Project-tabs runtime smoke — the FIRST STAGE of the goal's B checklist.
+ *
+ *   npm run build && node scripts/verify/project-tabs.mjs
+ *
+ * WHAT IT PROVES (real server, real bundle, real Chromium — no mocks):
+ *   S1  the vault window boots and mounts exactly ONE ProjectInstance for `?vault=`
+ *   S2  the chip strip renders exactly one chip, carrying that project's name
+ *   S3  the instance wrapper is NOT hidden and NOT inert while it is the only chip
+ *   S4  `.project-instance[hidden]` genuinely computes to `display: none` — the rule the
+ *       whole hiding contract rests on (a `hidden` attribute alone loses to any author
+ *       `display` rule, which would render every instance on top of the others)
+ *   S5  no chip list is persisted: a reload comes back with exactly one chip (checklist B9)
+ *   S6  every `/api/` call the boot actually makes SUCCEEDS. This one exists because of a
+ *       real miss: the suite once reported all green on a page whose every request was
+ *       failing 400, because "it rendered" and "it works" are not the same claim. A vault
+ *       name the server does not know is answered with 400 on every route, and the shell
+ *       still paints. Rendering is not evidence that the vault plumbing is connected.
+ *   M1  two registered vaults open as two chips, with BOTH instances mounted at once
+ *   M2  exactly one instance is visible; the other is hidden AND inert AND display:none
+ *   M3  switching chips HIDES the old instance — its `data-instance` is unchanged, i.e. it
+ *       was not remounted (the structural half of the red line: a remount is a killed PTY)
+ *   M4  re-opening an already-open project focuses its chip instead of minting a second
+ *       instance against the same vault (checklist B6, in-window half)
+ *
+ * WHAT IT DELIBERATELY DOES NOT COVER — and why it is not silence:
+ *   Anything that needs a REAL agent: a chat that keeps streaming across a switch (B2), a
+ *   chip that bounces when a background chat asks (B3), a terminal's cols/rows after five
+ *   switches (B4/M-x1), one PTY per session under StrictMode (M-x2), teardown at the
+ *   six-instance ceiling (B7). Those need the Claude CLI and a live PTY, not a headless
+ *   Chromium. They are reported as UNPROVEN by whoever invokes this — never folded into a
+ *   pass, and never restated as if the structural check above had covered them.
+ *
+ * FAILURE POLICY — collect, don't fail fast: every check reports, then the process exits
+ * non-zero if any failed, so one broken assumption doesn't hide the rest.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { chromium } from 'playwright';
+
+const PORT = process.env.PORT || '4791';
+const URL = `http://127.0.0.1:${PORT}`;
+const results = [];
+const check = (name, ok, detail) => { results.push({ name, ok, detail }); console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`); };
+
+// Isolated scratch HOME so nothing touches the user's real vault registry. TWO vaults are
+// registered, because one is the shape that hides every bug this feature could have: with a
+// single project there is nothing to leak into, nothing to switch between, and nothing to
+// duplicate.
+const home = mkdtempSync(join(tmpdir(), 'dc-tabs-'));
+const seedVault = (name) => {
+  const dir = join(home, name);
+  mkdirSync(join(dir, '_dream_context', 'state'), { recursive: true });
+  writeFileSync(join(dir, '_dream_context', 'state', '.config.json'), JSON.stringify({ platforms: [] }, null, 2));
+  return { name, path: dir };
+};
+const vaults = [seedVault('scratch-a'), seedVault('scratch-b')];
+mkdirSync(join(home, '.dreamcontext'), { recursive: true });
+writeFileSync(join(home, '.dreamcontext', 'vaults.json'), JSON.stringify({ version: 1, vaults }, null, 2));
+
+const server = spawn(process.execPath, ['dist/index.js', 'dashboard', '--no-open', '--port', PORT], {
+  env: { ...process.env, HOME: home, DREAMCONTEXT_DESKTOP: '1' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let serverLog = '';
+server.stdout.on('data', (d) => { serverLog += d; });
+server.stderr.on('data', (d) => { serverLog += d; });
+
+const waitForServer = async () => {
+  for (let i = 0; i < 60; i++) {
+    try { const r = await fetch(`${URL}/api/health`); if (r.ok) return true; } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+};
+
+let browser;
+try {
+  if (!(await waitForServer())) {
+    check('server boots', false, `no /api/health after 30s. log tail: ${serverLog.slice(-400)}`);
+  } else {
+    check('server boots', true, `${URL}/api/health`);
+    browser = await chromium.launch();
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+
+    // S6 — watch every `/api/` response for the whole run, both loads.
+    // 404 is EXCLUDED from the failure set on purpose: several hooks are written to tolerate a
+    // route an older backend does not serve, so a 404 is a designed answer here. 400 (the vault
+    // the server cannot resolve), 401/403 and any 5xx are not — they mean the request reached
+    // the server carrying something wrong, which is precisely the class this check exists for.
+    const apiFailures = [];
+    page.on('response', (res) => {
+      const u = res.url();
+      if (!u.includes('/api/')) return;
+      const s = res.status();
+      if (s >= 400 && s !== 404) apiFailures.push(`${s} ${u.replace(URL, '')}`);
+    });
+
+    await page.goto(`${URL}/?vault=scratch-a`, { waitUntil: 'domcontentloaded' });
+
+    // S1 — exactly one instance mounts
+    await page.waitForSelector('.project-instance', { timeout: 20000 }).catch(() => {});
+    const instances = await page.locator('.project-instance').count();
+    check('S1 exactly one ProjectInstance mounts', instances === 1, `found ${instances}`);
+
+    // S2 — the chip strip renders one chip naming the project
+    // EXACT class only — `[class*="project-tab"]` also matches project-tab-name/-dot/-badge,
+    // i.e. one chip's own children, and would count a single chip eight times.
+    const chipText = await page.locator('.project-tab').allTextContents().catch(() => []);
+    check('S2 chip strip renders one chip for the project',
+      chipText.length === 1 && chipText[0].includes('scratch-a'),
+      `chips=${JSON.stringify(chipText)}`);
+
+    // S3 — the only chip's instance is visible and interactive
+    const state = await page.locator('.project-instance').first()
+      .evaluate((el) => ({ hidden: el.hasAttribute('hidden'), inert: el.hasAttribute('inert') }));
+    check('S3 the sole instance is not hidden and not inert',
+      state.hidden === false && state.inert === false, JSON.stringify(state));
+
+    // S4 — the hiding contract actually computes to display:none
+    const displayWhenHidden = await page.evaluate(() => {
+      const el = document.querySelector('.project-instance');
+      if (!el) return 'no-instance';
+      el.setAttribute('hidden', '');
+      const d = getComputedStyle(el).display;
+      el.removeAttribute('hidden');
+      return d;
+    });
+    check('S4 .project-instance[hidden] computes to display:none',
+      displayWhenHidden === 'none', `computed display = ${displayWhenHidden}`);
+
+    // S7 — a never-seen vault raises the "what's new" modal over the chrome, and its scrim
+    // swallows every click at the window level. Escape must dismiss it: that is the overlay
+    // stack answering for the ACTIVE instance, driven end to end rather than unit-tested.
+    // Checked HERE, before the reload, because the reload marks the announcement read and
+    // there would be nothing left to dismiss — a check that passes by finding nothing to do
+    // is the same green-for-no-reason this file added S6 to stop reporting.
+    const scrim = page.locator('.announcements-modal-scrim');
+    const hadModal = await scrim.count();
+    if (hadModal) {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(600);
+    }
+    check('S7 Escape dismisses the front-most overlay in the active project',
+      hadModal > 0 && (await scrim.count()) === 0,
+      hadModal ? `dismissed; scrims left: ${await scrim.count()}`
+        : 'NO MODAL APPEARED — nothing was exercised, so this is not evidence');
+
+    // S5 — no tab persistence (checklist B9)
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('.project-instance', { timeout: 20000 }).catch(() => {});
+    const afterReload = await page.locator('.project-instance').count();
+    check('S5 a reload comes back with exactly one project (no tab persistence)',
+      afterReload === 1, `found ${afterReload}`);
+
+    // ─── TWO PROJECTS IN ONE WINDOW ───────────────────────────────────────────────
+    // Everything above holds with a single chip, which is exactly the configuration that
+    // cannot catch a cross-project bug. From here on there are two.
+
+    const chipNames = () => page.locator('.project-tab-name').allTextContents();
+    const activeChip = () => page.locator(".project-tab[data-active='true'] .project-tab-name").first().textContent();
+    /** The mount identity of each instance — a REMOUNT changes it, a hide does not. */
+    const instanceIds = () => page.locator('.project-instance').evaluateAll(
+      (els) => els.map((e) => e.getAttribute('data-instance')));
+
+    /** Every fresh vault raises its own "what's new" modal, including the second one. */
+    const clearScrims = async () => {
+      for (let i = 0; i < 4 && await scrim.count(); i += 1) {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(400);
+      }
+    };
+    /** The switcher lists a "Launcher" home row FIRST, so `.psw-row` first is not the vault. */
+    const pickProject = async (name) => {
+      await page.locator('.project-tabs-add').click();
+      await page.waitForSelector('.psw-input', { timeout: 10000 });
+      await page.locator('.psw-input').fill(name);
+      await page.locator('.psw-row')
+        .filter({ has: page.locator('.psw-row-name', { hasText: new RegExp(`^${name}$`) }) })
+        .first().click();
+    };
+
+    const openSecond = async () => {
+      await pickProject('scratch-b');
+      await page.waitForFunction(() => document.querySelectorAll('.project-tab').length === 2, null, { timeout: 15000 });
+      await clearScrims();
+    };
+    await openSecond().catch((e) => check('M1 the + button opens a second project', false, String(e.message ?? e)));
+
+    // M1 — both projects are chips, and BOTH are mounted. Two chips with one instance would
+    // mean the strip is a router, not a holder of live projects.
+    const names = await chipNames();
+    const ids = await instanceIds();
+    check('M1 two projects are open as two chips, both instances mounted',
+      names.length === 2 && names.includes('scratch-a') && names.includes('scratch-b') && ids.length === 2,
+      `chips=${JSON.stringify(names)} instances=${ids.length}`);
+
+    // M2 — exactly one is visible; the other is hidden AND inert. Inert matters on its own:
+    // a merely-invisible instance still takes focus and still answers the keyboard.
+    const visibility = await page.locator('.project-instance').evaluateAll((els) => els.map((e) => ({
+      hidden: e.hasAttribute('hidden'), inert: e.hasAttribute('inert'),
+      display: getComputedStyle(e).display,
+    })));
+    const shown = visibility.filter((v) => !v.hidden);
+    check('M2 exactly one instance is visible, the other hidden + inert + display:none',
+      shown.length === 1 && visibility.filter((v) => v.hidden).every((v) => v.inert && v.display === 'none'),
+      JSON.stringify(visibility));
+
+    // M3 — THE RED LINE, structurally: switching chips must HIDE, never remount. A changed
+    // `data-instance` is a torn-down instance, which is a killed PTY and a dropped socket
+    // mid-conversation. This is the automatable half of B2/B4; the streaming half still needs
+    // a real agent and is not claimed here.
+    const before = await instanceIds();
+    const other = (await activeChip())?.trim() === 'scratch-a' ? 'scratch-b' : 'scratch-a';
+    await page.locator('.project-tab-main', { hasText: other }).first().click();
+    await page.waitForTimeout(400);
+    const afterSwitch = await instanceIds();
+    const nowActive = (await activeChip())?.trim();
+    check('M3 switching chips hides the old instance rather than remounting it',
+      nowActive === other && JSON.stringify(before) === JSON.stringify(afterSwitch),
+      `active=${nowActive} ids ${JSON.stringify(before)} -> ${JSON.stringify(afterSwitch)}`);
+
+    // M4 — the same project can never be open twice (checklist B6, in-window half). Picking a
+    // project that already has a chip must FOCUS it, not mint a second instance against the
+    // same vault — two writers on one project's session roster is the failure being blocked.
+    await pickProject('scratch-a');
+    await page.waitForTimeout(700);
+    await clearScrims();
+    const dupNames = await chipNames();
+    const dupIds = await instanceIds();
+    check('M4 re-opening an already-open project focuses its chip instead of duplicating it',
+      dupNames.length === 2 && dupIds.length === 2 && (await activeChip())?.trim() === 'scratch-a',
+      `chips=${JSON.stringify(dupNames)} instances=${dupIds.length}`);
+
+    // S6 — judged LAST, so it covers every request both projects made: the boot, the reload,
+    // the second project's whole page load and both switches. A wrong vault reaching the
+    // server shows up here as 400 and nowhere else — the UI paints either way.
+    await page.waitForTimeout(1500);
+    check('S6 no /api/ request failed across both projects (400/401/403/5xx)',
+      apiFailures.length === 0,
+      apiFailures.length ? `${apiFailures.length} failures: ${apiFailures.slice(0, 6).join(' | ')}`
+        : 'every /api/ response 2xx/3xx (404 tolerated)');
+  }
+} catch (err) {
+  check('harness ran to completion', false, String(err && err.message ? err.message : err));
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  server.kill('SIGTERM');
+}
+
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) { console.log('FAILED:', failed.map((f) => f.name).join(', ')); process.exit(1); }

--- a/tests/unit/agent-ask-attention.test.ts
+++ b/tests/unit/agent-ask-attention.test.ts
@@ -2,27 +2,34 @@
  * Unit tests for `attention.ts` — the "Claude is asking" alarm that a fresh question
  * fires from both session engines (chat's `pushAsk`, the terminal's `onSettle`).
  *
- * Three properties are worth locking, because all three are invisible until they're wrong:
+ * Four properties are worth locking, because all four are invisible until they're wrong:
  *
- *   1. ONE interruption. The throttle is shared by chime + banner + Dock bounce, so two
- *      agents asking in the same breath produce one alarm, not two of each. This moved UP
- *      from chime.ts (which used to throttle only itself) when the banner and bounce were
- *      added — a per-transport throttle would have let the banner double while the chime
- *      stayed single.
- *   2. The banner is for someone who is ELSEWHERE. A system notification sliding over the
- *      very chat that raised it is noise, so a focused, visible window gets the chime only.
- *   3. The body says what is actually being asked, clipped to something scannable.
+ *   1. ONE interruption PER PROJECT. Within a project, agents asking in the same breath
+ *      produce one alarm rather than three of each. ACROSS projects they do not collapse:
+ *      one window now holds several live projects, and two of them asking a second apart are
+ *      two separate things the user has to answer — under the old single window-wide gate
+ *      the second one was silently dropped. The chime is the one transport that keeps a
+ *      window-wide floor, because it plays through a single shared AudioContext.
+ *   2. The banner is for someone who is ELSEWHERE — and "elsewhere" now includes another
+ *      CHIP in this same window. A focused window showing project A must still raise the
+ *      user when project B asks; only an alarm from the project on screen stays quiet.
+ *   3. With no chip probe registered (the launcher, the browser build), the alarm behaves
+ *      exactly as it did when a window held one project.
+ *   4. The body says what is actually being asked, clipped to something scannable.
  *
  * There is no jsdom/happy-dom in this repo (root vitest runs plain Node — see
  * checklist-store.test.ts), so `window`/`document`/`Notification` are shimmed here with the
  * minimal surface the module actually touches. `window` is deliberately a BARE object: no
  * `__TAURI_INTERNALS__`, so `isDesktop()` is false and the alarm takes its browser path —
- * which is the arm a Node test can observe. `AudioContext` is left undefined on purpose;
- * the chime swallows its own absence, and that it does so is part of the contract (a
- * headless/blocked audio context must never stop the banner).
+ * which is the arm a Node test can observe. `chime.ts` is mocked to a counter so the voices
+ * are countable in Node (it needs a real AudioContext to do anything else); swallowing a
+ * missing/blocked audio context is chime.ts's own contract, not this module's.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { raiseAskAttention } from '../../dashboard/src/lib/attention.js';
+import { raiseAskAttention, setChipActiveProbe } from '../../dashboard/src/lib/attention.js';
+import { playAskChime } from '../../dashboard/src/lib/chime.js';
+
+vi.mock('../../dashboard/src/lib/chime.js', () => ({ playAskChime: vi.fn() }));
 
 interface SentNotification { title: string; body?: string; tag?: string }
 
@@ -57,6 +64,7 @@ beforeEach(() => {
   clock += 60_000;
   vi.useFakeTimers();
   vi.setSystemTime(clock);
+  vi.mocked(playAskChime).mockClear();
   (globalThis as unknown as { window: unknown }).window = {}; // present, but not Tauri
   setWatching(false);
   installNotificationStub();
@@ -64,6 +72,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  // The probe is module state on `attention.ts` — a test that registers one must not leave
+  // it answering for the next test's alarms.
+  setChipActiveProbe(null);
 });
 
 /** Let the alarm's fire-and-forget transports settle (they are async, nobody awaits them). */
@@ -96,6 +107,34 @@ describe('raiseAskAttention — one alarm per interruption', () => {
     await settle();
     expect(sent.map((n) => n.body)).toEqual(['first', 'later']);
   });
+
+  it('keeps a burst inside ONE project to a single banner', async () => {
+    raiseAskAttention({ source: 'atlas', detail: 'first' });
+    raiseAskAttention({ source: 'atlas', detail: 'second' });
+    raiseAskAttention({ source: 'atlas', detail: 'third' });
+    await settle();
+    expect(sent.map((n) => n.body)).toEqual(['first']);
+  });
+
+  it('does NOT collapse two different projects — they are two interruptions', async () => {
+    raiseAskAttention({ source: 'atlas', detail: 'atlas asks' });
+    await vi.advanceTimersByTimeAsync(1000); // well inside the 1.5s gate
+    raiseAskAttention({ source: 'borealis', detail: 'borealis asks' });
+    await settle();
+    expect(sent.map((n) => n.title)).toEqual([
+      'Claude is asking · atlas',
+      'Claude is asking · borealis',
+    ]);
+  });
+
+  it('rings ONE chime for two projects asking together — one AudioContext, one voice', async () => {
+    raiseAskAttention({ source: 'atlas', detail: 'atlas asks' });
+    await vi.advanceTimersByTimeAsync(200);
+    raiseAskAttention({ source: 'borealis', detail: 'borealis asks' });
+    await settle();
+    expect(sent).toHaveLength(2); // two banners…
+    expect(playAskChime).toHaveBeenCalledTimes(1); // …one voice
+  });
 });
 
 describe('raiseAskAttention — the banner is for someone elsewhere', () => {
@@ -114,6 +153,52 @@ describe('raiseAskAttention — the banner is for someone elsewhere', () => {
     raiseAskAttention({ detail: 'minimized' });
     await settle();
     expect(sent).toHaveLength(1);
+  });
+});
+
+/**
+ * The headline scenario of the project-tabs work: one window, several live projects, and the
+ * one that is asking is not the one on screen. Window focus alone cannot answer that, so
+ * `WindowChrome` registers a probe saying which chip is visible.
+ */
+describe('raiseAskAttention — a background CHIP counts as elsewhere', () => {
+  it('raises for a project that is not the visible chip, even with the window focused', async () => {
+    setWatching(true);
+    setChipActiveProbe((vault) => vault === 'atlas');
+    raiseAskAttention({ source: 'borealis', detail: 'which branch should I use?' });
+    await settle();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].title).toBe('Claude is asking · borealis');
+  });
+
+  it('stays quiet for the project the user is looking straight at', async () => {
+    setWatching(true);
+    setChipActiveProbe((vault) => vault === 'atlas');
+    raiseAskAttention({ source: 'atlas', detail: 'you can already see this' });
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('with no probe registered, a focused window suppresses exactly as it always did', async () => {
+    setWatching(true);
+    raiseAskAttention({ source: 'atlas', detail: 'launcher / browser build — no chips' });
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('does not attribute a sourceless alarm to a background chip', async () => {
+    setWatching(true);
+    setChipActiveProbe((vault) => vault === 'atlas');
+    raiseAskAttention({ detail: 'no project pinned' });
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('still raises when the window itself is unfocused, whatever the probe says', async () => {
+    setChipActiveProbe(() => true); // claims "on screen"…
+    raiseAskAttention({ source: 'atlas', detail: 'window is in the background' });
+    await settle();
+    expect(sent).toHaveLength(1); // …but nobody is looking at the window at all
   });
 });
 

--- a/tests/unit/agent-ask-attention.test.ts
+++ b/tests/unit/agent-ask-attention.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for `attention.ts` — the "Claude is asking" alarm that a fresh question
+ * fires from both session engines (chat's `pushAsk`, the terminal's `onSettle`).
+ *
+ * Three properties are worth locking, because all three are invisible until they're wrong:
+ *
+ *   1. ONE interruption. The throttle is shared by chime + banner + Dock bounce, so two
+ *      agents asking in the same breath produce one alarm, not two of each. This moved UP
+ *      from chime.ts (which used to throttle only itself) when the banner and bounce were
+ *      added — a per-transport throttle would have let the banner double while the chime
+ *      stayed single.
+ *   2. The banner is for someone who is ELSEWHERE. A system notification sliding over the
+ *      very chat that raised it is noise, so a focused, visible window gets the chime only.
+ *   3. The body says what is actually being asked, clipped to something scannable.
+ *
+ * There is no jsdom/happy-dom in this repo (root vitest runs plain Node — see
+ * checklist-store.test.ts), so `window`/`document`/`Notification` are shimmed here with the
+ * minimal surface the module actually touches. `window` is deliberately a BARE object: no
+ * `__TAURI_INTERNALS__`, so `isDesktop()` is false and the alarm takes its browser path —
+ * which is the arm a Node test can observe. `AudioContext` is left undefined on purpose;
+ * the chime swallows its own absence, and that it does so is part of the contract (a
+ * headless/blocked audio context must never stop the banner).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { raiseAskAttention } from '../../dashboard/src/lib/attention.js';
+
+interface SentNotification { title: string; body?: string; tag?: string }
+
+let sent: SentNotification[] = [];
+
+/** Minimal `Notification` stand-in recording every banner the module posts. */
+function installNotificationStub(permission: NotificationPermission = 'granted'): void {
+  class NotificationStub {
+    static permission: NotificationPermission = permission;
+    static requestPermission = vi.fn(async () => NotificationStub.permission);
+    constructor(title: string, options?: { body?: string; tag?: string }) {
+      sent.push({ title, body: options?.body, tag: options?.tag });
+    }
+  }
+  (globalThis as unknown as { Notification: unknown }).Notification = NotificationStub;
+}
+
+/** Is the user looking straight at this window? Drives the banner/bounce gate. */
+function setWatching(watching: boolean): void {
+  (globalThis as unknown as { document: unknown }).document = {
+    visibilityState: watching ? 'visible' : 'hidden',
+    hasFocus: () => watching,
+  };
+}
+
+// The module-level throttle survives between tests, so each test starts on a clock far
+// enough ahead that the previous test's alarm can never suppress this one's first call.
+let clock = Date.UTC(2026, 0, 1);
+
+beforeEach(() => {
+  sent = [];
+  clock += 60_000;
+  vi.useFakeTimers();
+  vi.setSystemTime(clock);
+  (globalThis as unknown as { window: unknown }).window = {}; // present, but not Tauri
+  setWatching(false);
+  installNotificationStub();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Let the alarm's fire-and-forget transports settle (they are async, nobody awaits them). */
+async function settle(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe('raiseAskAttention — one alarm per interruption', () => {
+  it('posts a banner when the user is in another window', async () => {
+    raiseAskAttention({ source: 'dreamcontext', detail: 'Which auth method should we use?' });
+    await settle();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].title).toBe('Claude is asking · dreamcontext');
+    expect(sent[0].body).toBe('Which auth method should we use?');
+  });
+
+  it('collapses a burst of asks into a single banner', async () => {
+    raiseAskAttention({ detail: 'first' });
+    raiseAskAttention({ detail: 'second' }); // same breath — one interruption
+    raiseAskAttention({ detail: 'third' });
+    await settle();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].body).toBe('first');
+  });
+
+  it('raises again once the throttle window has passed', async () => {
+    raiseAskAttention({ detail: 'first' });
+    await vi.advanceTimersByTimeAsync(1600);
+    raiseAskAttention({ detail: 'later' });
+    await settle();
+    expect(sent.map((n) => n.body)).toEqual(['first', 'later']);
+  });
+});
+
+describe('raiseAskAttention — the banner is for someone elsewhere', () => {
+  it('stays silent while the window is focused and visible', async () => {
+    setWatching(true);
+    raiseAskAttention({ detail: 'you are already looking at this' });
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('a hidden-but-focused window still counts as away (backgrounded tab)', async () => {
+    (globalThis as unknown as { document: unknown }).document = {
+      visibilityState: 'hidden',
+      hasFocus: () => true,
+    };
+    raiseAskAttention({ detail: 'minimized' });
+    await settle();
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe('raiseAskAttention — banner copy', () => {
+  it('falls back to a generic title and body when the caller has neither', async () => {
+    raiseAskAttention();
+    await settle();
+    expect(sent[0].title).toBe('Claude is asking');
+    expect(sent[0].body).toBe('A question is waiting for your answer.');
+  });
+
+  it('treats a null/blank source or detail as absent (getActiveVault returns null)', async () => {
+    raiseAskAttention({ source: null, detail: '   ' });
+    await settle();
+    expect(sent[0].title).toBe('Claude is asking');
+    expect(sent[0].body).toBe('A question is waiting for your answer.');
+  });
+
+  it('flattens newlines and clips a long question to one scannable line', async () => {
+    raiseAskAttention({ detail: `Should we\n\n  ship it?  ${'x'.repeat(400)}` });
+    await settle();
+    const body = sent[0].body ?? '';
+    expect(body.startsWith('Should we ship it? xxx')).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(180);
+    expect(body.endsWith('…')).toBe(true);
+  });
+
+  it('tags the banner so a second ask replaces the first instead of stacking', async () => {
+    raiseAskAttention({ detail: 'anything' });
+    await settle();
+    expect(sent[0].tag).toBe('dreamcontext-ask');
+  });
+});
+
+describe('raiseAskAttention — degrades instead of throwing', () => {
+  it('posts nothing when notification permission is denied, and does not throw', async () => {
+    installNotificationStub('denied');
+    expect(() => raiseAskAttention({ detail: 'blocked' })).not.toThrow();
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('survives an environment with no Notification API at all', async () => {
+    delete (globalThis as unknown as { Notification?: unknown }).Notification;
+    expect(() => raiseAskAttention({ detail: 'no api' })).not.toThrow();
+    await settle();
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/tests/unit/agent-settings.test.ts
+++ b/tests/unit/agent-settings.test.ts
@@ -5,20 +5,48 @@
  * dashboard side only; the two are kept in lockstep by applying the identical rule per
  * field — verified by inspection, same convention as the existing renderer/chatView
  * coverage below). Focus: the `renderer` field added for the GPU/comfort terminal
- * toggle, the `chatView` field added for the Agent Chat view (beta) — task_nQb0y85X —
- * and `chatPermissionMode` added for the Agent Chat redesign's state-6 remembered
- * permission-mode dropdown. Contract for all three: the default (webgl / Chat / auto)
- * applies whenever the key is absent or garbage, and ONLY the documented explicit
- * opt-out value flips it, so an old persisted blob without the key never silently
- * changes behavior.
+ * toggle and the `chatView` field added for the Agent Chat view (beta) — task_nQb0y85X.
+ * Contract for both: the default (webgl / Chat) applies whenever the key is absent or
+ * garbage, and ONLY the documented explicit opt-out value flips it, so an old persisted
+ * blob without the key never silently changes behavior.
  *
  * `chatView` is the one field with a MIGRATION on top of that contract: Chat became the
  * standard Agent screen in 0.22, and every blob written before then carries a
  * `chatView:false` that came from the old opt-in default rather than from a user's
  * choice — so an explicit `false` is honoured only on a `screenMigrated` blob.
+ *
+ * `chatPermissionMode` USED to be a field of this blob and is now a per-vault value with
+ * its own accessors — a permission gate cannot be shared by every project living in one
+ * window. Its old coercion contract ("only an exact 'bypass' opts in") is unchanged and is
+ * asserted at the bottom of this file against `readChatPermissionMode`, alongside the
+ * isolation and legacy-drop rules that are new. `localStorage` is shimmed in-memory here
+ * for the same reason as in `scoped-storage.test.ts`: root vitest runs under plain Node.
  */
-import { describe, it, expect } from 'vitest';
-import { coerceAgentSettings, DEFAULT_AGENT_SETTINGS } from '../../dashboard/src/lib/agentSettings.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  coerceAgentSettings, DEFAULT_AGENT_SETTINGS,
+  readChatPermissionMode, writeChatPermissionMode,
+  CHAT_PERMISSION_MODE_KEY, CHAT_PERMISSION_MODE_EVENT,
+} from '../../dashboard/src/lib/agentSettings.js';
+import { SCOPE_PREFIX } from '../../dashboard/src/lib/scopedStorage.js';
+
+function makeLocalStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() { return store.size; },
+  } as unknown as Storage;
+}
+
+// `scopedStorage`'s migration latch is module-level and survives between tests in a file, so
+// each test below uses its OWN vault name rather than trying to reset it.
+beforeEach(() => {
+  (globalThis as unknown as { localStorage: Storage }).localStorage = makeLocalStorageStub();
+});
 
 describe('coerceAgentSettings renderer', () => {
   it('defaults to webgl when the key is absent (old persisted blob)', () => {
@@ -99,29 +127,63 @@ describe('coerceAgentSettings chatView (Chat is the default Agent screen, 0.22)'
   });
 });
 
-describe('coerceAgentSettings chatPermissionMode (Agent Chat redesign, state 6 remembered mode)', () => {
-  it('defaults to auto when the key is absent (old persisted blob)', () => {
-    expect(coerceAgentSettings({}).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings(null).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings(undefined).chatPermissionMode).toBe('auto');
-    expect(DEFAULT_AGENT_SETTINGS.chatPermissionMode).toBe('auto');
+describe('chatPermissionMode (per vault, split out of the global blob)', () => {
+  it('is NOT part of the app-global settings blob any more', () => {
+    // The whole point of the split: a permission gate cannot ride a blob that every project
+    // in the window shares. A stray `chatPermissionMode` in an old persisted blob is dropped
+    // on the floor by the coercer rather than being carried into the new shape.
+    expect(DEFAULT_AGENT_SETTINGS).not.toHaveProperty('chatPermissionMode');
+    expect(coerceAgentSettings({ chatPermissionMode: 'bypass' } as never)).not.toHaveProperty('chatPermissionMode');
+  });
+
+  it('defaults to auto when this vault has never chosen', () => {
+    expect(readChatPermissionMode('proj-unset')).toBe('auto');
+    expect(readChatPermissionMode(null)).toBe('auto');
   });
 
   it('honors an explicit bypass opt-in', () => {
-    expect(coerceAgentSettings({ chatPermissionMode: 'bypass' }).chatPermissionMode).toBe('bypass');
+    writeChatPermissionMode(new EventTarget(), 'proj-optin', 'bypass');
+    expect(readChatPermissionMode('proj-optin')).toBe('bypass');
   });
 
+  // Same contract the coercer used to hold, asserted on the new reader: ONLY an exact
+  // 'bypass' opts into the caution mode, so a stale or malformed value can never fail open.
   it('coerces garbage values to the auto default', () => {
-    expect(coerceAgentSettings({ chatPermissionMode: 'yes' as never }).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings({ chatPermissionMode: 1 as never }).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings({ chatPermissionMode: 'Bypass' as never }).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings({ chatPermissionMode: null as never }).chatPermissionMode).toBe('auto');
-    expect(coerceAgentSettings({ chatPermissionMode: undefined }).chatPermissionMode).toBe('auto');
+    for (const [i, garbage] of ['yes', '1', 'Bypass', 'null', '{"mode":"bypass"}', ''].entries()) {
+      const vault = `proj-garbage-${i}`;
+      localStorage.setItem(`${SCOPE_PREFIX}${vault}:${CHAT_PERMISSION_MODE_KEY}`, garbage);
+      expect(readChatPermissionMode(vault)).toBe('auto');
+    }
   });
 
-  it('keeps the pre-existing field contracts intact alongside chatPermissionMode (regression)', () => {
+  it('one project opting into bypass leaves every OTHER project on auto', () => {
+    // The defect the split exists for. With the value on the global blob, flipping bypass in
+    // one project rewrote the remembered default for every project in the window.
+    writeChatPermissionMode(new EventTarget(), 'proj-a', 'bypass');
+    expect(readChatPermissionMode('proj-a')).toBe('bypass');
+    expect(readChatPermissionMode('proj-b')).toBe('auto');
+  });
+
+  it('DROPS a pre-split global bypass instead of migrating it into every vault', () => {
+    // Deliberate: carrying the legacy value forward is the harm here — a `bypass` set once,
+    // when it meant "this window's project", would fan out to every project at once. The key
+    // is new, so nothing is at the legacy name to migrate and every vault starts at 'auto'.
+    localStorage.setItem(CHAT_PERMISSION_MODE_KEY, 'bypass');
+    expect(readChatPermissionMode('proj-legacy')).toBe('auto');
+  });
+
+  it('notifies the INSTANCE bus, never window', () => {
+    // A permission change must reach only the project it was made in.
+    const bus = new EventTarget();
+    let heard: string | null = null;
+    bus.addEventListener(CHAT_PERMISSION_MODE_EVENT, (e) => { heard = (e as CustomEvent<string>).detail; });
+    writeChatPermissionMode(bus, 'proj-bus', 'bypass');
+    expect(heard).toBe('bypass');
+  });
+
+  it('keeps the pre-existing field contracts intact after the split (regression)', () => {
     const cfg = coerceAgentSettings({
-      enabled: false, autoTitle: true, hotkey: '  ', renderer: 'dom', chatView: true, chatPermissionMode: 'bypass',
+      enabled: false, autoTitle: true, hotkey: '  ', renderer: 'dom', chatView: true,
     });
     expect(cfg.enabled).toBe(false);
     expect(cfg.restoreTabs).toBe(true);
@@ -129,6 +191,5 @@ describe('coerceAgentSettings chatPermissionMode (Agent Chat redesign, state 6 r
     expect(cfg.hotkey).toBe(DEFAULT_AGENT_SETTINGS.hotkey);
     expect(cfg.renderer).toBe('dom');
     expect(cfg.chatView).toBe(true);
-    expect(cfg.chatPermissionMode).toBe('bypass');
   });
 });

--- a/tests/unit/agent-status-project-rollup.test.ts
+++ b/tests/unit/agent-status-project-rollup.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for rollupProject — the project-level counterpart to rollupKind. A background
+ * project's chip in the tab strip needs three things at once: what colour to draw (worst-of
+ * urgency), what number to badge (how many chats are actually live), and whether to bounce
+ * (anything waiting on the user). Each is a distinct rule with its own failure mode, so each
+ * gets its own coverage rather than one blended assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveSessionStatus, rollupProject, KIND_RANK,
+  type SessionRow, type SessionStatusKind,
+} from '../../dashboard/src/components/sleepy/agentStatus.js';
+
+/** Minimal row factory — mirrors tests/unit/agent-status.test.ts's `row()` plus an
+ *  `attention` override, since rollupProject's `waiting` count reads that field too. */
+function row(
+  id: string,
+  kind: SessionStatusKind,
+  opts: { sessionKind?: SessionRow['kind']; attention?: boolean } = {},
+): SessionRow {
+  const infoByKind: Record<SessionStatusKind, () => SessionRow['info']> = {
+    saved: () => deriveSessionStatus({ dormant: true }),
+    starting: () => deriveSessionStatus({ status: 'connecting' }),
+    working: () => deriveSessionStatus({ status: 'open', busy: true }),
+    asking: () => deriveSessionStatus({ status: 'open', asking: true }),
+    ready: () => deriveSessionStatus({ status: 'open' }),
+    ended: () => deriveSessionStatus({ status: 'closed' }),
+  };
+  return {
+    id,
+    title: id,
+    kind: opts.sessionKind ?? 'agent',
+    info: infoByKind[kind](),
+    attention: opts.attention ?? false,
+  };
+}
+
+describe('rollupProject', () => {
+  it('worst is the KIND_RANK worst-of, same as rollupKind — asking beats working beats ready', () => {
+    expect(rollupProject([row('a', 'ready'), row('b', 'working')]).worst).toBe('working');
+    expect(rollupProject([row('a', 'working'), row('b', 'asking'), row('c', 'ended')]).worst).toBe('asking');
+    // Cross-check directly against KIND_RANK so this doesn't silently drift from the
+    // urgency order rollupKind is defined by.
+    const rows = [row('a', 'saved'), row('b', 'ready'), row('c', 'starting')];
+    const expectedWorst = rows.reduce<SessionStatusKind>(
+      (worst, r) => (KIND_RANK[r.info.kind] > KIND_RANK[worst] ? r.info.kind : worst),
+      'ended',
+    );
+    expect(rollupProject(rows).worst).toBe(expectedWorst);
+  });
+
+  it('excludes saved rows from live', () => {
+    const r = rollupProject([row('a', 'saved'), row('b', 'working')]);
+    expect(r.live).toBe(1);
+  });
+
+  it('excludes ended rows from live', () => {
+    const r = rollupProject([row('a', 'ended'), row('b', 'asking')]);
+    expect(r.live).toBe(1);
+  });
+
+  it('excludes shell rows from live even when the session is otherwise open/ready', () => {
+    const r = rollupProject([
+      row('a', 'ready', { sessionKind: 'shell' }),
+      row('b', 'working', { sessionKind: 'shell' }),
+      row('c', 'ready'),
+    ]);
+    expect(r.live).toBe(1);
+  });
+
+  it('REGRESSION LOCK — a project whose only row is a live shell reports live:0 (badge quiet) but alive:1 (must not be evicted)', () => {
+    const r = rollupProject([row('a', 'ready', { sessionKind: 'shell' })]);
+    expect(r.live).toBe(0);
+    expect(r.alive).toBe(1);
+  });
+
+  it('excludes saved and ended rows from alive too', () => {
+    const r = rollupProject([row('a', 'saved'), row('b', 'ended'), row('c', 'ready')]);
+    expect(r.alive).toBe(1);
+  });
+
+  it('a mixed project (one live chat + one live shell) reports live:1, alive:2', () => {
+    const r = rollupProject([row('a', 'working'), row('b', 'ready', { sessionKind: 'shell' })]);
+    expect(r.live).toBe(1);
+    expect(r.alive).toBe(2);
+  });
+
+  it('a row that is both asking and attention-flagged counts once in waiting', () => {
+    const r = rollupProject([row('a', 'asking', { attention: true })]);
+    expect(r.waiting).toBe(1);
+  });
+
+  it('attention alone (without asking) still counts toward waiting', () => {
+    const r = rollupProject([row('a', 'ready', { attention: true })]);
+    expect(r.waiting).toBe(1);
+  });
+
+  it('empty input reads as { worst: "ended", live: 0, waiting: 0, alive: 0 }, matching rollupKind', () => {
+    expect(rollupProject([])).toEqual({ worst: 'ended', live: 0, waiting: 0, alive: 0 });
+  });
+
+  it('a project of only dormant (saved) rows has live: 0 and alive: 0 — no badge, safely evictable', () => {
+    const r = rollupProject([row('a', 'saved'), row('b', 'saved')]);
+    expect(r.live).toBe(0);
+    expect(r.alive).toBe(0);
+    expect(r.worst).toBe('saved');
+  });
+});

--- a/tests/unit/automation-run-chat.test.ts
+++ b/tests/unit/automation-run-chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 /**
  * The automation-run → chat bridge (`dashboard/src/lib/automationRunChat.ts`).
@@ -7,39 +7,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
  * `chat-actions.test.ts` is: the module is pure TS with no React in it, and this suite
  * already reaches into `dashboard/src` by path.
  *
- * `requestAutomationRunChat` talks to `window`, which a node-environment vitest run does
- * not have — so the test installs a bare `EventTarget` as `window`. That is not a
- * convenience: it is exactly the contract the function needs (addEventListener /
- * dispatchEvent, dispatch running its listeners INLINE), so a stub that satisfies it
- * proves the real thing works for the reason the real thing works.
+ * This suite used to install a bare `EventTarget` as a fake `window`, because the request
+ * was broadcast there. It no longer needs one: `openAutomationRunChat` takes the caller's
+ * INSTANCE BUS explicitly, so a plain `new EventTarget()` per test IS the production object,
+ * not a stand-in for it — and the absence of any `window` in this file is itself the check
+ * that nothing crept back onto the global.
  */
 
-let listeners: Array<{ type: string; fn: EventListener }> = [];
-
-beforeEach(async () => {
-  const target = new EventTarget();
-  const realAdd = target.addEventListener.bind(target);
-  // Track registrations so each test can tear its own down — a leaked listener would make
-  // the "no surface mounted" case pass for the wrong reason in whatever test ran next.
-  (target as EventTarget & { addEventListener: EventTarget['addEventListener'] }).addEventListener = ((
-    type: string, fn: EventListener,
-  ) => {
-    listeners.push({ type, fn });
-    realAdd(type, fn);
-  }) as EventTarget['addEventListener'];
-  (globalThis as unknown as { window: EventTarget }).window = target;
-});
-
-afterEach(() => {
-  const target = (globalThis as unknown as { window?: EventTarget }).window;
-  for (const l of listeners) target?.removeEventListener(l.type, l.fn);
-  listeners = [];
-  delete (globalThis as unknown as { window?: EventTarget }).window;
-});
-
 async function load() {
-  // Imported AFTER the window stub exists. The module has no import-time window access
-  // today, and this ordering keeps the test honest if that ever changes.
   return import('../../dashboard/src/lib/automationRunChat.js');
 }
 
@@ -100,38 +75,41 @@ describe('runChatUnavailableReason', () => {
   });
 });
 
-describe('requestAutomationRunChat', () => {
+describe('openAutomationRunChat', () => {
   it('reports FALSE when no surface is mounted to take it', async () => {
-    const { requestAutomationRunChat } = await load();
+    const { openAutomationRunChat } = await load();
     // A button that silently does nothing is exactly what the ACK exists to prevent.
-    expect(requestAutomationRunChat(RUN)).toBe(false);
+    expect(openAutomationRunChat(new EventTarget(), RUN)).toBe(false);
   });
 
   it('reports FALSE when a mounted surface declines (guards rejected)', async () => {
-    const { requestAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const { openAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const bus = new EventTarget();
     // A listener that looks but never acks — not desktop, no claude CLI, Agents disabled.
-    window.addEventListener(AUTOMATION_RUN_CHAT_EVENT, () => { /* declines */ });
-    expect(requestAutomationRunChat(RUN)).toBe(false);
+    bus.addEventListener(AUTOMATION_RUN_CHAT_EVENT, () => { /* declines */ });
+    expect(openAutomationRunChat(bus, RUN)).toBe(false);
   });
 
   it('reports TRUE synchronously once the surface acks', async () => {
-    const { requestAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
-    window.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
+    const { openAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const bus = new EventTarget();
+    bus.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
       (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
     });
     // Synchronous by construction: dispatchEvent runs listeners inline. If anything async
     // is ever introduced between the dispatch and the read, this is the test that fails.
-    expect(requestAutomationRunChat(RUN)).toBe(true);
+    expect(openAutomationRunChat(bus, RUN)).toBe(true);
   });
 
   it('carries every field the resumed tab needs to describe itself', async () => {
-    const { requestAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const { openAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const bus = new EventTarget();
     let seen: Record<string, unknown> | null = null;
-    window.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
+    bus.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
       seen = { ...(e as CustomEvent).detail };
       (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
     });
-    requestAutomationRunChat(RUN);
+    openAutomationRunChat(bus, RUN);
     expect(seen).toMatchObject(RUN);
     // `seen` is the detail as it ARRIVED (copied before this listener acked): the ACK field
     // must start false. A detail that arrived pre-accepted would make the surface's answer
@@ -140,13 +118,31 @@ describe('requestAutomationRunChat', () => {
   });
 
   it('never mutates the caller\'s run object', async () => {
-    const { requestAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
-    window.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
+    const { openAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    const bus = new EventTarget();
+    bus.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
       (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
     });
     const original = { ...RUN };
-    requestAutomationRunChat(RUN);
+    openAutomationRunChat(bus, RUN);
     expect(RUN).toEqual(original);
     expect('accepted' in RUN).toBe(false);
+  });
+
+  it('reaches ONLY the project it was asked of (M0)', async () => {
+    const { openAutomationRunChat, AUTOMATION_RUN_CHAT_EVENT } = await load();
+    // Two live projects in one window, each with its own agent surface listening on its own
+    // bus. Broadcast, B would also `--resume` A's conversation uuid — two live CLIs appending
+    // to one transcript, neither seeing the other's turns — and whichever listener ran first
+    // would set the ACK, so A's panel could report success for a tab that opened in B.
+    const busA = new EventTarget();
+    const busB = new EventTarget();
+    let bSaw = 0;
+    busA.addEventListener(AUTOMATION_RUN_CHAT_EVENT, (e) => {
+      (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
+    });
+    busB.addEventListener(AUTOMATION_RUN_CHAT_EVENT, () => { bSaw += 1; });
+    expect(openAutomationRunChat(busA, RUN)).toBe(true);
+    expect(bSaw).toBe(0);
   });
 });

--- a/tests/unit/chat-entities.test.ts
+++ b/tests/unit/chat-entities.test.ts
@@ -1588,40 +1588,48 @@ describe('stepHistory', () => {
 // Replaying a known natural size reserves the box up front. (Measured: an unreserved image
 // in this transcript's CSS goes 2px → 420px on load; a reserved one is 420px throughout.)
 
+// Every box below is remembered PER VAULT. A reference is a bare relative path, so
+// `shots/a.png` names a different file in every project — one shared map would replay one
+// project's aspect ratio onto another's image, and one shared 400-entry bound would let a
+// busy project evict a quiet one's boxes. `V` is this block's project unless a test is
+// specifically about two of them.
+
+const V = 'boxes-vault';
+
 describe('remembered image boxes', () => {
   it('an image never displayed has no remembered box', () => {
-    expect(knownMediaBox('never/seen/at/all.png')).toBeNull();
+    expect(knownMediaBox(V, 'never/seen/at/all.png')).toBeNull();
   });
 
   it('remembers a natural size and replays it for the next element built for that path', () => {
-    rememberMediaBox('shots/a.png', 1200, 800);
-    expect(knownMediaBox('shots/a.png')).toEqual({ w: 1200, h: 800 });
+    rememberMediaBox(V, 'shots/a.png', 1200, 800);
+    expect(knownMediaBox(V, 'shots/a.png')).toEqual({ w: 1200, h: 800 });
   });
 
   it('a file that changed shape overwrites the stale box rather than keeping it', () => {
-    rememberMediaBox('shots/b.png', 800, 600);
-    rememberMediaBox('shots/b.png', 640, 640);
-    expect(knownMediaBox('shots/b.png')).toEqual({ w: 640, h: 640 });
+    rememberMediaBox(V, 'shots/b.png', 800, 600);
+    rememberMediaBox(V, 'shots/b.png', 640, 640);
+    expect(knownMediaBox(V, 'shots/b.png')).toEqual({ w: 640, h: 640 });
   });
 
   it('refuses a size that is not an aspect ratio — a NaN box would reserve unpredictable height', () => {
     for (const [w, h] of [[0, 100], [100, 0], [-5, 5], [Number.NaN, 10], [10, Number.POSITIVE_INFINITY]]) {
-      rememberMediaBox('shots/bad.png', w, h);
-      expect(knownMediaBox('shots/bad.png')).toBeNull();
+      rememberMediaBox(V, 'shots/bad.png', w, h);
+      expect(knownMediaBox(V, 'shots/bad.png')).toBeNull();
     }
   });
 
   it('a decode that reports 0x0 (a failed image) never displaces a good remembered box', () => {
-    rememberMediaBox('shots/c.png', 900, 300);
-    rememberMediaBox('shots/c.png', 0, 0);
-    expect(knownMediaBox('shots/c.png')).toEqual({ w: 900, h: 300 });
+    rememberMediaBox(V, 'shots/c.png', 900, 300);
+    rememberMediaBox(V, 'shots/c.png', 0, 0);
+    expect(knownMediaBox(V, 'shots/c.png')).toEqual({ w: 900, h: 300 });
   });
 
   it('is bounded — the oldest box goes, not the newest arrival', () => {
-    rememberMediaBox('evict/oldest.png', 10, 10);
-    for (let i = 0; i < 420; i += 1) rememberMediaBox(`evict/filler-${i}.png`, 30, 40);
-    expect(knownMediaBox('evict/oldest.png')).toBeNull();
-    expect(knownMediaBox('evict/filler-419.png')).toEqual({ w: 30, h: 40 });
+    rememberMediaBox(V, 'evict/oldest.png', 10, 10);
+    for (let i = 0; i < 420; i += 1) rememberMediaBox(V, `evict/filler-${i}.png`, 30, 40);
+    expect(knownMediaBox(V, 'evict/oldest.png')).toBeNull();
+    expect(knownMediaBox(V, 'evict/filler-419.png')).toEqual({ w: 30, h: 40 });
   });
 
   it('re-seeing an UNCHANGED image refreshes its place in the queue', () => {
@@ -1629,12 +1637,30 @@ describe('remembered image boxes', () => {
     // it is exactly the signal that this image is still being looked at. Without the refresh
     // a screenshot the reader keeps scrolling past is evicted by images they passed once,
     // and the reveal it is mounted in grows under them again.
-    rememberMediaBox('lru/kept.png', 20, 20);
-    for (let i = 0; i < 399; i += 1) rememberMediaBox(`lru/fill-a-${i}.png`, 30, 40);
-    expect(knownMediaBox('lru/kept.png')).toEqual({ w: 20, h: 20 }); // at the cap, still in
-    rememberMediaBox('lru/kept.png', 20, 20);                        // same size — a refresh
-    for (let i = 0; i < 300; i += 1) rememberMediaBox(`lru/fill-b-${i}.png`, 30, 40);
-    expect(knownMediaBox('lru/kept.png')).toEqual({ w: 20, h: 20 });
+    rememberMediaBox(V, 'lru/kept.png', 20, 20);
+    for (let i = 0; i < 399; i += 1) rememberMediaBox(V, `lru/fill-a-${i}.png`, 30, 40);
+    expect(knownMediaBox(V, 'lru/kept.png')).toEqual({ w: 20, h: 20 }); // at the cap, still in
+    rememberMediaBox(V, 'lru/kept.png', 20, 20);                        // same size — a refresh
+    for (let i = 0; i < 300; i += 1) rememberMediaBox(V, `lru/fill-b-${i}.png`, 30, 40);
+    expect(knownMediaBox(V, 'lru/kept.png')).toEqual({ w: 20, h: 20 });
+  });
+
+  it('two projects sharing a relative path keep SEPARATE boxes', () => {
+    // The cross-project defect: both projects keep screenshots under `shots/`, and one
+    // window now holds both. Project A's 1200×800 must never be reserved for B's image.
+    rememberMediaBox('proj-a', 'shots/shared-name.png', 1200, 800);
+    rememberMediaBox('proj-b', 'shots/shared-name.png', 400, 400);
+    expect(knownMediaBox('proj-a', 'shots/shared-name.png')).toEqual({ w: 1200, h: 800 });
+    expect(knownMediaBox('proj-b', 'shots/shared-name.png')).toEqual({ w: 400, h: 400 });
+    // A third project has simply never seen it — not "inherits whoever loaded first".
+    expect(knownMediaBox('proj-c', 'shots/shared-name.png')).toBeNull();
+  });
+
+  it('one project filling its cache does not evict another project’s boxes', () => {
+    // The bound is per vault, so a busy project cannot push a quiet one's screenshots out.
+    rememberMediaBox('quiet-proj', 'keep/me.png', 50, 50);
+    for (let i = 0; i < 420; i += 1) rememberMediaBox('busy-proj', `flood/${i}.png`, 30, 40);
+    expect(knownMediaBox('quiet-proj', 'keep/me.png')).toEqual({ w: 50, h: 50 });
   });
 });
 

--- a/tests/unit/chat-reveal-path.test.ts
+++ b/tests/unit/chat-reveal-path.test.ts
@@ -11,9 +11,14 @@
  * `fetch` is stubbed, so no server and no OS opener are involved.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import { ApiClient } from '../../dashboard/src/api/client.js';
 import { revealPath } from '../../dashboard/src/components/sleepy/chat/chatEntities.js';
 
 const realFetch = globalThis.fetch;
+// `revealPath` now takes its client as a parameter (one window can hold several live
+// projects) — no vault pinned, matching what the old module-global `api` singleton read in
+// this test environment (nothing ever called `setActiveVault`).
+const api = new ApiClient(null);
 
 /** A stubbed `fetch` answering one status + JSON body, recording what it was called with. */
 function stubFetch(status: number, body: Record<string, unknown>): { calls: Array<[string, RequestInit]> } {
@@ -34,12 +39,12 @@ afterEach(() => { globalThis.fetch = realFetch; });
 describe('revealPath', () => {
   it('resolves null when the OS took the path — nothing for the caller to say', async () => {
     stubFetch(200, { opened: true });
-    await expect(revealPath('_dream_context/tmp/shot.png')).resolves.toBeNull();
+    await expect(revealPath(api, '_dream_context/tmp/shot.png')).resolves.toBeNull();
   });
 
   it('POSTs the path verbatim to the reveal route, letting the route decide by default', async () => {
     const { calls } = stubFetch(200, { opened: true });
-    await revealPath('_dream_context/tmp/shot.png');
+    await revealPath(api, '_dream_context/tmp/shot.png');
     const [url, init] = calls[0];
     expect(url).toContain('/api/agent/reveal');
     expect(init.method).toBe('POST');
@@ -51,7 +56,7 @@ describe('revealPath', () => {
   // never be SHOWN in the file manager, only opened.
   it('asks for the file manager outright when told to', async () => {
     const { calls } = stubFetch(200, { opened: true, mode: 'reveal' });
-    await expect(revealPath('_dream_context/tmp/shot.png', 'reveal')).resolves.toBeNull();
+    await expect(revealPath(api, '_dream_context/tmp/shot.png', 'reveal')).resolves.toBeNull();
     expect(JSON.parse(String(calls[0][1].body))).toEqual({ path: '_dream_context/tmp/shot.png', mode: 'reveal' });
   });
 
@@ -60,7 +65,7 @@ describe('revealPath', () => {
   // reported as a failure, or `handleAction`'s reveal case would open a panel on top of it.
   it('treats the executable downgrade as success, not something to report', async () => {
     stubFetch(200, { opened: true, mode: 'reveal' });
-    await expect(revealPath('/tmp/install.sh')).resolves.toBeNull();
+    await expect(revealPath(api, '/tmp/install.sh')).resolves.toBeNull();
   });
 
   // The words are the UI's, not the route's. "Path escapes the project root" is a correct
@@ -69,24 +74,24 @@ describe('revealPath', () => {
   // itself, so the `error` slug is what these map from.
   it('says a missing file is missing, in words meant for a person', async () => {
     stubFetch(404, { error: 'not_found', message: 'Not found: /tmp/gone.png' });
-    const said = await revealPath('/tmp/gone.png');
+    const said = await revealPath(api, '/tmp/gone.png');
     expect(said).toBe('this file isn’t there any more');
     expect(said).not.toContain('/tmp/gone.png');
   });
 
   it('says the desktop gate plainly instead of looking like a no-op in the browser', async () => {
     stubFetch(403, { error: 'desktop_only', message: 'Available only in the desktop app.' });
-    await expect(revealPath('/tmp/shot.png')).resolves.toBe('only available in the desktop app');
+    await expect(revealPath(api, '/tmp/shot.png')).resolves.toBe('only available in the desktop app');
   });
 
   it('still says SOMETHING when the request never lands (server down, offline)', async () => {
     globalThis.fetch = vi.fn(async () => { throw new Error(''); }) as unknown as typeof fetch;
-    await expect(revealPath('/tmp/shot.png')).resolves.toBe('couldn’t open this one');
+    await expect(revealPath(api, '/tmp/shot.png')).resolves.toBe('couldn’t open this one');
   });
 
   it('never leaks a raw route message, whatever the failure was', async () => {
     stubFetch(500, { error: 'open_failed', message: 'The system opener could not be started.' });
-    await expect(revealPath('/tmp/shot.png')).resolves.toBe('couldn’t open this one');
+    await expect(revealPath(api, '/tmp/shot.png')).resolves.toBe('couldn’t open this one');
   });
 
   // A rejection here would take down whatever drew the button; the contract is that it
@@ -94,7 +99,7 @@ describe('revealPath', () => {
   it('never rejects, whatever the route did', async () => {
     for (const status of [200, 400, 403, 404, 500]) {
       stubFetch(status, { message: 'nope' });
-      await expect(revealPath('/tmp/x.png')).resolves.not.toThrow();
+      await expect(revealPath(api, '/tmp/x.png')).resolves.not.toThrow();
     }
   });
 
@@ -102,6 +107,6 @@ describe('revealPath', () => {
   // a real file, the route opens it, and there is nothing to say.
   it('says nothing at all for the reference from the 07-28 report', async () => {
     stubFetch(200, { opened: true });
-    await expect(revealPath('../../tmp/dc-verify-auto/automations-light.png')).resolves.toBeNull();
+    await expect(revealPath(api, '../../tmp/dc-verify-auto/automations-light.png')).resolves.toBeNull();
   });
 });

--- a/tests/unit/delegate-agent.test.ts
+++ b/tests/unit/delegate-agent.test.ts
@@ -30,7 +30,8 @@ vi.mock('../../dashboard/src/api/client', () => ({
   getActiveVault: () => 'test-vault',
 }));
 
-const { buildDelegatePrompt } = await import('../../dashboard/src/lib/delegateAgent');
+const { buildDelegatePrompt, requestDelegateAgent, DELEGATE_AGENT_EVENT } =
+  await import('../../dashboard/src/lib/delegateAgent');
 const { encodedPromptLen, promptFitsInline, preparePrompt, MAX_PROMPT_ENCODED } =
   await import('../../dashboard/src/lib/agentPrompt');
 
@@ -76,19 +77,19 @@ describe('agentPrompt — inline ceiling', () => {
 describe('agentPrompt — preparePrompt routing', () => {
   it('inlines a short prompt with NO server round-trip', async () => {
     const p = 'Do the thing.';
-    await expect(preparePrompt(p)).resolves.toEqual({ inline: p, token: '' });
+    await expect(preparePrompt('test-vault', p)).resolves.toEqual({ inline: p, token: '' });
     expect(post).not.toHaveBeenCalled();
   });
 
   it('mints a token for an oversized prompt and inlines nothing', async () => {
     const huge = 'x'.repeat(MAX_PROMPT_ENCODED * 3);
-    await expect(preparePrompt(huge)).resolves.toEqual({ inline: '', token: 'tok-123' });
+    await expect(preparePrompt('test-vault', huge)).resolves.toEqual({ inline: '', token: 'tok-123' });
     expect(post).toHaveBeenCalledWith('/agent/prompt', { vault: 'test-vault', prompt: huge });
   });
 
   it('sends the prompt WHOLE — the token path must not truncate', async () => {
     const huge = `HEAD${'x'.repeat(MAX_PROMPT_ENCODED * 3)}TAIL`;
-    await preparePrompt(huge);
+    await preparePrompt('test-vault', huge);
     const sent = (post.mock.calls[0][1] as { prompt: string }).prompt;
     expect(sent).toBe(huge);
     expect(sent).toContain('TAIL'); // the exact content the old truncation would have shed
@@ -96,12 +97,17 @@ describe('agentPrompt — preparePrompt routing', () => {
 
   it('REJECTS rather than degrading when the server refuses a token', async () => {
     post.mockRejectedValue(new Error('desktop_only'));
-    await expect(preparePrompt('y'.repeat(MAX_PROMPT_ENCODED * 3))).rejects.toThrow('desktop_only');
+    // A real vault, not null: this exercises the SERVER-REFUSAL path (api.post rejects), not
+    // the missing-vault guard — passing null here would throw "No vault is active" instead and
+    // the assertion below would fail for the wrong reason.
+    await expect(preparePrompt('test-vault', 'y'.repeat(MAX_PROMPT_ENCODED * 3))).rejects.toThrow('desktop_only');
   });
 
   it('rejects a malformed token response instead of returning an empty token', async () => {
     post.mockResolvedValue({ ok: true, token: '' });
-    await expect(preparePrompt('z'.repeat(MAX_PROMPT_ENCODED * 3))).rejects.toThrow(/token/i);
+    // Same reasoning as above: a real vault, so the failure exercised is the malformed-response
+    // guard inside mintPromptToken, not the "no vault pinned" guard ahead of it.
+    await expect(preparePrompt('test-vault', 'z'.repeat(MAX_PROMPT_ENCODED * 3))).rejects.toThrow(/token/i);
   });
 });
 
@@ -128,6 +134,50 @@ describe('delegateAgent — buildDelegatePrompt', () => {
 
   it('uses the caller-supplied title verbatim (no drift from the tab title)', () => {
     expect(buildDelegatePrompt(task({ slug: 'a-b-c', name: '' }), 'a b c')).toContain('Task: a b c');
+  });
+});
+
+// ── The delegate lands in the project it was delegated FROM (finding M0) ────────────────
+// The worst failure this refactor had to fix. One window now holds several live projects, so
+// while this event was broadcast on `window` every mounted `AgentSurface` heard it — and the
+// ACK is written back onto the payload SYNCHRONOUSLY by the listener, so the FIRST one to run
+// claimed the delegate. The composer in project A was told "Delegated ✓" while the agent
+// doing the work sat in project B, against B's repo, reading a
+// `_dream_context/state/<slug>.md` that does not exist there. The bus is what makes the ACK
+// mean "the project I delegated from took it".
+const DETAIL = { title: 'T', prompt: 'do it', promptToken: '', bypass: false };
+
+describe('delegateAgent — requestDelegateAgent is scoped to one project', () => {
+  it('reports FALSE when no surface on that bus takes it', () => {
+    expect(requestDelegateAgent(new EventTarget(), { ...DETAIL })).toBe(false);
+  });
+
+  it('reports TRUE synchronously once that project\'s surface acks', () => {
+    const bus = new EventTarget();
+    bus.addEventListener(DELEGATE_AGENT_EVENT, (e) => {
+      (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
+    });
+    // Synchronous by construction: dispatch runs listeners inline, so the ACK is readable on
+    // the next line. An `await` anywhere between the two makes this the failing test.
+    expect(requestDelegateAgent(bus, { ...DETAIL })).toBe(true);
+  });
+
+  it('never reaches another live project, and never lets it answer', () => {
+    const busA = new EventTarget();
+    const busB = new EventTarget();
+    let bSaw = 0;
+    // B is the eager one — it would have claimed the delegate on `window` (listeners fire in
+    // registration order, and B's surface may well have mounted first).
+    busB.addEventListener(DELEGATE_AGENT_EVENT, (e) => {
+      bSaw += 1;
+      (e as CustomEvent<{ accepted?: boolean }>).detail.accepted = true;
+    });
+    // A declines (its guards rejected: not desktop / prereqs missing / surface disabled).
+    busA.addEventListener(DELEGATE_AGENT_EVENT, () => { /* declines */ });
+    // The honest answer is FALSE. A `true` here would be the exact lie M0 describes: B's ACK
+    // answering for a hand-off A never accepted.
+    expect(requestDelegateAgent(busA, { ...DETAIL })).toBe(false);
+    expect(bSaw).toBe(0);
   });
 });
 
@@ -185,7 +235,7 @@ describe('delegateAgent — every real task in the vault is delegable intact', (
       const { slug, prompt } = built;
 
       post.mockClear();
-      const { inline, token } = await preparePrompt(prompt);
+      const { inline, token } = await preparePrompt('test-vault', prompt);
 
       // Exactly one transport, and whichever it is must carry the prompt unmodified.
       if (token) {

--- a/tests/unit/overlay-stack-scope.test.ts
+++ b/tests/unit/overlay-stack-scope.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for `overlayStack.ts` — who owns the Escape key when one window holds several
+ * projects at once.
+ *
+ * The stack used to be a single flat LIFO, which was correct while a window held exactly one
+ * project: "the front-most overlay" and "the overlay the user can see" were the same thing.
+ * They are not any more. Every project instance stays MOUNTED when its chip goes to the
+ * background — that is the whole point of the design, so a running agent survives a switch —
+ * and a mounted overlay's Escape handler is still registered on `window` and still fires.
+ *
+ * Two symmetric failures follow from one shared stack, and both are locked here:
+ *
+ *   A) Esc goes DEAF in the foreground. Panel open in A, switch to B, panel open in B,
+ *      switch back to A. A's panel is the one on screen; B's entry is topmost; Esc in A
+ *      does nothing and the panel cannot be dismissed.
+ *   B) Esc hits the WRONG project. The same two panels, background pushed last. Esc in B
+ *      closes A's invisible panel and leaves B's open — a keystroke acting on a project the
+ *      user is not looking at.
+ *
+ * The fix is that entries remember the scope they were pushed in and Esc is answered per
+ * scope. `scope === null` (no `WindowChrome`: the launcher, the browser build, these tests
+ * before a scope is set) must keep the old flat behaviour EXACTLY — that path is what every
+ * single-surface window still runs.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  pushOverlay, popOverlay, isTopOverlay, setActiveOverlayScope, resetOverlayStack,
+} from '../../dashboard/src/lib/overlayStack.js';
+
+beforeEach(() => resetOverlayStack());
+
+describe('overlayStack — unscoped (one project per window, the legacy path)', () => {
+  it('the last overlay pushed owns Esc', () => {
+    pushOverlay('palette');
+    expect(isTopOverlay('palette')).toBe(true);
+    pushOverlay('picker');
+    expect(isTopOverlay('picker')).toBe(true);
+    expect(isTopOverlay('palette')).toBe(false);
+  });
+
+  it('closing the top hands Esc back to the one underneath', () => {
+    pushOverlay('palette');
+    pushOverlay('picker');
+    popOverlay('picker');
+    expect(isTopOverlay('palette')).toBe(true);
+  });
+
+  it('an overlay that was never pushed never owns Esc', () => {
+    expect(isTopOverlay('nobody')).toBe(false);
+    pushOverlay('palette');
+    expect(isTopOverlay('nobody')).toBe(false);
+  });
+
+  it('re-pushing an open overlay moves it to the top rather than duplicating it', () => {
+    pushOverlay('a');
+    pushOverlay('b');
+    pushOverlay('a');
+    expect(isTopOverlay('a')).toBe(true);
+    // One entry, not two: a single pop must fully close it.
+    popOverlay('a');
+    expect(isTopOverlay('b')).toBe(true);
+    expect(isTopOverlay('a')).toBe(false);
+  });
+});
+
+describe('overlayStack — several projects live in one window', () => {
+  it('REGRESSION A: the foreground project keeps Esc even when the background pushed later', () => {
+    // Panel open in A…
+    setActiveOverlayScope('inst-a');
+    pushOverlay('inst-a::panel');
+    // …switch to B, panel open in B (pushed LAST — this is what used to win)…
+    setActiveOverlayScope('inst-b');
+    pushOverlay('inst-b::panel');
+    expect(isTopOverlay('inst-b::panel')).toBe(true);
+    // …switch back to A. A's panel is the one on screen, so A's panel answers Esc.
+    setActiveOverlayScope('inst-a');
+    expect(isTopOverlay('inst-a::panel')).toBe(true);
+    expect(isTopOverlay('inst-b::panel')).toBe(false);
+  });
+
+  it('REGRESSION B: a background overlay never answers Esc, however recently it was pushed', () => {
+    setActiveOverlayScope('inst-b');
+    pushOverlay('inst-b::panel');
+    setActiveOverlayScope('inst-a');
+    pushOverlay('inst-a::panel');   // pushed last, but A is about to go to the background
+    setActiveOverlayScope('inst-b');
+    expect(isTopOverlay('inst-a::panel')).toBe(false); // invisible — must not eat the key
+    expect(isTopOverlay('inst-b::panel')).toBe(true);  // the one on screen gets it
+  });
+
+  it('stacking still works WITHIN the foreground project', () => {
+    setActiveOverlayScope('inst-a');
+    pushOverlay('inst-a::panel');
+    pushOverlay('inst-a::palette');   // opened on top of the panel
+    expect(isTopOverlay('inst-a::palette')).toBe(true);
+    expect(isTopOverlay('inst-a::panel')).toBe(false);
+    popOverlay('inst-a::palette');
+    expect(isTopOverlay('inst-a::panel')).toBe(true);
+  });
+
+  it('a background project\'s overlays are untouched — switching back finds them as they were', () => {
+    setActiveOverlayScope('inst-a');
+    pushOverlay('inst-a::panel');
+    pushOverlay('inst-a::palette');
+    setActiveOverlayScope('inst-b');
+    expect(isTopOverlay('inst-a::palette')).toBe(false);
+    setActiveOverlayScope('inst-a');
+    // Same LIFO order it had before the trip: the stack is scoped, not cleared.
+    expect(isTopOverlay('inst-a::palette')).toBe(true);
+    popOverlay('inst-a::palette');
+    expect(isTopOverlay('inst-a::panel')).toBe(true);
+  });
+
+  it('no overlay open in the foreground means nobody owns Esc', () => {
+    setActiveOverlayScope('inst-a');
+    pushOverlay('inst-a::panel');
+    setActiveOverlayScope('inst-b');
+    expect(isTopOverlay('inst-a::panel')).toBe(false);
+    expect(isTopOverlay('inst-b::panel')).toBe(false);
+  });
+
+  it('a revived cold chip does not inherit the dead instance\'s overlays', () => {
+    // Closing a project at the ceiling tears the instance down; reopening mints a NEW id.
+    setActiveOverlayScope('inst-a-1');
+    pushOverlay('inst-a-1::panel');
+    setActiveOverlayScope('inst-a-2');            // same vault, fresh instance
+    expect(isTopOverlay('inst-a-1::panel')).toBe(false);
+    pushOverlay('inst-a-2::panel');
+    expect(isTopOverlay('inst-a-2::panel')).toBe(true);
+  });
+
+  it('an id-less popover (useId, no vault prefix) still owns Esc in the project it opened in', () => {
+    // `RangeControl` / `FunnelOverviewPage` / `SkillPickerPopover` build ids from `useId()`
+    // and know nothing about vaults. Scope is captured at PUSH time precisely so those keep
+    // working without every popover having to become vault-aware.
+    setActiveOverlayScope('inst-a');
+    pushOverlay(':r7:');
+    expect(isTopOverlay(':r7:')).toBe(true);
+    setActiveOverlayScope('inst-b');
+    expect(isTopOverlay(':r7:')).toBe(false);
+  });
+
+  it('an entry pushed before any scope existed answers in every scope', () => {
+    // The launcher and the browser build never set a scope. Such an entry must not become
+    // undismissable just because some other surface later declared one.
+    pushOverlay('unscoped');
+    setActiveOverlayScope('inst-a');
+    expect(isTopOverlay('unscoped')).toBe(true);
+  });
+});

--- a/tests/unit/scoped-storage.test.ts
+++ b/tests/unit/scoped-storage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for `scopedStorage.ts` — the per-project localStorage namespace that one
+ * window holding N live projects depends on. Two things are load-bearing and locked here:
+ * a null vault must behave EXACTLY as the app did before scoping existed (the launcher and
+ * the plain browser build read the legacy key verbatim), and the legacy→scoped migration
+ * must be a MOVE that happens at most once, because the second project to read a legacy key
+ * inheriting the first project's value is precisely the cross-project bug this module exists
+ * to prevent.
+ *
+ * There is no jsdom/happy-dom in this repo (root vitest runs under plain Node), so
+ * `localStorage` is shimmed with a minimal in-memory object implementing the real `Storage`
+ * surface. The module's migration latch is a module-level Set that survives between tests in
+ * this file, so every test uses its OWN vault/key names rather than trying to reset it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  SCOPE_PREFIX, scopedKey,
+  readScopedRaw, writeScopedRaw, readScoped, writeScoped, removeScoped,
+} from '../../dashboard/src/lib/scopedStorage.js';
+
+function makeLocalStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() { return store.size; },
+  } as unknown as Storage;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { localStorage: Storage }).localStorage = makeLocalStorageStub();
+});
+
+// ─── key shape ────────────────────────────────────────────────────────────────
+
+describe('scopedKey', () => {
+  it('a null vault yields the LEGACY key verbatim — never a prefixed one', () => {
+    expect(scopedKey(null, 'dreamcontext.dashboard.activePage')).toBe('dreamcontext.dashboard.activePage');
+    expect(scopedKey(null, 'x')).not.toContain(SCOPE_PREFIX);
+  });
+
+  it('a real vault yields `dreamcontext:<vault>:<key>`', () => {
+    expect(scopedKey('alpha', 'activePage')).toBe(`${SCOPE_PREFIX}alpha:activePage`);
+  });
+
+  it('two vaults never share a key', () => {
+    expect(scopedKey('alpha', 'k')).not.toBe(scopedKey('beta', 'k'));
+  });
+
+  it('an empty vault name counts as no vault (`?vault=` with no value is launcher mode)', () => {
+    expect(scopedKey('', 'k')).toBe('k');
+  });
+});
+
+// ─── null vault: byte-identical to pre-scoping behaviour ──────────────────────
+
+describe('a null vault touches only the legacy key', () => {
+  it('reads and writes the bare key, and migrates nothing', () => {
+    localStorage.setItem('legacy.null.k', 'from-before');
+    expect(readScopedRaw(null, 'legacy.null.k')).toBe('from-before');
+
+    writeScopedRaw(null, 'legacy.null.k', 'updated');
+    expect(localStorage.getItem('legacy.null.k')).toBe('updated');
+    expect(localStorage.getItem(`${SCOPE_PREFIX}:legacy.null.k`)).toBeNull();
+  });
+});
+
+// ─── migration: a MOVE, once, to the first reader ─────────────────────────────
+
+describe('legacy → scoped migration', () => {
+  it('copies the legacy value into the scoped key AND deletes the legacy key', () => {
+    localStorage.setItem('mig.move', '1');
+
+    expect(readScopedRaw('alpha', 'mig.move')).toBe('1');
+    expect(localStorage.getItem(scopedKey('alpha', 'mig.move'))).toBe('1');
+    expect(localStorage.getItem('mig.move')).toBeNull();
+  });
+
+  it('the SECOND vault gets the fallback — it must not inherit the first project value', () => {
+    localStorage.setItem('mig.first-wins', 'alpha-owned');
+
+    expect(readScopedRaw('alpha', 'mig.first-wins')).toBe('alpha-owned');
+    expect(readScopedRaw('beta', 'mig.first-wins')).toBeNull();
+    expect(readScoped('beta', 'mig.first-wins', 'fallback')).toBe('fallback');
+  });
+
+  it('never overwrites an existing scoped value with a stale legacy one', () => {
+    localStorage.setItem(scopedKey('alpha', 'mig.no-clobber'), 'mine');
+    localStorage.setItem('mig.no-clobber', 'stale');
+
+    expect(readScopedRaw('alpha', 'mig.no-clobber')).toBe('mine');
+  });
+
+  it('runs at most once per vault+key: a legacy value re-appearing later is ignored', () => {
+    localStorage.setItem('mig.once', 'original');
+    expect(readScopedRaw('alpha', 'mig.once')).toBe('original');
+
+    // Recreate the exact pre-migration state, bypassing the module so only the latch can
+    // stop a second migration.
+    localStorage.removeItem(scopedKey('alpha', 'mig.once'));
+    localStorage.setItem('mig.once', 'resurrected');
+
+    expect(readScopedRaw('alpha', 'mig.once')).toBeNull();
+    expect(localStorage.getItem('mig.once')).toBe('resurrected');
+  });
+
+  it('keepLegacy copies without deleting, so every vault seeds from the same value', () => {
+    localStorage.setItem('mig.keep', '0');
+
+    expect(readScopedRaw('alpha', 'mig.keep', { keepLegacy: true })).toBe('0');
+    expect(localStorage.getItem('mig.keep')).toBe('0');
+    expect(readScopedRaw('beta', 'mig.keep', { keepLegacy: true })).toBe('0');
+  });
+});
+
+// ─── raw and JSON layers ──────────────────────────────────────────────────────
+
+describe('raw and JSON layers', () => {
+  it('agree: the JSON layer is exactly JSON over the raw pair', () => {
+    writeScoped('alpha', 'layers.json', { page: 'tasks', n: 2 });
+
+    expect(readScopedRaw('alpha', 'layers.json')).toBe(JSON.stringify({ page: 'tasks', n: 2 }));
+    expect(readScoped('alpha', 'layers.json', null)).toEqual({ page: 'tasks', n: 2 });
+  });
+
+  it('migrates a JSON value through the same raw code path', () => {
+    localStorage.setItem('layers.migrated', JSON.stringify(['a', 'b']));
+
+    expect(readScoped('alpha', 'layers.migrated', [])).toEqual(['a', 'b']);
+    expect(localStorage.getItem('layers.migrated')).toBeNull();
+  });
+
+  it('corrupt JSON falls back instead of throwing into a render', () => {
+    writeScopedRaw('alpha', 'layers.corrupt', '{not json');
+
+    expect(readScoped('alpha', 'layers.corrupt', 'fallback')).toBe('fallback');
+  });
+
+  it('an unset key falls back', () => {
+    expect(readScoped('alpha', 'layers.absent', 42)).toBe(42);
+    expect(readScopedRaw('alpha', 'layers.absent')).toBeNull();
+  });
+});
+
+// ─── remove ───────────────────────────────────────────────────────────────────
+
+describe('removeScoped', () => {
+  it('deletes the scoped value', () => {
+    writeScopedRaw('alpha', 'rm.plain', 'v');
+    removeScoped('alpha', 'rm.plain');
+
+    expect(readScopedRaw('alpha', 'rm.plain')).toBeNull();
+  });
+
+  it('consumes the legacy key too, so the next read cannot resurrect what was deleted', () => {
+    localStorage.setItem('rm.legacy', 'from-before');
+
+    removeScoped('alpha', 'rm.legacy');
+
+    expect(readScopedRaw('alpha', 'rm.legacy')).toBeNull();
+    expect(localStorage.getItem('rm.legacy')).toBeNull();
+  });
+});
+
+// ─── storage that throws (private mode / quota) ───────────────────────────────
+
+describe('unavailable storage', () => {
+  beforeEach(() => {
+    const throwing = {
+      getItem: () => { throw new Error('localStorage unavailable'); },
+      setItem: () => { throw new Error('localStorage unavailable'); },
+      removeItem: () => { throw new Error('localStorage unavailable'); },
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = throwing;
+  });
+
+  it('reads fall back and writes are swallowed — never a throw into a render', () => {
+    expect(() => writeScopedRaw('alpha', 'boom', 'v')).not.toThrow();
+    expect(() => writeScoped('alpha', 'boom', { a: 1 })).not.toThrow();
+    expect(() => removeScoped('alpha', 'boom')).not.toThrow();
+    expect(readScopedRaw('alpha', 'boom')).toBeNull();
+    expect(readScoped('alpha', 'boom', 'fallback')).toBe('fallback');
+  });
+});


### PR DESCRIPTION
A second project used to mean a second OS window — its own Dock icon, its own place in the ⌘` cycle, its own everything. One window now holds them all as a centred glass capsule of chips, and every open project stays **live** inside it: backgrounded instances are `hidden` + `inert`, never unmounted, so an agent keeps working and a terminal keeps its PTY while you look at something else.

The headline is what that buys: **a background project's chip jumps and shows its live-chat count the moment one of its chats asks you a question.** You no longer have to be looking at a project to learn that it needs you.

## Why it is this large

"One window = one project" was never a setting — it was an assumption threaded through the dashboard. Every place it lived had to be scoped to the instance:

- **The API client is per-instance** and sends its vault as a header, replacing a module-global "active vault" that would have raced whichever chip was touched last. Six routes still use the unpinned client; each one is on the server's own `VAULT_AGNOSTIC_PREFIXES` list.
- **Each instance owns its `QueryClient`.** The cache keys on the query alone, so a shared client would have served project B's `['tasks']` to project A the moment both were mounted. Isolation here is structural, not a matter of key hygiene. A hidden instance also stops page-data polling — and nothing else.
- **`localStorage` keys are namespaced per vault.** A null vault reads the legacy key *verbatim*, so single-window installs keep their settings; the one preference whose unset default is "on" migrates with the legacy key left in place.
- **Ten window-level custom events moved onto a per-instance `EventTarget` bus.** The ones still on `window` are genuinely window-level (OS zoom, app-wide agent settings) rather than leftovers.
- **Overlay ids and the Escape stack are scoped to the project on screen.** A panel left open in a background project can neither swallow Escape nor be closed by it.
- **The checklist submit can carry a pasted secret**, so it resolves a corroborated live window or refuses. There is no fallback label.

The ceiling is six live instances. Past it, the oldest project with nothing alive becomes a cold chip that revives on click — and "alive" deliberately counts a bare shell, so a dev server nobody has a chat open against is never mistaken for an idle project and killed. A project that has not yet reported is never a candidate either.

Multi-window remains the escape hatch: any chip detaches to its own window.

## Two defects found in final review

**The Escape stack broke in both directions.** One flat LIFO now spans several *mounted* projects and had no notion of which one is on screen: a panel open in A, then one in B, then back to A, left A's visible panel deaf to Escape — and in the other order, Escape pressed in B closed A's invisible panel instead of B's. A `popAllWithPrefix` helper had been written for exactly this and never called; wiring it up would not have fixed it, because the panel stays mounted and would have come back with no stack entry at all. Entries now record the scope they were pushed in and Escape is answered per scope. Capturing scope at *push* time also fixes three popovers that build ids from `useId()` and know nothing about vaults.

**The eviction ceiling nearly killed running shells.** `ProjectRollup.live` excludes shells — correct, it is the chat badge count — but it was also the ceiling's idle test, so a project whose only live thing was a dev server read as idle and would have been torn down mid-process. Split into a separate `alive` count that the ceiling alone consults, with a regression test named for the bug.

## Verification

- `cd dashboard && npx tsc --noEmit` — exit 0, zero diagnostics. Re-run against the **committed tree in an isolated worktree**, because this commit is hunk-split (below).
- `npm run build` — exit 0.
- Unit tests for this goal's surface — green, including 12 new tests for the scoped Escape stack (both regression cases fail against the old implementation), plus the scoped-storage and rollup suites.
- `npm run verify:project-tabs` — **12/12** against a real server, a real bundle and headless Chromium, with **two** registered scratch vaults. One project is the shape that cannot catch a cross-project bug, so the harness opens two: both instances mount, exactly one is visible and the other is `hidden` + `inert` + `display:none`, switching chips leaves `data-instance` unchanged (a remount is a killed PTY — the structural half of the red line), reopening an open project focuses rather than duplicates, Escape dismisses the front-most overlay, and **no `/api/` call fails**. That last check exists because a run once reported all green on a page whose every request was 400ing: "it rendered" and "it works" are not the same claim.

### Not proven — stated, not folded into the pass

Everything needing a **real agent** is unverified: a chat that keeps streaming across a switch, the chip bounce when a background chat asks, terminal cols/rows after five switches, one PTY per session under StrictMode, and teardown at the six-instance ceiling. Those need the Claude CLI and a live PTY, not headless Chromium. The structural checks above do not substitute for them.

## Note for review: this commit is hunk-split

A second, unrelated goal (the automations flow-graph work) is **in progress in the same checkout** and has grown into three of these dashboard files. Only this goal's hunks are committed — staged via `git apply --cached` so the working tree was never touched and that work stays exactly where it was left. Nothing under `src/` and no `automations-*.test.ts` is included. The committed tree was typechecked in a clean worktree specifically to prove the split did not leave a commit that only compiles next to the other run's edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
