### PR TITLE
fix(sleep): consolidated work stops re-booking itself, so debt can actually reach 0

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -114,13 +114,29 @@ const MAX_TEXT_BLOCK_CHARS = 20000;
  * Analyze a JSONL transcript file for tool usage.
  * Returns change count (Write/Edit), total tool count, and auto-detected task slugs.
  * Returns zeros on any error.
+ *
+ * `sinceISO` (the last completed consolidation, `state.last_consolidated_at`)
+ * bounds what counts as debt: records stamped at or before it are EXCLUDED
+ * from every scored axis. Without the bound, a session that spans a sleep
+ * re-books its whole already-consolidated history at its next Stop — the
+ * consolidation deletes the session RECORD but the transcript persists, so the
+ * re-stop scored the full file from scratch and debt could never reach 0.
+ * The same bound zeroes out the sleep fan-out itself: the orchestrating
+ * session's sub-agent transcripts (the sleep specialists) all predate
+ * `sleep done`, so they stop counting as ~10 fresh debt per cycle.
+ *
+ * Task slugs stay whole-transcript on purpose — they are linkage metadata,
+ * not debt, and dropping a pre-boundary slug would orphan the session.
+ * Records without a parseable timestamp count (fail-open): losing real work
+ * is worse than over-counting a malformed line.
  */
-export function analyzeTranscript(transcriptPath: string): TranscriptAnalysis {
+export function analyzeTranscript(transcriptPath: string, sinceISO?: string | null): TranscriptAnalysis {
   if (!existsSync(transcriptPath)) return ZERO_ANALYSIS;
   try {
     const stat = statSync(transcriptPath);
     if (stat.size === 0 || stat.size > MAX_TRANSCRIPT_BYTES) return ZERO_ANALYSIS;
     const content = readFileSync(transcriptPath, 'utf-8');
+    const sinceMs = sinceISO ? Date.parse(sinceISO) : NaN;
     const changeMatches = content.match(/"name"\s*:\s*"(?:Write|Edit)"/g);
     const toolMatches = content.match(/"name"\s*:\s*"[A-Za-z_]+"/g);
 
@@ -146,19 +162,36 @@ export function analyzeTranscript(transcriptPath: string): TranscriptAnalysis {
     let assistantChars = 0;
     let decisionMarkers = 0;
     let novelTokens = 0;
+    // Per-record tool counts, used ONLY when the boundary actually excluded
+    // something — the flat-regex counts above can't be time-bucketed. When
+    // nothing is excluded the regex counts are returned unchanged, so every
+    // session that doesn't span a consolidation scores bit-for-bit as before.
+    let excludedAny = false;
+    let boundedChanges = 0;
+    let boundedTools = 0;
     for (const line of content.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) continue;
-      if (DECISION_RE.test(trimmed) || CORRECTION_RE.test(trimmed)) {
-        decisionMarkers++;
-      }
+      const isDecision = DECISION_RE.test(trimmed) || CORRECTION_RE.test(trimmed);
       let rec: unknown;
       try {
         rec = JSON.parse(trimmed);
       } catch {
+        if (isDecision) decisionMarkers++;
         continue; // not a JSON record (or partial) — skip
       }
-      if (!rec || typeof rec !== 'object') continue;
+      if (!rec || typeof rec !== 'object') {
+        if (isDecision) decisionMarkers++;
+        continue;
+      }
+      if (!Number.isNaN(sinceMs)) {
+        const ts = recordTimestampMs(rec);
+        if (ts !== null && ts <= sinceMs) {
+          excludedAny = true;
+          continue; // already consolidated — contributes to no scored axis
+        }
+      }
+      if (isDecision) decisionMarkers++;
       novelTokens += novelTokensFromUsage(rec);
       const role = recordRole(rec);
       if (role === 'user') {
@@ -166,11 +199,14 @@ export function analyzeTranscript(transcriptPath: string): TranscriptAnalysis {
       } else if (role === 'assistant') {
         assistantChars += sumAssistantTextChars(rec);
       }
+      const uses = countToolUseBlocks(rec);
+      boundedTools += uses.tools;
+      boundedChanges += uses.changes;
     }
 
     return {
-      changeCount: changeMatches ? changeMatches.length : 0,
-      toolCount: toolMatches ? toolMatches.length : 0,
+      changeCount: excludedAny ? boundedChanges : (changeMatches ? changeMatches.length : 0),
+      toolCount: excludedAny ? boundedTools : (toolMatches ? toolMatches.length : 0),
       taskSlugs: [...slugs],
       userTurns,
       assistantChars,
@@ -205,6 +241,44 @@ function insightReadDirective(slug: string, vault?: string): string {
     ? `read \`${vault}\`'s \`lab/insights/${slug}.md\` + \`lab/cache/${slug}.json\` (or run \`lab show ${slug}\` in that vault)`
     : `\`dreamcontext lab show ${slug}\` — cached series, never fetches`;
   return `    → ALREADY TRACKED as an insight: ${how}. Do NOT fetch this metric from an API, an MCP tool, or a one-off script; only \`lab sync ${slug}\` when the cache is TTL-stale.`;
+}
+
+/**
+ * Millisecond timestamp of one transcript record, or null when absent or
+ * unparseable. Claude Code stamps every JSONL record with a top-level ISO
+ * `timestamp`; null means the caller must treat the record as countable
+ * (fail-open — see analyzeTranscript's boundary contract).
+ */
+function recordTimestampMs(rec: object): number | null {
+  const t = (rec as { timestamp?: unknown }).timestamp;
+  if (typeof t !== 'string') return null;
+  const ms = Date.parse(t);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Count `tool_use` content blocks in one record (and how many are Write/Edit).
+ * The per-record twin of the whole-file `"name":"…"` regexes — used only when
+ * a consolidation boundary excludes part of the transcript, where a flat regex
+ * can't be time-bucketed.
+ */
+function countToolUseBlocks(rec: object): { tools: number; changes: number } {
+  const r = rec as { message?: { content?: unknown }; content?: unknown };
+  const content = (r.message && typeof r.message === 'object' ? r.message.content : undefined) ?? r.content;
+  let tools = 0;
+  let changes = 0;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block && typeof block === 'object') {
+        const b = block as { type?: unknown; name?: unknown };
+        if (b.type === 'tool_use') {
+          tools++;
+          if (b.name === 'Write' || b.name === 'Edit') changes++;
+        }
+      }
+    }
+  }
+  return { tools, changes };
 }
 
 /** Extract the role of a transcript record, tolerating both flat and nested message shapes. */
@@ -446,12 +520,12 @@ export function mergeAnalyses(main: TranscriptAnalysis, subs: TranscriptAnalysis
  * Sub-agent harvesting is best-effort — a missing or unreadable `subagents/`
  * dir yields the main analysis unchanged, never a throw.
  */
-export function analyzeSession(loc: TranscriptLocation): TranscriptAnalysis {
-  const main = loc.mainPath ? analyzeTranscript(loc.mainPath) : ZERO_ANALYSIS;
+export function analyzeSession(loc: TranscriptLocation, sinceISO?: string | null): TranscriptAnalysis {
+  const main = loc.mainPath ? analyzeTranscript(loc.mainPath, sinceISO) : ZERO_ANALYSIS;
   try {
     const subPaths = listSubagentTranscripts(loc);
     if (subPaths.length === 0) return main;
-    return mergeAnalyses(main, subPaths.map(p => analyzeTranscript(p)));
+    return mergeAnalyses(main, subPaths.map(p => analyzeTranscript(p, sinceISO)));
   } catch {
     return main;
   }
@@ -532,6 +606,7 @@ export function resolveCatchupFinalization(
   session: Pick<SessionRecord, 'stopped_at' | 'last_assistant_message' | 'task_slugs'>,
   loc: TranscriptLocation,
   nowMs: number,
+  sinceISO?: string | null,
 ): CatchupFinalizeResult | null {
   if (!loc.mainPath) {
     const stoppedMs = Date.parse(session.stopped_at ?? '') || 0;
@@ -548,7 +623,7 @@ export function resolveCatchupFinalization(
     };
   }
 
-  const analysis = analyzeSession(loc);
+  const analysis = analyzeSession(loc, sinceISO);
   const score = scoreSession(analysis);
   return {
     changeCount: analysis.changeCount,
@@ -1239,9 +1314,13 @@ export function registerHookCommand(program: Command): void {
       // Resolve the full location (not just the flat path) so `analyzeSession`
       // can fold in this session's sub-agent transcripts — a fan-out session's
       // real work lives in `subagents/`, not in the one `Task` call the main
-      // transcript records.
+      // transcript records. Bounded by the last completed consolidation:
+      // records at or before `last_consolidated_at` were either consolidated
+      // (pre-epoch work) or produced BY the consolidation (the sleep fan-out),
+      // and re-scoring them here is exactly how debt was flooring at 9-10
+      // right after every sleep instead of resting at 0.
       const analysis = transcriptOnDisk
-        ? analyzeSession(resolveTranscript(transcriptPath, { sessionId }))
+        ? analyzeSession(resolveTranscript(transcriptPath, { sessionId }), state.last_consolidated_at)
         : ZERO_ANALYSIS;
       const { changeCount, toolCount } = analysis;
       // Weighted-sum debt: log-compressed token / change / tool axes plus the
@@ -1441,7 +1520,10 @@ export function registerHookCommand(program: Command): void {
         // transcript-location change degrades gracefully instead of silently
         // zeroing capture.
         const loc = resolveTranscript(session.transcript_path, { sessionId: session.session_id });
-        const result = resolveCatchupFinalization(session, loc, Date.now());
+        // Same consolidation bound as the Stop hook — a pending session that
+        // spans a sleep must not re-book its already-consolidated records when
+        // the catch-up finally scores it.
+        const result = resolveCatchupFinalization(session, loc, Date.now(), state.last_consolidated_at);
         if (result === null) continue; // still pending — a later start catches it up
 
         session.change_count = result.changeCount;

--- a/src/lib/brain-dirty.ts
+++ b/src/lib/brain-dirty.ts
@@ -94,10 +94,20 @@ export function collectBrainDirty(
     return relative(realProjectRoot, abs).split(sep).join('/');
   };
 
+  // The pathspec means every entry git returned lives under OUR context dir —
+  // so a path that cannot be re-based under projectRoot says the
+  // topLevel/projectRoot resolution assumption itself broke (case-folding
+  // mismatch, an exotic symlink the realpath fallback didn't bridge). That
+  // report is INCONCLUSIVE, not clean: this warning exists so a stray
+  // `git checkout .` can't silently erase a sleep's output, and a silent
+  // false-negative here fails it in exactly the mode it was built to prevent.
   const prefix = `${contextDirName}/`;
-  const paths = raw
-    .map(rebase)
-    .filter((p): p is string => p !== null && (p === contextDirName || p.startsWith(prefix)));
+  const paths: string[] = [];
+  for (const entry of raw) {
+    const rebased = rebase(entry);
+    if (rebased === null) return { paths: [], unavailable: true };
+    if (rebased === contextDirName || rebased.startsWith(prefix)) paths.push(rebased);
+  }
   return { paths, unavailable: false };
 }
 

--- a/src/lib/brain-dirty.ts
+++ b/src/lib/brain-dirty.ts
@@ -8,7 +8,8 @@
  * string literals rendered for the user to run themselves).
  */
 
-import { resolve } from 'node:path';
+import { join, relative, resolve, sep } from 'node:path';
+import { realpathSync } from 'node:fs';
 import { statusPorcelainTracked, repoToplevel } from './git-sync/git.js';
 
 export interface BrainDirtyReport {
@@ -24,13 +25,20 @@ export interface BrainDirtyReport {
  * Collect uncommitted paths under `<contextDirName>/`, scoped to that prefix so
  * a dirty CODE tree never triggers this warning — only brain output does.
  *
- * `projectRoot` MUST be its own repo top-level before `git status` output is
- * trusted: when a scratch vault sits NESTED inside an enclosing checkout (no
- * `.git` of its own), `git status` run there walks UP to the enclosing repo,
- * and its uncommitted paths have nothing to do with `projectRoot` — reporting
- * them would falsely warn about another project's files. `repoToplevel`
- * resolves the work-tree root git would actually operate on; a mismatch (or a
- * failed/absent repo) makes the report `unavailable` rather than wrong.
+ * The scoping is a git PATHSPEC, not a top-level equality check. The old
+ * `repoToplevel === projectRoot` gate existed so a vault nested inside an
+ * enclosing checkout couldn't be blamed for the enclosing repo's dirty files —
+ * but it also made every vault living in a SUBDIRECTORY of its repo (a
+ * monorepo app dir, the common team layout) report `unavailable` after every
+ * single sleep, which users read as a scary git failure. Passing
+ * `<projectRoot>/<contextDirName>` as the pathspec gives the same safety with
+ * none of the false alarms: whatever repo git resolves to, every returned path
+ * is under OUR context dir by construction. Only a truly absent repo (or a
+ * failing git) is `unavailable` now.
+ *
+ * Returned paths are re-based to be projectRoot-relative (git prints them
+ * relative to the repo top-level, which may sit above `projectRoot`), so the
+ * rendered warning and its `git add` command keep working from the vault.
  *
  * Reuses `statusPorcelainTracked` (already includes untracked files, already
  * swallows its own git-invocation errors to `[]`); the try/catch around both
@@ -41,7 +49,7 @@ export function collectBrainDirty(
   projectRoot: string,
   opts: {
     contextDirName?: string;
-    statusImpl?: (cwd: string) => string[];
+    statusImpl?: (cwd: string, pathspecs?: string[]) => string[];
     topLevelImpl?: (cwd: string) => string | null;
   } = {},
 ): BrainDirtyReport {
@@ -55,19 +63,41 @@ export function collectBrainDirty(
   } catch {
     return { paths: [], unavailable: true };
   }
-  if (!topLevel || resolve(topLevel) !== resolve(projectRoot)) {
+  if (!topLevel) {
     return { paths: [], unavailable: true };
   }
 
   let raw: string[];
   try {
-    raw = statusImpl(projectRoot);
+    raw = statusImpl(projectRoot, [join(projectRoot, contextDirName)]);
   } catch {
     return { paths: [], unavailable: true };
   }
 
+  // Re-base git's repo-top-relative paths onto projectRoot. realpath both
+  // sides first: git prints PHYSICAL paths (macOS `/tmp` → `/private/tmp`),
+  // and a symlinked projectRoot would otherwise never prefix-match. Falls back
+  // to the logical path when realpath fails (injected test doubles use paths
+  // that don't exist) — a mismatch there degrades to "no paths", never a throw.
+  const physical = (p: string): string => {
+    try {
+      return realpathSync(resolve(p));
+    } catch {
+      return resolve(p);
+    }
+  };
+  const realProjectRoot = physical(projectRoot);
+  const realTopLevel = physical(topLevel);
+  const rebase = (p: string): string | null => {
+    const abs = resolve(realTopLevel, p);
+    if (abs !== realProjectRoot && !abs.startsWith(realProjectRoot + sep)) return null;
+    return relative(realProjectRoot, abs).split(sep).join('/');
+  };
+
   const prefix = `${contextDirName}/`;
-  const paths = raw.filter((p) => p === contextDirName || p.startsWith(prefix));
+  const paths = raw
+    .map(rebase)
+    .filter((p): p is string => p !== null && (p === contextDirName || p.startsWith(prefix)));
   return { paths, unavailable: false };
 }
 
@@ -88,7 +118,8 @@ export function renderBrainDirtyWarning(
 
   if (r.unavailable) {
     return [
-      `⚠ Could not verify whether ${opts.contextDirName}/ is committed (git status unavailable) — check manually.`,
+      `⚠ Could not verify whether ${opts.contextDirName}/ is committed — this project is not a git repository (or git itself failed). ` +
+        'Your consolidated brain has no version history; consider `git init` so a stray deletion is recoverable.',
     ];
   }
   if (r.paths.length === 0) return [];

--- a/src/lib/git-sync/git.ts
+++ b/src/lib/git-sync/git.ts
@@ -369,11 +369,17 @@ export function hasMergeHead(cwd: string): boolean {
  * edit that must be committed/checkpointed too (an already-ignored file never
  * shows up here regardless — `git status` never lists ignored paths without
  * `--ignored`).
+ *
+ * `pathspecs` (absolute or cwd-relative) scopes the status to those paths.
+ * Returned entries stay exactly as git prints them: relative to the REPO
+ * TOP-LEVEL, not to `cwd` — callers below a repo root translate themselves.
  */
-export function statusPorcelainTracked(cwd: string): string[] {
+export function statusPorcelainTracked(cwd: string, pathspecs?: string[]): string[] {
   let raw: string;
   try {
-    raw = execFileSync('git', ['status', '--porcelain', '-z'], {
+    const args = ['status', '--porcelain', '-z'];
+    if (pathspecs && pathspecs.length > 0) args.push('--', ...pathspecs);
+    raw = execFileSync('git', args, {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/tests/unit/brain-dirty.test.ts
+++ b/tests/unit/brain-dirty.test.ts
@@ -51,17 +51,39 @@ describe('collectBrainDirty', () => {
     expect(report.paths).toEqual(['_dream_context/state/x.json']);
   });
 
-  it('nested-non-repo: projectRoot sits inside an enclosing repo — reports unavailable, never the enclosing repo\'s files', () => {
+  it('nested vault: another project\'s files inside the enclosing repo NEVER surface', () => {
     const statusImpl = () => [
-      // What the ENCLOSING repo's status would show — must NEVER surface.
+      // What the ENCLOSING repo's status would show for a DIFFERENT project —
+      // must never be blamed on this vault.
       'some-other-project/_dream_context/state/x.json',
     ];
     const report = collectBrainDirty('/enclosing/nested-vault', {
       statusImpl,
       topLevelImpl: () => '/enclosing', // toplevel walks UP past the nested vault
     });
-    expect(report.unavailable).toBe(true);
+    expect(report.unavailable).toBe(false);
     expect(report.paths).toEqual([]);
+  });
+
+  it('nested vault: its own dirty brain files are re-based from repo-top-relative to vault-relative', () => {
+    // Git prints paths relative to the repo TOP; the vault lives a level down.
+    const statusImpl = () => ['nested-vault/_dream_context/state/x.json'];
+    const report = collectBrainDirty('/enclosing/nested-vault', {
+      statusImpl,
+      topLevelImpl: () => '/enclosing',
+    });
+    expect(report.unavailable).toBe(false);
+    expect(report.paths).toEqual(['_dream_context/state/x.json']);
+  });
+
+  it('scopes the git status probe with a context-dir pathspec', () => {
+    let seen: string[] | undefined;
+    const statusImpl = (_cwd: string, pathspecs?: string[]) => {
+      seen = pathspecs;
+      return [];
+    };
+    collectBrainDirty('/repo', { statusImpl, topLevelImpl: sameRootTopLevel });
+    expect(seen).toEqual(['/repo/_dream_context']);
   });
 
   it('rev-parse failure (not a repo at all, or git absent): unavailable', () => {

--- a/tests/unit/brain-dirty.test.ts
+++ b/tests/unit/brain-dirty.test.ts
@@ -51,17 +51,19 @@ describe('collectBrainDirty', () => {
     expect(report.paths).toEqual(['_dream_context/state/x.json']);
   });
 
-  it('nested vault: another project\'s files inside the enclosing repo NEVER surface', () => {
+  it('a path that cannot be re-based under the vault marks the report INCONCLUSIVE, never silently clean', () => {
     const statusImpl = () => [
-      // What the ENCLOSING repo's status would show for a DIFFERENT project —
-      // must never be blamed on this vault.
+      // The pathspec guarantees every real git entry lives under our context
+      // dir — an entry that resolves OUTSIDE the vault means the
+      // topLevel/projectRoot resolution assumption broke. That must surface
+      // as "could not verify", and it must never blame another project.
       'some-other-project/_dream_context/state/x.json',
     ];
     const report = collectBrainDirty('/enclosing/nested-vault', {
       statusImpl,
       topLevelImpl: () => '/enclosing', // toplevel walks UP past the nested vault
     });
-    expect(report.unavailable).toBe(false);
+    expect(report.unavailable).toBe(true);
     expect(report.paths).toEqual([]);
   });
 

--- a/tests/unit/sleep-debt-consolidation-boundary.test.ts
+++ b/tests/unit/sleep-debt-consolidation-boundary.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  analyzeTranscript,
+  analyzeSession,
+  scoreSession,
+  resolveCatchupFinalization,
+} from '../../src/cli/commands/hook.js';
+import { resolveTranscript } from '../../src/lib/transcript-locate.js';
+
+/**
+ * Regression: sleep debt never reached 0 (team reports, Slack 2026-08-04).
+ *
+ * Consolidation deletes pre-epoch SESSION RECORDS, but the transcripts persist.
+ * The Stop hook then scored each transcript from scratch, so:
+ *  (A) the session that ORCHESTRATED the sleep re-booked the whole fan-out —
+ *      every sleep specialist's sub-agent transcript folded into its score,
+ *      putting a ~9-10 debt floor right back after every single sleep;
+ *  (B) any tab that continued after a sleep re-booked its entire
+ *      already-consolidated history as a "new" session (several tabs → 35).
+ *
+ * The fix bounds analysis at `last_consolidated_at`: records stamped at or
+ * before it contribute to no scored axis.
+ */
+
+const BOUNDARY = '2026-08-04T17:00:00.000Z';
+const BEFORE = '2026-08-04T16:00:00.000Z';
+const AFTER = '2026-08-04T18:00:00.000Z';
+
+function makeTmpDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function usageLine(u: Record<string, number>, timestamp?: string): string {
+  return JSON.stringify({
+    ...(timestamp ? { timestamp } : {}),
+    message: { role: 'assistant', content: [{ type: 'text', text: 'x'.repeat(100) }], usage: u },
+  });
+}
+
+function toolLine(name: string, timestamp?: string): string {
+  return JSON.stringify({
+    ...(timestamp ? { timestamp } : {}),
+    message: { role: 'assistant', content: [{ type: 'tool_use', name, input: {} }] },
+  });
+}
+
+function userLine(timestamp?: string): string {
+  return JSON.stringify({
+    ...(timestamp ? { timestamp } : {}),
+    message: { role: 'user', content: 'do the thing' },
+  });
+}
+
+describe('analyzeTranscript — consolidation boundary', () => {
+  it('excludes records at or before the boundary from every scored axis', () => {
+    const dir = makeTmpDir('dc-bound');
+    const p = join(dir, 's.jsonl');
+    writeFileSync(p, [
+      userLine(BEFORE),
+      usageLine({ output_tokens: 1_000_000 }, BEFORE),
+      toolLine('Edit', BEFORE),
+      toolLine('Edit', BOUNDARY), // exactly AT the boundary — consolidated, excluded
+      userLine(AFTER),
+      usageLine({ output_tokens: 500 }, AFTER),
+      toolLine('Write', AFTER),
+    ].join('\n'));
+
+    const bounded = analyzeTranscript(p, BOUNDARY);
+    expect(bounded.novelTokens).toBe(500);
+    expect(bounded.userTurns).toBe(1);
+    expect(bounded.changeCount).toBe(1);
+    expect(bounded.toolCount).toBe(1);
+  });
+
+  it('without a boundary the full transcript scores exactly as before', () => {
+    const dir = makeTmpDir('dc-bound');
+    const p = join(dir, 's.jsonl');
+    const lines = [
+      usageLine({ output_tokens: 1_000_000 }, BEFORE),
+      toolLine('Edit', BEFORE),
+      usageLine({ output_tokens: 500 }, AFTER),
+    ].join('\n');
+    writeFileSync(p, lines);
+
+    const unbounded = analyzeTranscript(p);
+    expect(unbounded.novelTokens).toBe(1_000_500);
+    expect(unbounded.changeCount).toBe(1);
+    expect(analyzeTranscript(p, null)).toEqual(unbounded);
+  });
+
+  it('a boundary older than every record changes nothing — counts stay on the legacy regex path', () => {
+    const dir = makeTmpDir('dc-bound');
+    const p = join(dir, 's.jsonl');
+    writeFileSync(p, [
+      usageLine({ output_tokens: 100 }, AFTER),
+      toolLine('Edit', AFTER),
+    ].join('\n'));
+
+    expect(analyzeTranscript(p, BEFORE)).toEqual(analyzeTranscript(p));
+  });
+
+  it('records without a timestamp count (fail-open) even when a boundary is set', () => {
+    const dir = makeTmpDir('dc-bound');
+    const p = join(dir, 's.jsonl');
+    writeFileSync(p, [
+      usageLine({ output_tokens: 1_000 }, BEFORE), // excluded
+      usageLine({ output_tokens: 70 }),            // no timestamp — kept
+    ].join('\n'));
+
+    expect(analyzeTranscript(p, BOUNDARY).novelTokens).toBe(70);
+  });
+
+  it('task slugs stay whole-transcript — linkage metadata is not debt', () => {
+    const dir = makeTmpDir('dc-bound');
+    const p = join(dir, 's.jsonl');
+    writeFileSync(p, [
+      JSON.stringify({
+        timestamp: BEFORE,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', name: 'Bash', input: { command: 'dreamcontext tasks log fix-the-thing "done"' } }],
+        },
+      }),
+      usageLine({ output_tokens: 10 }, AFTER),
+    ].join('\n'));
+
+    const bounded = analyzeTranscript(p, BOUNDARY);
+    expect(bounded.taskSlugs).toEqual(['fix-the-thing']);
+    expect(bounded.toolCount).toBe(0); // ...but the pre-boundary tool call is not debt
+  });
+});
+
+describe('analyzeSession — the sleep fan-out stops re-booking itself (leak A)', () => {
+  it('sub-agent transcripts that predate the boundary contribute nothing', () => {
+    const dir = makeTmpDir('dc-fanout');
+    const sessionId = 'orchestrator';
+    const mainPath = join(dir, `${sessionId}.jsonl`);
+    // The orchestrating session: pre-sleep work, the Task dispatch, a tiny
+    // post-`sleep done` summary turn.
+    writeFileSync(mainPath, [
+      usageLine({ output_tokens: 200_000 }, BEFORE),
+      toolLine('Task', BEFORE),
+      usageLine({ output_tokens: 300 }, AFTER),
+    ].join('\n'));
+
+    // The sleep specialists: heavy writes, all during the sleep window.
+    const subDir = join(dir, sessionId, 'subagents');
+    mkdirSync(subDir, { recursive: true });
+    for (const agent of ['sleep-tasks', 'sleep-state', 'sleep-product']) {
+      writeFileSync(join(subDir, `agent-${agent}.jsonl`), [
+        usageLine({ output_tokens: 400_000, cache_creation_input_tokens: 900_000 }, BEFORE),
+        ...Array.from({ length: 15 }, () => toolLine('Edit', BEFORE)),
+      ].join('\n'));
+    }
+
+    const loc = resolveTranscript(mainPath, { sessionId });
+    const unbounded = analyzeSession(loc);
+    const bounded = analyzeSession(loc, BOUNDARY);
+
+    // Unbounded, the fan-out books serious debt — the exact 9-10 floor reported.
+    expect(scoreSession(unbounded)).toBeGreaterThanOrEqual(7);
+    // Bounded, only the post-sleep summary turn counts.
+    expect(bounded.novelTokens).toBe(300);
+    expect(bounded.changeCount).toBe(0);
+    expect(scoreSession(bounded)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('resolveCatchupFinalization — a spanning session does not re-book (leak B)', () => {
+  it('scores only post-boundary work when the catch-up finalizes a pending session', () => {
+    const dir = makeTmpDir('dc-catchup');
+    const sessionId = 'heavy-tab';
+    const mainPath = join(dir, `${sessionId}.jsonl`);
+    writeFileSync(mainPath, [
+      // A full day of already-consolidated work…
+      ...Array.from({ length: 30 }, () => toolLine('Edit', BEFORE)),
+      usageLine({ output_tokens: 2_000_000 }, BEFORE),
+      // …and one small post-sleep turn.
+      usageLine({ output_tokens: 1_000 }, AFTER),
+    ].join('\n'));
+
+    const session = { stopped_at: AFTER, last_assistant_message: null, task_slugs: [] };
+    const loc = resolveTranscript(mainPath, { sessionId });
+
+    const unbounded = resolveCatchupFinalization(session, loc, Date.parse(AFTER));
+    const bounded = resolveCatchupFinalization(session, loc, Date.parse(AFTER), BOUNDARY);
+
+    expect(unbounded!.score).toBeGreaterThanOrEqual(5); // the old re-book
+    expect(bounded!.score).toBeLessThanOrEqual(1);
+    expect(bounded!.debtDelta).toBe(bounded!.score);
+    expect(bounded!.changeCount).toBe(0);
+    expect(bounded!.novelTokens).toBe(1_000);
+  });
+});


### PR DESCRIPTION
## The reports

From the team thread (Slack, 2026-08-04):

1. **Bedirhan:** after every sleep, debt floors at **9-10 minimum** — never 0 — even doing nothing during the sleep.
2. **Berdan:** sleeps, debt comes back as **35**.
3. **Bedirhan:** a "git commit" warning after **every** sleep (suspected gh CLI — it isn't).

## Root cause (1 & 2)

Consolidation deletes pre-epoch **session records**, but the transcripts persist — and the Stop hook scored each transcript **from scratch**:

- **Leak A — the sleep re-books itself.** The orchestrating session stops after `sleep done`. Its score folds in every sleep specialist's sub-agent transcript (`analyzeSession` harvests `subagents/agent-*.jsonl`). A fan-out writes 20-40 files over millions of novel tokens → the scoring axes saturate → **~9-10 fresh debt per sleep**. That's the floor Bedirhan sees.
- **Leak B — cleared sessions re-book.** A tab that continues after a sleep re-stops; `upsertSessionOnStop` finds no record (consolidation cleared it) and books the **full already-consolidated history** as a brand-new session. A few tabs at the 10-point cap → 35. That's Berdan.

## The fix

Transcript analysis is now bounded at `last_consolidated_at`: records stamped at or before the last completed consolidation contribute to **no scored axis** — they were either consolidated (pre-epoch work) or produced *by* the consolidation (the fan-out). Applied at both scoring entry points: the Stop hook and the SessionStart catch-up finalization.

Design notes:
- Sessions that never span a consolidation score **bit-for-bit as before** (the flat-regex counters stay in charge; the per-record counter takes over only when the boundary excluded something).
- Task slugs stay whole-transcript — linkage metadata, not debt.
- Records without a parseable timestamp count (fail-open).
- Work that **stops during** a sleep still books to the next cycle — the "çalışmaya devam edebilelim" design is preserved.

## The git warning (3)

`collectBrainDirty` required `projectRoot` to *be* the repo top-level and reported `unavailable` otherwise — so any vault living in a **subdirectory of its repo** (the common monorepo layout) printed "⚠ Could not verify whether _dream_context/ is committed" after *every* sleep. It now scopes `git status` with a context-dir **pathspec** (same nested-vault safety, by construction), re-bases git's repo-top-relative paths onto the vault, and reserves `unavailable` for a genuinely absent repo — with a message that says so. The binding 2026-07-18 decision is untouched: warn loudly, never auto-commit.

## Tests

- New `tests/unit/sleep-debt-consolidation-boundary.test.ts` — 7 tests modeling both leaks end-to-end (the fan-out fixture scores ≥7 unbounded, ≤1 bounded; the spanning-tab fixture likewise), plus fail-open, boundary-inclusive (`<=`), and no-boundary bit-compatibility cases.
- `brain-dirty.test.ts` updated to the new semantics: nested vault now *works* (own files re-based, other projects' files never surface, pathspec asserted) instead of reporting unavailable.
- Full suite: 6642 passed. The one failure (`platform-install.test.ts`, retired task-manager skill removal) reproduces on clean `main` — pre-existing, unrelated.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)