### PR TITLE
fix(cli): stamp the version into the bundle so the .app can name itself

### DIFF
--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -65,11 +65,42 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 let cachedVersion: string | null = null;
 
+/** A stamp must look like a real semver core before we trust it as a version. */
+const SEMVER_CORE = /^\d+\.\d+\.\d+(?:[-+].*)?$/;
+
+/**
+ * The version tsup stamped into this bundle at build time (see `define` in
+ * tsup.config.ts, which substitutes the literal for this exact expression).
+ *
+ * Empty when running straight from src/ (tsx/vitest) — which needs no stamp,
+ * because the repo-root package.json is always reachable from src/lib/.
+ */
+function stampedVersion(): string {
+  const stamped = process.env.DREAMCONTEXT_BUILD_VERSION;
+  return typeof stamped === 'string' && SEMVER_CORE.test(stamped) ? stamped : '';
+}
+
 /**
  * Read the dreamcontext package.json version from disk RIGHT NOW — no cache.
- * Returns '0.0.0' when no valid package.json is found (e.g. mid-upgrade, when
- * npm has the directory in a transient state) so callers can treat that as
- * "unknown" rather than a real version change.
+ *
+ * Disk FIRST, on purpose: the on-disk package.json is the only thing that
+ * changes under a long-lived process when npm swaps the package out from under
+ * it, and the drift/upgrade-ready watches in server/lifecycle.ts exist to notice
+ * exactly that. A build-time stamp would be frozen at launch and could never
+ * report an upgrade.
+ *
+ * When NO package.json is reachable, fall back to the build-time stamp rather
+ * than the '0.0.0' sentinel. That is the Tauri .app case: it ships
+ * `Contents/Resources/dist/index.js` with no package.json at any candidate path,
+ * so every probe below misses. Stamping '0.0.0' there was not merely cosmetic —
+ * '0.0.0' sorts below every migration version, so `pendingMigrations` and
+ * `unfinishedAgentTasks` silently returned nothing and NO migration could fire
+ * through the bundled CLI (the first-run-before-npm-install fallback path in
+ * `resolve_cli`), and every manifest it wrote was stamped 0.0.0.
+ *
+ * '0.0.0' survives as the last resort and still means "unknown": an unstamped
+ * build with no package.json in sight. Callers that treat it as "no signal"
+ * (the lifecycle watches, setup-drift's fail-safe) stay correct.
  */
 export function readDreamcontextVersionFromDisk(): string {
   const candidates = [
@@ -91,7 +122,7 @@ export function readDreamcontextVersionFromDisk(): string {
     }
   }
 
-  return '0.0.0';
+  return stampedVersion() || '0.0.0';
 }
 
 /**

--- a/src/server/routes/version-check.ts
+++ b/src/server/routes/version-check.ts
@@ -32,7 +32,10 @@ export async function handleVersionCheckGet(
     // the user had ALREADY installed — until they fully relaunched the app.
     // Reading fresh lets the badge self-clear on the next poll once the on-disk
     // package is upgraded. Fall back to the cached value if the fresh read is
-    // momentarily unavailable (npm mid-swap returns the '0.0.0' sentinel).
+    // momentarily unavailable — the '0.0.0' sentinel. A built CLI now falls back
+    // to its own build-time stamp first (so the .app bundle, which has no
+    // package.json to read, reports its real version), which leaves this guard
+    // for the unstamped case only. Kept: '0.0.0' still means "no signal".
     const freshCli = readDreamcontextVersionFromDisk();
     const installedCli = freshCli === '0.0.0' ? dreamcontextVersion() : freshCli;
     // Scope the pack universe to what THIS project opted into (config.packs),

--- a/tests/integration/bundled-cli-version.test.ts
+++ b/tests/integration/bundled-cli-version.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression: the app-bundled CLI must report its REAL version, not '0.0.0'.
+ *
+ * The Tauri .app lays the CLI out as `Contents/Resources/dist/index.js` and
+ * ships NO package.json at any path `readDreamcontextVersionFromDisk()` probes.
+ * Every probe missed and the lookup fell through to the '0.0.0' sentinel, which
+ * sorts below every migration version — so `pendingMigrations` /
+ * `unfinishedAgentTasks` returned nothing and NO migration could ever fire
+ * through the bundled CLI. That is the exact path `resolve_cli` takes on
+ * first run, before a global npm CLI exists (desktop/src-tauri/src/lib.rs).
+ *
+ * Strategy: rebuild that layout in a temp dir from the real dist/index.js and
+ * run the CLI out of it. Only index.js is copied — the bug is the ABSENCE of a
+ * package.json, which holds either way, and copying the whole dist/ would drag
+ * the dashboard bundle along for nothing.
+ *
+ * These tests need a CURRENT `npm run build:cli`; CI builds before vitest runs.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const BUILT_CLI = join(REPO_ROOT, 'dist', 'index.js');
+
+function packageVersion(): string {
+  return JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')).version as string;
+}
+
+/** `<tmp>/dreamcontext-beta.app/Contents/Resources/dist/index.js` — no package.json anywhere. */
+function stageAppBundle(): string {
+  const dist = join(
+    mkdtempSync(join(tmpdir(), 'dc-bundle-')),
+    'dreamcontext-beta.app', 'Contents', 'Resources', 'dist',
+  );
+  mkdirSync(dist, { recursive: true });
+  const cli = join(dist, 'index.js');
+  copyFileSync(BUILT_CLI, cli);
+  return cli;
+}
+
+function run(cli: string, args: string[], cwd?: string): string {
+  try {
+    return execFileSync(process.execPath, [cli, ...args], { cwd, encoding: 'utf-8' });
+  } catch (e: unknown) {
+    return (e as { stdout?: string }).stdout ?? '';
+  }
+}
+
+describe('app-bundled CLI version', () => {
+  beforeAll(() => {
+    expect(
+      existsSync(BUILT_CLI),
+      'dist/index.js is missing — run `npm run build:cli` before this suite',
+    ).toBe(true);
+  });
+
+  it('reports the real version from a .app layout with no package.json in sight', () => {
+    const version = run(stageAppBundle(), ['--version']).trim();
+
+    expect(version).not.toBe('0.0.0');
+    expect(version).toBe(packageVersion()); // stale dist/ → rebuild with `npm run build:cli`
+  });
+
+  it('lets version-gated migrations fire through the bundled CLI', () => {
+    const cli = stageAppBundle();
+    const project = mkdtempSync(join(tmpdir(), 'dc-proj-'));
+    mkdirSync(join(project, '_dream_context', 'state'), { recursive: true });
+    // Code steps ran, the agent step never did → an unfinished agentTask, which
+    // `migrations pending` exists to print. Under the '0.0.0' sentinel every
+    // migration compared as NEWER than the CLI and this printed nothing.
+    writeFileSync(
+      join(project, '_dream_context', 'state', '.migrations.json'),
+      JSON.stringify([{
+        version: '0.23.0',
+        step: 'people-first',
+        executor: 'code',
+        timestamp: '2026-07-30T00:00:00.000Z',
+        filesTouched: [],
+        summary: 'code steps ran',
+      }]),
+    );
+
+    const out = run(cli, ['migrations', 'pending'], project);
+
+    expect(out).toContain('distribute-user-md-residue');
+    expect(out).not.toContain('No pending agent migration tasks');
+  });
+
+  it('still prefers the on-disk package.json over the build stamp', () => {
+    // Load-bearing for server/lifecycle.ts's drift + upgrade-ready watches: they
+    // notice an npm swap ONLY because the version is re-read from disk. A stamp
+    // that won would be frozen at launch and could never report an upgrade.
+    const root = mkdtempSync(join(tmpdir(), 'dc-npm-'));
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    copyFileSync(BUILT_CLI, join(root, 'dist', 'index.js'));
+    writeFileSync(
+      join(root, 'package.json'),
+      // `type: module` mirrors the real package and keeps node from reparsing
+      // the ESM bundle as CJS (a noisy MODULE_TYPELESS_PACKAGE_JSON warning).
+      JSON.stringify({ name: 'dreamcontext', version: '99.9.9', type: 'module' }),
+    );
+
+    expect(run(join(root, 'dist', 'index.js'), ['--version']).trim()).toBe('99.9.9');
+  });
+});

--- a/tests/unit/build-version-stamp.test.ts
+++ b/tests/unit/build-version-stamp.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The build must stamp its own version into the bundle.
+ *
+ * This is the guard on the tsup half of the .app-reports-0.0.0 fix: the runtime
+ * fallback in `readDreamcontextVersionFromDisk()` is only as good as the `define`
+ * that feeds it, and a `define` is easy to drop in a config refactor without
+ * anything failing loudly. The behavioural proof lives in
+ * tests/integration/bundled-cli-version.test.ts; this catches the cause directly
+ * (and without needing a build).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+describe('tsup build-version stamp', () => {
+  it('defines process.env.DREAMCONTEXT_BUILD_VERSION as the package version', async () => {
+    const config = (await import('../../tsup.config.js')).default as {
+      define?: Record<string, string>;
+    };
+    const pkgVersion = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'),
+    ).version as string;
+
+    expect(config.define?.['process.env.DREAMCONTEXT_BUILD_VERSION']).toBe(
+      JSON.stringify(pkgVersion),
+    );
+  });
+
+  it('reads the stamp at the exact expression esbuild substitutes', () => {
+    // esbuild replaces this expression TEXTUALLY. Rewriting it (destructuring
+    // process.env, aliasing the key, reading it via a computed index) silently
+    // breaks the substitution and quietly restores the 0.0.0 sentinel.
+    const source = readFileSync(join(REPO_ROOT, 'src', 'lib', 'manifest.ts'), 'utf-8');
+    expect(source).toContain('process.env.DREAMCONTEXT_BUILD_VERSION');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,37 @@
 import { defineConfig } from 'tsup';
-import { chmodSync, cpSync, existsSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The version to stamp INTO the bundle, read from package.json at build time.
+ *
+ * `readDreamcontextVersionFromDisk()` finds the version by probing for a
+ * package.json relative to the running file. That resolves for an npm install
+ * (`node_modules/dreamcontext/dist/index.js` → `../package.json`) but NOT for
+ * the Tauri .app, which ships `Contents/Resources/dist/index.js` with no
+ * package.json at ANY candidate path — so every probe missed and the lookup
+ * fell through to the '0.0.0' sentinel. '0.0.0' sorts below every migration
+ * version, so `pendingMigrations` / `unfinishedAgentTasks` returned nothing and
+ * no migration could ever fire through the bundled CLI — which is exactly the
+ * first-run-before-npm-install path `resolve_cli` falls back to.
+ *
+ * A stamp is the artifact's own identity, so it can never be missing.
+ *
+ * Deliberately NOT solved by copying a package.json into dist/: that would make
+ * Node resolve dist/ as its own package (needing `"type": "module"` just to
+ * keep the ESM output ESM), and it would make agent-terminal.ts's
+ * `cliPackageRoot()` treat the signed, read-only .app bundle as a valid
+ * `npm install node-pty` target.
+ */
+function versionToStamp(): string {
+  const pkgPath = resolve(process.cwd(), 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  if (pkg.name !== 'dreamcontext' || typeof pkg.version !== 'string') {
+    // Fail the BUILD rather than ship an artifact that can't name itself.
+    throw new Error(`tsup: ${pkgPath} is not the dreamcontext package — cannot stamp a build version.`);
+  }
+  return pkg.version;
+}
 
 export default defineConfig({
   entry: ['src/cli/index.ts'],
@@ -7,6 +39,14 @@ export default defineConfig({
   target: 'node18',
   clean: true,
   splitting: false,
+  // esbuild substitutes this expression with the literal version, so the
+  // built dist/index.js carries its own version with no disk lookup. Read by
+  // `readDreamcontextVersionFromDisk()` as the fallback when no package.json is
+  // reachable. Running from src/ (tsx/vitest) has no stamp — and needs none,
+  // since the repo-root package.json is always two levels up from src/lib/.
+  define: {
+    'process.env.DREAMCONTEXT_BUILD_VERSION': JSON.stringify(versionToStamp()),
+  },
   banner: {
     // Shebang + a createRequire shim: bundled CJS deps (commander, gray-matter…)
     // call require() for node builtins; ESM output has no require, so provide one.


### PR DESCRIPTION
## The bug

The Tauri `.app` ships the CLI as `Contents/Resources/dist/index.js` with **no `package.json` at any path** `readDreamcontextVersionFromDisk()` probes, so every candidate missed and the lookup fell through to the `'0.0.0'` sentinel.

```
$ node ~/Applications/dreamcontext-beta.app/Contents/Resources/dist/index.js --version
0.0.0
```

That is not cosmetic. `'0.0.0'` sorts below every migration version, so `pendingMigrations()` and `unfinishedAgentTasks()` compared every migration as *newer* than the CLI and returned nothing — **no migration could ever fire through the bundled CLI**. `setup-drift`'s `resolveDriftState()` also fail-safes `'0.0.0'` to `'current'`, so the "your assets are out of date" directive stayed silent, and every manifest the bundle wrote was stamped `0.0.0`.

It is a narrow path — `resolve_cli` prefers the global npm CLI and only falls back to the bundle when none is installed — but that is exactly **first run, before `npm install`**.

## The fix

`tsup` substitutes the package version into the bundle at build time (esbuild `define`), and the build **throws** rather than emit an artifact that cannot name itself. `readDreamcontextVersionFromDisk()` falls back to that stamp instead of `'0.0.0'`.

The disk probe still runs **first** and still wins. That is load-bearing, not incidental: `startVersionDriftWatch` / `startUpgradeReadyWatch` notice an npm swap *only* because the version is re-read from disk, so a stamp that won would be frozen at launch and could never report an upgrade. `'0.0.0'` survives as the last resort and still means "unknown", so every caller that treats it as "no signal" stays correct.

### Rejected: shipping a `package.json` into the bundle

The other candidate in the issue, with two concrete harms:

1. Node would resolve `dist/` as its own package, so the shim would need `"type": "module"` merely to keep the ESM output ESM — a silent CJS reparse otherwise.
2. `cliPackageRoot()` walks up from `process.argv[1]` for the nearest `package.json` to pick an `npm install node-pty` target. A shim would aim that install at the signed, read-only `.app` bundle. Today it correctly finds nothing and the UI degrades to a manual command.

## Verification

Rebuilt the real `.app` layout in a temp dir and ran the CLI out of it:

| | before | after |
|---|---|---|
| `--version` from `Contents/Resources/dist/index.js` | `0.0.0` | real version |
| `migrations pending` (ledger with unfinished agentTask) | "No pending agent migration tasks" | prints `distribute-user-md-residue` |
| drift directive at `setupVersion 0.20.0` | silent (`0.0.0` → `current` fail-safe) | "run `dreamcontext update` NOW" |
| on-disk `package.json` still beats the stamp | — | confirmed (`99.9.9` fixture) |

New regression tests:

- `tests/integration/bundled-cli-version.test.ts` — rebuilds the `.app` layout and covers all three behaviours above.
- `tests/unit/build-version-stamp.test.ts` — guards the `define` itself, and that `manifest.ts` reads it at the exact expression esbuild substitutes (rewriting it would silently restore the sentinel).

Built and validated in a clean worktree off `main`: **402 files / 7092 tests pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)