### PR TITLE
fix(council): a report section runs to the next heading, not to its first "z"

### DIFF
--- a/dashboard/src/components/council/lib/councilStats.ts
+++ b/dashboard/src/components/council/lib/councilStats.ts
@@ -245,11 +245,11 @@ export function computeDebateStats(debate: DebateDetail): DebateStats {
   let minorityViews = 0;
   if (debate.finalReport) {
     const c = debate.finalReport.content;
-    const risksMatch = c.match(/##\s+Open\s+risks\s*\n([\s\S]*?)(?=^##\s+|\Z)/im);
+    const risksMatch = c.match(/##\s+Open\s+risks\s*\n([\s\S]*?)(?=^##\s+|$(?![\s\S]))/im);
     if (risksMatch) {
       openRisks = (risksMatch[1].match(/^\s*[-*]/gm) ?? []).length;
     }
-    const minorityMatch = c.match(/##\s+Minority\s+views\s*\n([\s\S]*?)(?=^##\s+|\Z)/im);
+    const minorityMatch = c.match(/##\s+Minority\s+views\s*\n([\s\S]*?)(?=^##\s+|$(?![\s\S]))/im);
     if (minorityMatch) {
       const body = minorityMatch[1].trim();
       if (body.length > 0 && !/\(none\)|n\/?a/i.test(body)) {
@@ -315,7 +315,12 @@ export interface FinalReportSections {
 
 export function parseFinalReport(content: string): FinalReportSections {
   const result: FinalReportSections = { verdict: '', appendix: null, sections: [] };
-  const re = /^##\s+(.+?)\s*\n([\s\S]*?)(?=^##\s+|\Z)/gim;
+  // The body runs to the next H2 or to end of input. JavaScript has NO `\Z`
+  // anchor — written as `\Z` it degrades to the literal letter "Z", so under
+  // `/i` every section was silently cut at its first "z" (brutal in Turkish,
+  // where "z" ends a great many words). `$(?![\s\S])` is end-of-input even
+  // under `/m`, where a bare `$` would only mean end-of-line.
+  const re = /^##\s+(.+?)\s*\n([\s\S]*?)(?=^##\s+|$(?![\s\S]))/gim;
   let m: RegExpExecArray | null;
   while ((m = re.exec(content)) !== null) {
     const heading = m[1].trim();

--- a/src/cli/commands/council.ts
+++ b/src/cli/commands/council.ts
@@ -455,8 +455,9 @@ function registerRoundContext(council: Command): void {
         // Also print the debate's Question + Constraints
         const debateFile = join(getDebateDir(debateId), 'debate.md');
         const debateRaw = readFileSync(debateFile, 'utf-8');
-        const questionMatch = debateRaw.match(/##\s+Question\s*\n([\s\S]*?)(?=\n##\s|\Z)/);
-        const constraintsMatch = debateRaw.match(/##\s+Constraints & Known Facts\s*\n([\s\S]*?)(?=\n##\s|\Z)/);
+        // `$(?![\s\S])` is end-of-input; JS has no `\Z` (it would read as a literal "Z").
+        const questionMatch = debateRaw.match(/##\s+Question\s*\n([\s\S]*?)(?=\n##\s|$(?![\s\S]))/);
+        const constraintsMatch = debateRaw.match(/##\s+Constraints & Known Facts\s*\n([\s\S]*?)(?=\n##\s|$(?![\s\S]))/);
 
         if (questionMatch) {
           console.log('\n---\n');

--- a/src/lib/council.ts
+++ b/src/lib/council.ts
@@ -220,7 +220,8 @@ export function validateRoundEntry(body: string): ValidationResult {
   }
 
   const execMatch = body.match(
-    /^###\s+Executive Summary\s*\n([\s\S]*?)(?=^###\s+|\Z)/m,
+    // `$(?![\s\S])` is end-of-input; JS has no `\Z` (it would read as a literal "Z").
+    /^###\s+Executive Summary\s*\n([\s\S]*?)(?=^###\s+|$(?![\s\S]))/m,
   );
   if (execMatch) {
     const words = execMatch[1].trim().split(/\s+/).filter(Boolean).length;
@@ -238,7 +239,8 @@ export function validateRoundEntry(body: string): ValidationResult {
  */
 export function extractExecutiveSummary(roundBody: string): string | null {
   const match = roundBody.match(
-    /^###\s+Executive Summary\s*\n([\s\S]*?)(?=^###\s+|\Z)/m,
+    // `$(?![\s\S])` is end-of-input; JS has no `\Z` (it would read as a literal "Z").
+    /^###\s+Executive Summary\s*\n([\s\S]*?)(?=^###\s+|$(?![\s\S]))/m,
   );
   return match ? match[1].trim() : null;
 }

--- a/src/server/routes/council.ts
+++ b/src/server/routes/council.ts
@@ -66,7 +66,8 @@ interface DebateDetail {
 
 function extractNamedSubsection(body: string, heading: string): string | null {
   const pattern = new RegExp(
-    `^###\\s+${heading.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\s*\\n([\\s\\S]*?)(?=^###\\s+|\\Z)`,
+    // `$(?![\s\S])` is end-of-input; JS has no `\Z` (it would read as a literal "Z").
+    `^###\\s+${heading.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\s*\\n([\\s\\S]*?)(?=^###\\s+|$(?![\\s\\S]))`,
     'm',
   );
   const match = body.match(pattern);

--- a/tests/unit/council-report-parse.test.ts
+++ b/tests/unit/council-report-parse.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseFinalReport,
+  computeDebateStats,
+} from '../../dashboard/src/components/council/lib/councilStats';
+import { extractExecutiveSummary } from '../../src/lib/council';
+
+/**
+ * Regression: every section parser in the council pipeline terminated its body
+ * with `(?=^##\s+|\Z)`. JavaScript has no `\Z` anchor — it degrades to the
+ * literal letter "Z", so under `/i` each body was cut at its first "z". Turkish
+ * reports lost most of their prose ("bağımsız" → "bağımsı", "çözecek" → "çö").
+ */
+
+const TURKISH_REPORT = `---
+id: test-debate
+---
+
+## Verdict
+
+Oda semantik olarak güçlü birleşti. 5 personanın 4'ü aynı mimariye bağımsız
+olarak yakınsadı.
+
+## Decision Card
+
+Aşağıdakiler senin vereceğin sayılı kararlar — oda bunları çözemez.
+
+## Open risks
+
+- Milestone kapanışı tanımsız kaldı
+- Snapshot diff ücretsiz değil
+
+## Minority views
+
+- veri-disiplin-gercekci yalnız kaldı ve pozisyonunu korudu
+
+## Appendix
+
+Kartın son bölümü üç satır yalnızca.
+`;
+
+describe('parseFinalReport', () => {
+  const parsed = parseFinalReport(TURKISH_REPORT);
+
+  it('keeps the verdict body past its first "z"', () => {
+    expect(parsed.verdict).toContain('bağımsız');
+    expect(parsed.verdict).toContain('olarak yakınsadı.');
+  });
+
+  it('keeps every other section body past its first "z"', () => {
+    const decision = parsed.sections.find((s) => s.heading === 'Decision Card');
+    expect(decision?.body).toContain('çözemez');
+
+    const risks = parsed.sections.find((s) => s.heading === 'Open risks');
+    expect(risks?.body).toContain('tanımsız kaldı');
+    expect(risks?.body).toContain('ücretsiz değil');
+  });
+
+  it('splits the appendix off intact', () => {
+    expect(parsed.appendix?.heading).toBe('Appendix');
+    expect(parsed.appendix?.body).toContain('yalnızca');
+  });
+
+  it('does not bleed one section into the next', () => {
+    const decision = parsed.sections.find((s) => s.heading === 'Decision Card');
+    expect(decision?.body).not.toContain('Open risks');
+  });
+
+  it('reads the final section all the way to end of input', () => {
+    const noTrailingNewline = '## Verdict\n\nson söz burada bitiyor.';
+    expect(parseFinalReport(noTrailingNewline).verdict).toBe('son söz burada bitiyor.');
+  });
+});
+
+describe('computeDebateStats', () => {
+  // Only the finalReport branch is under test; the rest of DebateDetail is
+  // shaped just enough for the reducers to run.
+  const debate = {
+    frontmatter: { id: 'test-debate', topic: 'test', rounds_planned: 2 },
+    personas: [],
+    finalReport: { frontmatter: {}, content: TURKISH_REPORT },
+  } as unknown as Parameters<typeof computeDebateStats>[0];
+
+  const stats = computeDebateStats(debate);
+
+  it('counts open risks whose text contains a "z"', () => {
+    expect(stats.openRisks).toBe(2);
+  });
+
+  it('counts a minority view whose text contains a "z"', () => {
+    expect(stats.minorityViews).toBe(1);
+  });
+});
+
+describe('extractExecutiveSummary', () => {
+  it('keeps the summary past its first "Z"', () => {
+    const body = [
+      '### Executive Summary',
+      '',
+      'Zaman kısıtı nedeniyle Zorunlu kapsam daraltıldı.',
+      '',
+      '### Position',
+      '',
+      'ignored',
+    ].join('\n');
+    expect(extractExecutiveSummary(body)).toBe('Zaman kısıtı nedeniyle Zorunlu kapsam daraltıldı.');
+  });
+});


### PR DESCRIPTION
## The bug

Council report sections render truncated in the dashboard. Every parser in the council pipeline terminated its section body with the lookahead `(?=^##\s+|\Z)`.

**JavaScript has no `\Z` anchor.** It's an identity escape — it reads as the literal letter `Z`. Under `/i`, that means every section body stopped at its first `z`.

```js
// OLD → "…5 personanın 4'ü aynı mimariye bağımsı"
// NEW → "…5 personanın 4'ü aynı mimariye bağımsız olarak yakınsadı."
```

Turkish is hit brutally hard — `z` closes a great many words (`bağımsız`, `çözecek`, `ücretsiz`, `yalnızca`, `tanımsız`). Cuts often landed mid-markdown too, which is why a minority-view section rendered as a bare `**A`.

The same defect explains why the **OPEN RISKS** and **DISSENT** tiles both read `0` on a report that visibly has both sections: their parsers were cut identically, before the bullets they count.

## The fix

`$(?![\s\S])` — end-of-input even under `/m`, where a bare `$` means end-of-*line* and would stop a lazy `[\s\S]*?` at the first blank line inside a section.

Eight sites, all the same defect:

| File | What was truncated |
|---|---|
| `dashboard/src/components/council/lib/councilStats.ts` | `parseFinalReport` — every section body in the Overview tab |
| ″ | `Open risks` + `Minority views` parsers behind the stat tiles |
| `src/lib/council.ts` | `extractExecutiveSummary` + the `validateRoundEntry` word-count check |
| `src/server/routes/council.ts` | `extractNamedSubsection` — Position / Reasoning / Reactions / Open questions |
| `src/cli/commands/council.ts` | the debate Question + Constraints echo in `round-context` |

`src/lib/excalidraw-text.ts` already documented that JS has no `\Z` and routed around it with split-on-headings. The council parsers never got that treatment.

## Tests

`tests/unit/council-report-parse.test.ts` — 8 tests over a Turkish fixture, verified to fail against the old regex. Also covers section-bleed and a final section with no trailing newline.

- Full suite: `380 passed`, 6641 tests. The one failure (`tests/integration/platform-install.test.ts` — retired task-manager skill removal) ==reproduces on clean `main`== and is unrelated to this change.
- `tsc --noEmit` clean for both root and dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)